### PR TITLE
 Summary Report: Mobile Display Fix

### DIFF
--- a/frontend/src/components/ui/DashboardLayout.tsx
+++ b/frontend/src/components/ui/DashboardLayout.tsx
@@ -85,6 +85,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
       {/* Main Content Area */}
       <div className={`
         transition-all duration-300 ease-in-out
+        pt-14 lg:pt-0
         ${isSidebarCollapsed ? "lg:ml-20" : "lg:ml-64"}
       `}>
         <main>


### PR DESCRIPTION
Problem

  On mobile devices, the page content was appearing behind the menu button and notification icons at the top of the screen, making it difficult to see and interact with.

  What Was Fixed

  Added spacing at the top of the page content on mobile so it no longer overlaps with the menu and notification buttons.

  Result

  - Mobile users can now see all content clearly without any overlap

  - The menu button and notification icons remain visible and accessible

  - Desktop view is unchanged

  Areas Affected

  All dashboard pages (Customer, Shop, and Admin sections)