### PR TITLE
feat: add server-side pagination for customer profile and customers table

### DIFF
--- a/backend/src/domains/customer/controllers/CustomerController.ts
+++ b/backend/src/domains/customer/controllers/CustomerController.ts
@@ -148,11 +148,12 @@ export class CustomerController {
   async getTransactionHistory(req: Request, res: Response) {
     try {
       const { address } = req.params;
-      const { limit = '50', offset = '0', type } = req.query;
-      
+      const { limit = '5', page = '1', type } = req.query;
+
       const result = await this.customerService.getTransactionHistory(
         address,
         parseInt(limit as string),
+        parseInt(page as string),
         type as string,
         req.user?.address,
         req.user?.role

--- a/backend/src/domains/customer/routes/exportData.ts
+++ b/backend/src/domains/customer/routes/exportData.ts
@@ -38,7 +38,7 @@ router.get('/:address/export',
       }
 
       // Get transaction history
-      const transactions = await transactionRepository.getTransactionsByCustomer(address, 1000);
+      const { transactions } = await transactionRepository.getTransactionsByCustomer(address, 1000);
 
       // Get referral data
       const referralRepository = new (await import('../../../repositories/ReferralRepository')).ReferralRepository();

--- a/backend/src/domains/customer/services/CustomerService.ts
+++ b/backend/src/domains/customer/services/CustomerService.ts
@@ -283,7 +283,7 @@ export class CustomerService {
     }
   }
 
-  async getTransactionHistory(address: string, limit: number = 50, type?: string, requestingUserAddress?: string, userRole?: string) {
+  async getTransactionHistory(address: string, limit: number = 50, page: number = 1, type?: string, requestingUserAddress?: string, userRole?: string) {
     try {
       // Check if customer exists
       const customer = await customerRepository.getCustomer(address);
@@ -296,42 +296,53 @@ export class CustomerService {
         throw new Error('Can only view your own transaction history');
       }
 
+      const offset = (page - 1) * limit;
+
       // Get transactions from repository
-      const transactions = await transactionRepository.getTransactionsByCustomer(address, limit);
-      
+      const { transactions, totalItems } = await transactionRepository.getTransactionsByCustomer(address, limit, offset);
+
       // Transform transaction types for frontend expectations
       const transformedTransactions = transactions.map((tx: any) => {
         // Check if this is an admin manual transfer
-        const isAdminTransfer = tx.type === 'mint' && !tx.shopId && 
-          (tx.metadata?.source === 'admin_manual_transfer' || 
+        const isAdminTransfer = tx.type === 'mint' && !tx.shopId &&
+          (tx.metadata?.source === 'admin_manual_transfer' ||
            tx.reason?.includes('Admin manual transfer'));
-        
+
         return {
           id: tx.id,
           type: tx.type === 'mint' ? 'earned' : tx.type === 'redeem' ? 'redeemed' : tx.type,
           amount: parseFloat(tx.amount),
           shopId: tx.shopId,
           shopName: isAdminTransfer ? 'RepairCoin Admin' : tx.shopName,
-          description: tx.reason || tx.description || 
-            (tx.type === 'mint' ? 'Repair reward' : 
-             tx.type === 'redeem' ? 'Redeemed at shop' : 
-             tx.type === 'referral' ? 'Referral bonus' : 
+          description: tx.reason || tx.description ||
+            (tx.type === 'mint' ? 'Repair reward' :
+             tx.type === 'redeem' ? 'Redeemed at shop' :
+             tx.type === 'referral' ? 'Referral bonus' :
              tx.type === 'tier_bonus' ? 'Tier bonus' :
              'Transaction'),
           createdAt: tx.timestamp,
           metadata: tx.metadata
         };
       });
-      
+
       // Filter by type if specified
       let filteredTransactions = transformedTransactions;
       if (type && ['earned', 'redeemed', 'bonus', 'referral'].includes(type)) {
         filteredTransactions = transformedTransactions.filter((t: any) => t.type === type);
       }
 
+      const totalPages = Math.ceil(totalItems / limit);
+
       return {
         transactions: filteredTransactions,
         count: filteredTransactions.length,
+        pagination: {
+          page,
+          limit,
+          totalItems,
+          totalPages,
+          hasMore: page < totalPages,
+        },
         customer: {
           address: customer.address,
           tier: customer.tier,

--- a/backend/src/domains/shop/routes/index.ts
+++ b/backend/src/domains/shop/routes/index.ts
@@ -1557,6 +1557,149 @@ router.post('/:shopId/redeem',
   }
 );
 
+// Get full customer profile data in a single call (details, balance+analytics, bookings page, transactions page)
+router.get('/:shopId/customer-profile/:customerAddress',
+  authMiddleware,
+  requireShopOrAdmin,
+  requireShopOwnership,
+  async (req: Request, res: Response) => {
+    try {
+      const { shopId, customerAddress } = req.params;
+      const {
+        bookingsPage = '1', bookingsLimit = '5',
+        transactionsPage = '1', transactionsLimit = '5',
+      } = req.query;
+
+      const pool = getSharedPool();
+      const addr = customerAddress.toLowerCase();
+
+      // Lazy-init OrderRepository once (cached after first call)
+      if (!(router as any)._orderRepo) {
+        const { OrderRepository } = require('../../../repositories/OrderRepository');
+        (router as any)._orderRepo = new OrderRepository();
+      }
+      const orderRepo = (router as any)._orderRepo;
+
+      // Run all queries in parallel — 4 concurrent operations
+      const [
+        customerRow,
+        balanceAnalyticsRow,
+        bookingsResult,
+        transactionsResult,
+      ] = await Promise.all([
+        // 1. Customer details (uses PK index on address)
+        pool.query(
+          `SELECT * FROM customers WHERE address = $1`,
+          [addr]
+        ),
+        // 2. Balance + Analytics in a single table scan (uses idx_transactions_customer_address)
+        pool.query(
+          `SELECT
+            COUNT(*) as total_transactions,
+            COALESCE(SUM(CASE WHEN type = 'mint' THEN amount ELSE 0 END), 0) as total_earnings,
+            COALESCE(SUM(CASE WHEN type = 'redeem' THEN amount ELSE 0 END), 0) as total_redemptions,
+            COALESCE(SUM(CASE WHEN type = 'mint' THEN amount ELSE 0 END), 0) -
+            COALESCE(SUM(CASE WHEN type = 'redeem' THEN amount ELSE 0 END), 0) as available_balance,
+            CASE WHEN COUNT(*) > 0
+              THEN COALESCE(SUM(amount), 0) / COUNT(*)
+              ELSE 0
+            END as average_transaction_value
+           FROM transactions WHERE customer_address = $1`,
+          [addr]
+        ),
+        // 3. Bookings (paginated, scoped to this shop)
+        orderRepo.getOrdersByShop(
+          shopId,
+          { customerAddress: addr },
+          { page: Number(bookingsPage), limit: Number(bookingsLimit) }
+        ),
+        // 4. Transactions (paginated, uses idx_transactions_customer_timestamp)
+        transactionRepository.getTransactionsByCustomer(
+          addr,
+          Number(transactionsLimit),
+          (Number(transactionsPage) - 1) * Number(transactionsLimit)
+        ),
+      ]);
+
+      const customer = customerRow.rows[0];
+      if (!customer) {
+        return res.status(404).json({ success: false, error: 'Customer not found' });
+      }
+
+      const stats = balanceAnalyticsRow.rows[0];
+
+      // Transform transactions
+      const transformedTransactions = transactionsResult.transactions.map((tx: any) => {
+        const isAdminTransfer = tx.type === 'mint' && !tx.shopId &&
+          (tx.metadata?.source === 'admin_manual_transfer' ||
+           tx.reason?.includes('Admin manual transfer'));
+        return {
+          id: tx.id,
+          type: tx.type === 'mint' ? 'earned' : tx.type === 'redeem' ? 'redeemed' : tx.type,
+          amount: parseFloat(tx.amount),
+          shopId: tx.shopId,
+          shopName: isAdminTransfer ? 'RepairCoin Admin' : tx.shopName,
+          description: tx.reason || tx.description ||
+            (tx.type === 'mint' ? 'Repair reward' :
+             tx.type === 'redeem' ? 'Redeemed at shop' :
+             tx.type === 'referral' ? 'Referral bonus' :
+             tx.type === 'tier_bonus' ? 'Tier bonus' : 'Transaction'),
+          createdAt: tx.timestamp,
+          metadata: tx.metadata,
+        };
+      });
+
+      const txLimit = Number(transactionsLimit);
+      const txTotalPages = Math.ceil(transactionsResult.totalItems / txLimit);
+
+      res.json({
+        success: true,
+        data: {
+          customer: {
+            address: customer.address,
+            name: customer.name,
+            email: customer.email,
+            phone: customer.phone,
+            profile_image_url: customer.profile_image_url,
+            tier: customer.tier || 'BRONZE',
+            currentBalance: parseFloat(stats.available_balance) || 0,
+            lifetimeEarnings: parseFloat(stats.total_earnings) || 0,
+            totalRedemptions: parseFloat(stats.total_redemptions) || 0,
+            lastTransaction: customer.last_earned_date,
+            joinDate: customer.created_at,
+            isActive: customer.is_active !== false,
+            suspended: customer.suspended || false,
+          },
+          analytics: {
+            totalTransactions: parseInt(stats.total_transactions) || 0,
+            totalEarnings: parseFloat(stats.total_earnings) || 0,
+            totalRedemptions: parseFloat(stats.total_redemptions) || 0,
+            averageTransactionValue: parseFloat(stats.average_transaction_value) || 0,
+            monthlyActivity: [],
+          },
+          bookings: {
+            items: bookingsResult.items,
+            pagination: bookingsResult.pagination,
+          },
+          transactions: {
+            items: transformedTransactions,
+            pagination: {
+              page: Number(transactionsPage),
+              limit: txLimit,
+              totalItems: transactionsResult.totalItems,
+              totalPages: txTotalPages,
+              hasMore: Number(transactionsPage) < txTotalPages,
+            },
+          },
+        },
+      });
+    } catch (error) {
+      logger.error('Get customer profile error:', error);
+      res.status(500).json({ success: false, error: 'Failed to load customer profile' });
+    }
+  }
+);
+
 // Get customers who have earned from this shop
 router.get('/:shopId/customers',
   authMiddleware,

--- a/backend/src/domains/token/services/VerificationService.ts
+++ b/backend/src/domains/token/services/VerificationService.ts
@@ -248,7 +248,7 @@ export class VerificationService {
       }
 
       // Get all transactions for this customer
-      const transactions = await transactionRepository.getTransactionsByCustomer(customerAddress, 1000);
+      const { transactions } = await transactionRepository.getTransactionsByCustomer(customerAddress, 1000);
 
       // Group by shop and calculate totals
       const shopEarnings = new Map<string, any>();
@@ -382,7 +382,7 @@ export class VerificationService {
     fromTierBonuses: number;
   }> {
     try {
-      const transactions = await transactionRepository.getTransactionsByCustomer(customerAddress, 1000);
+      const { transactions } = await transactionRepository.getTransactionsByCustomer(customerAddress, 1000);
       
       const breakdown = {
         fromRepairs: 0,

--- a/backend/src/repositories/TransactionRepository.ts
+++ b/backend/src/repositories/TransactionRepository.ts
@@ -133,24 +133,35 @@ export class TransactionRepository extends BaseRepository {
     customerAddress: string,
     limit: number = 50,
     offset: number = 0
-  ): Promise<TransactionRecord[]> {
+  ): Promise<{ transactions: TransactionRecord[]; totalItems: number }> {
     try {
+      const countQuery = `
+        SELECT COUNT(*) as total
+        FROM transactions t
+        WHERE t.customer_address = $1
+      `;
+      const countResult = await this.pool.query(countQuery, [customerAddress.toLowerCase()]);
+      const totalItems = parseInt(countResult.rows[0].total, 10);
+
       const query = `
-        SELECT t.*, s.name as shop_name 
+        SELECT t.*, s.name as shop_name
         FROM transactions t
         LEFT JOIN shops s ON t.shop_id = s.shop_id
         WHERE t.customer_address = $1
         ORDER BY t.timestamp DESC
         LIMIT $2 OFFSET $3
       `;
-      
+
       const result = await this.pool.query(query, [
         customerAddress.toLowerCase(),
         limit,
         offset
       ]);
-      
-      return result.rows.map(row => this.mapToTransactionRecord(row));
+
+      return {
+        transactions: result.rows.map(row => this.mapToTransactionRecord(row)),
+        totalItems,
+      };
     } catch (error) {
       logger.error('Error fetching customer transactions:', error);
       throw new Error('Failed to fetch customer transactions');

--- a/backend/src/services/ReferralService.ts
+++ b/backend/src/services/ReferralService.ts
@@ -246,7 +246,7 @@ export class ReferralService {
       }
 
       // Check if this is the customer's first repair
-      const transactions = await this.transactionRepository.getTransactionsByCustomer(customerAddress, 100);
+      const { transactions } = await this.transactionRepository.getTransactionsByCustomer(customerAddress, 100);
       const repairCount = transactions.filter(t => t.type === 'mint' && t.shopId !== 'admin_system').length;
 
       logger.info('Checking repair count for referral eligibility', {

--- a/backend/tests/customer/customer.earnings.test.ts
+++ b/backend/tests/customer/customer.earnings.test.ts
@@ -131,7 +131,7 @@ describe("Customer Earnings and Redemption Tests", () => {
 
       jest
         .spyOn(TransactionRepository.prototype, "getTransactionsByCustomer")
-        .mockResolvedValue(mockTransactions as any);
+        .mockResolvedValue({ transactions: mockTransactions, totalItems: mockTransactions.length } as any);
 
       const response = await request(app)
         .get(`/api/customers/${customerAddress}/transactions?limit=10`)
@@ -144,7 +144,7 @@ describe("Customer Earnings and Redemption Tests", () => {
     it("should filter transactions by type", async () => {
       jest
         .spyOn(TransactionRepository.prototype, "getTransactionsByCustomer")
-        .mockResolvedValue([] as any);
+        .mockResolvedValue({ transactions: [], totalItems: 0 } as any);
 
       const response = await request(app)
         .get(`/api/customers/${customerAddress}/transactions?type=mint`)
@@ -627,7 +627,7 @@ describe("Customer Earnings and Redemption Tests", () => {
 
       jest
         .spyOn(TransactionRepository.prototype, "getTransactionsByCustomer")
-        .mockResolvedValue(mockTransactions as any);
+        .mockResolvedValue({ transactions: mockTransactions, totalItems: mockTransactions.length } as any);
 
       const response = await request(app)
         .get(
@@ -649,10 +649,10 @@ describe("Customer Earnings and Redemption Tests", () => {
 
       jest
         .spyOn(TransactionRepository.prototype, "getTransactionsByCustomer")
-        .mockResolvedValue(mockTransactions.slice(0, 5) as any);
+        .mockResolvedValue({ transactions: mockTransactions.slice(0, 5), totalItems: 5 } as any);
 
       const response = await request(app)
-        .get(`/api/customers/${customerAddress}/transactions?limit=5&offset=0`)
+        .get(`/api/customers/${customerAddress}/transactions?limit=5&page=1`)
         .set("Authorization", `Bearer ${customerToken}`);
 
       expect(response.status).toBe(200);

--- a/frontend/src/app/(authenticated)/shop/customers/[address]/page.tsx
+++ b/frontend/src/app/(authenticated)/shop/customers/[address]/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { Home, ChevronRight, UsersIcon, User } from "lucide-react";
+import DashboardLayout from "@/components/ui/DashboardLayout";
+import { CustomerProfileView } from "@/components/shop/customers/profile";
+import { useAuthStore } from "@/stores/authStore";
+
+function LoadingFallback() {
+  return (
+    <div className="flex items-center justify-center min-h-[400px]">
+      <div className="text-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#FFCC00] mx-auto"></div>
+        <p className="mt-4 text-white">Loading customer...</p>
+      </div>
+    </div>
+  );
+}
+
+function truncateAddress(address: string) {
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+export default function CustomerProfilePage() {
+  const params = useParams();
+  const router = useRouter();
+  const address = params.address as string;
+  const userProfile = useAuthStore((state) => state.userProfile);
+  const shopId = userProfile?.shopId;
+
+  const handleTabChange = (tab: string) => {
+    if (tab !== "customers") {
+      window.location.href = `/shop?tab=${tab}`;
+    }
+  };
+
+  return (
+    <DashboardLayout
+      userRole="shop"
+      activeTab="customers"
+      onTabChange={handleTabChange}
+    >
+      <div className="min-h-screen py-8">
+        <div className="max-w-screen-2xl w-[96%] mx-auto">
+          {/* Breadcrumb */}
+          <div className="border-b border-[#303236] pb-4 mb-6">
+            <div className="flex flex-wrap items-center gap-1.5 sm:gap-2 mb-2">
+              <button
+                onClick={() => router.push("/shop?tab=overview")}
+                className="p-1 rounded hover:bg-[#303236] transition-colors flex-shrink-0"
+                title="Go to Overview"
+              >
+                <Home className="w-4 h-4 sm:w-5 sm:h-5 text-white hover:text-[#FFCC00] transition-colors" />
+              </button>
+              <ChevronRight className="w-3 h-3 sm:w-4 sm:h-4 text-gray-400 flex-shrink-0" />
+              <button
+                onClick={() => router.push("/shop?tab=customers")}
+                className="flex items-center gap-1 sm:gap-1.5 hover:text-[#FFCC00] transition-colors flex-shrink-0"
+              >
+                <UsersIcon className="w-4 h-4 sm:w-5 sm:h-5 text-gray-400" />
+                <span className="text-sm sm:text-base font-medium text-gray-400 hidden sm:inline">Customers</span>
+              </button>
+              <ChevronRight className="w-3 h-3 sm:w-4 sm:h-4 text-gray-400 flex-shrink-0" />
+              <span className="text-[#FFCC00] flex-shrink-0">
+                <User className="w-4 h-4 sm:w-5 sm:h-5 inline mr-1" />
+              </span>
+              <span className="text-sm sm:text-base font-medium text-[#FFCC00] flex-shrink-0">{truncateAddress(address)}</span>
+            </div>
+            <p className="text-xs sm:text-sm text-[#ddd]">
+              View customer details, transaction history, and RCN activity
+            </p>
+          </div>
+
+          {shopId ? (
+            <CustomerProfileView
+              customerAddress={address}
+              shopId={shopId}
+              onBack={() => router.back()}
+            />
+          ) : (
+            <LoadingFallback />
+          )}
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/frontend/src/components/customer/ShopProfileClient.tsx
+++ b/frontend/src/components/customer/ShopProfileClient.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useShopProfileStore } from "@/stores/shopProfileStore";
 import { toast } from "react-hot-toast";
 import {
   MapPin,
@@ -38,6 +39,7 @@ import * as messagingApi from "@/services/api/messaging";
 import BookingAnalyticsTab from "@/components/shop/tabs/BookingAnalyticsTab";
 import { AppointmentCalendar } from "@/components/shop/AppointmentCalendar";
 import { CustomerGridView } from "@/components/shop/CustomerGridView";
+
 
 interface ShopInfo {
   shopId: string;
@@ -78,7 +80,7 @@ export const ShopProfileClient: React.FC<ShopProfileClientProps> = ({ shopId, is
   const [services, setServices] = useState<ShopServiceWithShopInfo[]>([]);
   const [selectedService, setSelectedService] = useState<ShopServiceWithShopInfo | null>(null);
   const [checkoutService, setCheckoutService] = useState<ShopServiceWithShopInfo | null>(null);
-  const [activeTab, setActiveTab] = useState<"services" | "about" | "gallery" | "reviews" | "analytics" | "appointments" | "customers">("services");
+  const { activeTab, setActiveTab } = useShopProfileStore();
   const [galleryPhotos, setGalleryPhotos] = useState<GalleryPhoto[]>([]);
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState(0);
@@ -87,6 +89,7 @@ export const ShopProfileClient: React.FC<ShopProfileClientProps> = ({ shopId, is
   const [isMessaging, setIsMessaging] = useState(false);
   const [showCreateServiceModal, setShowCreateServiceModal] = useState(false);
   const [customerCount, setCustomerCount] = useState<number | null>(null);
+
   const [reviews, setReviews] = useState<ServiceReview[]>([]);
   const [reviewsLoading, setReviewsLoading] = useState(false);
   const [reviewPage, setReviewPage] = useState(1);
@@ -957,7 +960,11 @@ export const ShopProfileClient: React.FC<ShopProfileClientProps> = ({ shopId, is
         {/* Customers Tab */}
         {activeTab === "customers" && isPreviewMode && (
           <div>
-            <CustomerGridView shopId={shopId} onCustomersLoaded={setCustomerCount} />
+            <CustomerGridView
+                shopId={shopId}
+                onCustomersLoaded={setCustomerCount}
+                onCustomerClick={(address) => router.push(`/shop/customers/${address}`)}
+              />
           </div>
         )}
         </div>

--- a/frontend/src/components/shop/CustomerGridView.tsx
+++ b/frontend/src/components/shop/CustomerGridView.tsx
@@ -10,9 +10,10 @@ import { toast } from "react-hot-toast";
 interface CustomerGridViewProps {
   shopId: string;
   onCustomersLoaded?: (count: number) => void;
+  onCustomerClick?: (address: string) => void;
 }
 
-export const CustomerGridView: React.FC<CustomerGridViewProps> = ({ shopId, onCustomersLoaded }) => {
+export const CustomerGridView: React.FC<CustomerGridViewProps> = ({ shopId, onCustomersLoaded, onCustomerClick }) => {
   const [customers, setCustomers] = useState<Customer[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
@@ -163,7 +164,8 @@ export const CustomerGridView: React.FC<CustomerGridViewProps> = ({ shopId, onCu
           {filteredCustomers.map((customer) => (
             <div
               key={customer.address}
-              className="bg-[#1A1A1A] border border-gray-800 rounded-2xl p-6 hover:border-[#FFCC00] transition-all duration-200 hover:shadow-lg hover:shadow-[#FFCC00]/10 group"
+              className="bg-[#1A1A1A] border border-gray-800 rounded-2xl p-6 hover:border-[#FFCC00] transition-all duration-200 hover:shadow-lg hover:shadow-[#FFCC00]/10 group cursor-pointer"
+              onClick={() => onCustomerClick?.(customer.address)}
             >
               {/* Circular Avatar */}
               <div className="flex flex-col items-center">

--- a/frontend/src/components/shop/customers/profile/CustomerProfileTabs.tsx
+++ b/frontend/src/components/shop/customers/profile/CustomerProfileTabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import {
   ClipboardCheck,
   ArrowUpRight,
@@ -8,7 +8,9 @@ import {
   TrendingUp,
   Trophy,
   StickyNote,
-  Coins,
+  ChevronLeft,
+  ChevronRight,
+  Loader2,
 } from "lucide-react";
 
 // --- Types ---
@@ -39,8 +41,14 @@ interface Transaction {
   shopName?: string;
   createdAt: string;
   description?: string;
-  transactionHash?: string;
-  status?: string;
+}
+
+interface PaginationMeta {
+  page: number;
+  limit: number;
+  totalItems: number;
+  totalPages: number;
+  hasMore: boolean;
 }
 
 interface CustomerAnalytics {
@@ -56,15 +64,16 @@ interface CustomerAnalytics {
 }
 
 interface CustomerProfileTabsProps {
-  bookings: BookingOrder[];
-  transactions: Transaction[];
+  shopId: string;
+  customerAddress: string;
   analytics: CustomerAnalytics | null;
   customerBalance: number;
   customerTier: "BRONZE" | "SILVER" | "GOLD";
-  shopId: string;
-  customerAddress: string;
+  initialBookings: { items: BookingOrder[]; pagination: PaginationMeta };
+  initialTransactions: { items: Transaction[]; pagination: PaginationMeta };
   selectedBookingId: string | null;
   onSelectBooking: (orderId: string | null) => void;
+  onBookingsLoaded?: (bookings: BookingOrder[]) => void;
 }
 
 // --- Helpers ---
@@ -101,14 +110,132 @@ const StatusBadge: React.FC<{ status: string }> = ({ status }) => {
   );
 };
 
+// --- Shared Pagination Component ---
+
+const PaginationControls: React.FC<{
+  currentPage: number;
+  totalPages: number;
+  totalItems: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+}> = ({ currentPage, totalPages, totalItems, pageSize, onPageChange }) => {
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="flex items-center justify-between pt-4 mt-2 border-t border-[#303236]">
+      <span className="text-sm text-gray-400">
+        {(currentPage - 1) * pageSize + 1}-{Math.min(currentPage * pageSize, totalItems)} of {totalItems}
+      </span>
+      <div className="flex items-center gap-1.5">
+        <button
+          onClick={() => onPageChange(Math.max(1, currentPage - 1))}
+          disabled={currentPage === 1}
+          className="p-1.5 rounded-lg bg-[#1a1a1a] border border-[#303236] text-white disabled:opacity-30 disabled:cursor-not-allowed hover:bg-[#2a2a2a] transition-colors"
+        >
+          <ChevronLeft className="w-3.5 h-3.5" />
+        </button>
+        {Array.from({ length: totalPages }, (_, i) => i + 1)
+          .filter((page) => {
+            if (totalPages <= 5) return true;
+            if (page === 1 || page === totalPages) return true;
+            return Math.abs(page - currentPage) <= 1;
+          })
+          .reduce<(number | "ellipsis")[]>((acc, page, idx, arr) => {
+            if (idx > 0 && page - (arr[idx - 1] as number) > 1) {
+              acc.push("ellipsis");
+            }
+            acc.push(page);
+            return acc;
+          }, [])
+          .map((item, idx) =>
+            item === "ellipsis" ? (
+              <span key={`ellipsis-${idx}`} className="px-1 text-gray-500">...</span>
+            ) : (
+              <button
+                key={item}
+                onClick={() => onPageChange(item)}
+                className={`w-7 h-7 rounded-lg text-xs font-medium transition-colors ${
+                  currentPage === item
+                    ? "bg-[#FFCC00] text-[#101010]"
+                    : "bg-[#1a1a1a] border border-[#303236] text-white hover:bg-[#2a2a2a]"
+                }`}
+              >
+                {item}
+              </button>
+            )
+          )}
+        <button
+          onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
+          disabled={currentPage === totalPages}
+          className="p-1.5 rounded-lg bg-[#1a1a1a] border border-[#303236] text-white disabled:opacity-30 disabled:cursor-not-allowed hover:bg-[#2a2a2a] transition-colors"
+        >
+          <ChevronRight className="w-3.5 h-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
 // --- Tab Components ---
 
+const mapBookingOrder = (o: any): BookingOrder => ({
+  orderId: o.orderId || o.order_id,
+  serviceName: o.serviceName || o.service_name || "Unknown Service",
+  serviceDescription: o.serviceDescription || o.service_description,
+  serviceCategory: o.serviceCategory || o.service_category,
+  status: o.status,
+  totalPrice: o.totalPrice || o.total_price || 0,
+  rcnDiscount: o.rcnDiscount || o.rcn_discount || 0,
+  finalPrice: o.finalPrice || o.final_price || 0,
+  rcnEarned: o.rcnEarned || o.rcn_earned || 0,
+  paymentMethod: o.paymentMethod || o.payment_method,
+  bookingTimeSlot: o.bookingTimeSlot || o.booking_time_slot,
+  bookingEndTime: o.bookingEndTime || o.booking_end_time,
+  createdAt: o.createdAt || o.created_at,
+  completedAt: o.completedAt || o.completed_at,
+  shopName: o.shopName || o.shop_name,
+});
+
 const BookingsTab: React.FC<{
-  bookings: BookingOrder[];
+  customerAddress: string;
+  initialData: { items: BookingOrder[]; pagination: PaginationMeta };
   selectedBookingId: string | null;
   onSelectBooking: (orderId: string | null) => void;
-}> = ({ bookings, selectedBookingId, onSelectBooking }) => {
-  if (bookings.length === 0) {
+  onBookingsLoaded?: (bookings: BookingOrder[]) => void;
+}> = ({ customerAddress, initialData, selectedBookingId, onSelectBooking, onBookingsLoaded }) => {
+  const [bookings, setBookings] = useState<BookingOrder[]>(initialData.items);
+  const [pagination, setPagination] = useState<PaginationMeta>(initialData.pagination);
+  const [currentPage, setCurrentPage] = useState(initialData.pagination.page);
+  const [loading, setLoading] = useState(false);
+
+  const fetchPage = useCallback(async (page: number) => {
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/services/orders/shop?customerAddress=${encodeURIComponent(customerAddress)}&page=${page}&limit=${pagination.limit}`,
+        { credentials: "include" }
+      );
+      if (!res.ok) throw new Error("Failed to fetch bookings");
+      const data = await res.json();
+
+      const items = (data.data || []).map(mapBookingOrder);
+      setBookings(items);
+      setPagination(data.pagination || pagination);
+      onBookingsLoaded?.(items);
+    } catch (error) {
+      console.error("Error fetching bookings:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, [customerAddress, pagination.limit, onBookingsLoaded]);
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+    onSelectBooking(null);
+    fetchPage(page);
+  };
+
+  if (!loading && bookings.length === 0 && currentPage === 1) {
     return (
       <div className="text-center py-12">
         <ClipboardCheck className="w-10 h-10 text-gray-600 mx-auto mb-3" />
@@ -119,56 +246,100 @@ const BookingsTab: React.FC<{
   }
 
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full">
-        <thead>
-          <tr className="border-b border-[#303236]">
-            <th className="text-left py-3 px-4 text-xs font-semibold text-gray-500 uppercase">Service</th>
-            <th className="text-left py-3 px-4 text-xs font-semibold text-gray-500 uppercase">Schedule</th>
-            <th className="text-left py-3 px-4 text-xs font-semibold text-gray-500 uppercase">Status</th>
-            <th className="text-right py-3 px-4 text-xs font-semibold text-gray-500 uppercase">Cost</th>
-          </tr>
-        </thead>
-        <tbody>
-          {bookings.map((booking) => (
-            <tr
-              key={booking.orderId}
-              onClick={() =>
-                onSelectBooking(
-                  selectedBookingId === booking.orderId ? null : booking.orderId
-                )
-              }
-              className={`border-b border-[#303236]/50 cursor-pointer transition-colors ${
-                selectedBookingId === booking.orderId
-                  ? "bg-[#FFCC00]/5"
-                  : "hover:bg-[#1a1a1a]"
-              }`}
-            >
-              <td className="py-3 px-4">
-                <p className="text-sm font-medium text-white">{booking.serviceName}</p>
-                <p className="text-xs text-gray-500 font-mono">{booking.orderId.slice(0, 12)}...</p>
-              </td>
-              <td className="py-3 px-4">
-                <p className="text-sm text-white">{formatDate(booking.bookingTimeSlot || booking.createdAt)}</p>
-                {booking.bookingTimeSlot && (
-                  <p className="text-xs text-gray-500">{formatTime(booking.bookingTimeSlot)}</p>
-                )}
-              </td>
-              <td className="py-3 px-4">
-                <StatusBadge status={booking.status} />
-              </td>
-              <td className="py-3 px-4 text-right">
-                <p className="text-sm font-semibold text-white">${booking.totalPrice.toFixed(2)}</p>
-              </td>
+    <div className={loading ? "opacity-50 pointer-events-none" : ""}>
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-[#303236]">
+              <th className="text-left py-3 px-4 text-xs font-semibold text-gray-500 uppercase">Service</th>
+              <th className="text-left py-3 px-4 text-xs font-semibold text-gray-500 uppercase">Schedule</th>
+              <th className="text-left py-3 px-4 text-xs font-semibold text-gray-500 uppercase">Status</th>
+              <th className="text-right py-3 px-4 text-xs font-semibold text-gray-500 uppercase">Cost</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {bookings.map((booking) => (
+              <tr
+                key={booking.orderId}
+                onClick={() =>
+                  onSelectBooking(
+                    selectedBookingId === booking.orderId ? null : booking.orderId
+                  )
+                }
+                className={`border-b border-[#303236]/50 cursor-pointer transition-colors ${
+                  selectedBookingId === booking.orderId
+                    ? "bg-[#FFCC00]/5"
+                    : "hover:bg-[#1a1a1a]"
+                }`}
+              >
+                <td className="py-3 px-4">
+                  <p className="text-sm font-medium text-white">{booking.serviceName}</p>
+                  <p className="text-xs text-gray-500 font-mono">{booking.orderId.slice(0, 12)}...</p>
+                </td>
+                <td className="py-3 px-4">
+                  <p className="text-sm text-white">{formatDate(booking.bookingTimeSlot || booking.createdAt)}</p>
+                  {booking.bookingTimeSlot && (
+                    <p className="text-xs text-gray-500">{formatTime(booking.bookingTimeSlot)}</p>
+                  )}
+                </td>
+                <td className="py-3 px-4">
+                  <StatusBadge status={booking.status} />
+                </td>
+                <td className="py-3 px-4 text-right">
+                  <p className="text-sm font-semibold text-white">${booking.totalPrice.toFixed(2)}</p>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <PaginationControls
+        currentPage={currentPage}
+        totalPages={pagination.totalPages}
+        totalItems={pagination.totalItems}
+        pageSize={pagination.limit}
+        onPageChange={handlePageChange}
+      />
     </div>
   );
 };
 
-const TransactionsTab: React.FC<{ transactions: Transaction[] }> = ({ transactions }) => {
+const TransactionsTab: React.FC<{
+  customerAddress: string;
+  shopId: string;
+  initialData: { items: Transaction[]; pagination: PaginationMeta };
+}> = ({ customerAddress, shopId, initialData }) => {
+  const [transactions, setTransactions] = useState<Transaction[]>(initialData.items);
+  const [pagination, setPagination] = useState<PaginationMeta>(initialData.pagination);
+  const [currentPage, setCurrentPage] = useState(initialData.pagination.page);
+  const [loading, setLoading] = useState(false);
+
+  const fetchPage = useCallback(async (page: number) => {
+    setLoading(true);
+    try {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/shops/${shopId}/customer-profile/${customerAddress}?bookingsPage=1&bookingsLimit=0&transactionsPage=${page}&transactionsLimit=${pagination.limit}`,
+        { credentials: "include" }
+      );
+      if (!res.ok) throw new Error("Failed to fetch transactions");
+      const json = await res.json();
+
+      const txData = json.data?.transactions;
+      setTransactions(txData?.items || []);
+      setPagination(txData?.pagination || pagination);
+    } catch (error) {
+      console.error("Error fetching transactions:", error);
+    } finally {
+      setLoading(false);
+    }
+  }, [customerAddress, shopId, pagination.limit]);
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+    fetchPage(page);
+  };
+
   const formatTxDate = (dateStr: string) => {
     return new Date(dateStr).toLocaleDateString("en-US", {
       month: "short",
@@ -179,7 +350,7 @@ const TransactionsTab: React.FC<{ transactions: Transaction[] }> = ({ transactio
     });
   };
 
-  if (transactions.length === 0) {
+  if (!loading && transactions.length === 0 && currentPage === 1) {
     return (
       <div className="text-center py-12">
         <TrendingUp className="w-10 h-10 text-gray-600 mx-auto mb-3" />
@@ -190,43 +361,53 @@ const TransactionsTab: React.FC<{ transactions: Transaction[] }> = ({ transactio
   }
 
   return (
-    <div className="space-y-2">
-      {transactions.map((tx) => {
-        const isEarn = tx.type === "earn" || tx.type === "gift_received" || tx.type === "mint";
-        return (
-          <div
-            key={tx.id}
-            className="flex items-center justify-between p-3 bg-[#0A0A0A] rounded-xl border border-[#303236]"
-          >
-            <div className="flex items-center gap-3">
-              <div className={`w-9 h-9 rounded-full flex items-center justify-center ${isEarn ? "bg-green-900/20" : "bg-blue-900/20"}`}>
-                {isEarn ? (
-                  <ArrowDownRight className="w-4 h-4 text-green-400" />
-                ) : (
-                  <ArrowUpRight className="w-4 h-4 text-blue-400" />
+    <div className={loading ? "opacity-50 pointer-events-none" : ""}>
+      <div className="space-y-2">
+        {transactions.map((tx) => {
+          const isEarn = tx.type === "earn" || tx.type === "earned" || tx.type === "gift_received" || tx.type === "mint";
+          return (
+            <div
+              key={tx.id}
+              className="flex items-center justify-between p-3 bg-[#0A0A0A] rounded-xl border border-[#303236]"
+            >
+              <div className="flex items-center gap-3">
+                <div className={`w-9 h-9 rounded-full flex items-center justify-center ${isEarn ? "bg-green-900/20" : "bg-blue-900/20"}`}>
+                  {isEarn ? (
+                    <ArrowDownRight className="w-4 h-4 text-green-400" />
+                  ) : (
+                    <ArrowUpRight className="w-4 h-4 text-blue-400" />
+                  )}
+                </div>
+                <div>
+                  <p className="text-sm font-medium text-white capitalize">
+                    {tx.type.replace("_", " ")}
+                  </p>
+                  <p className="text-xs text-gray-500">{tx.shopName || "Platform"}</p>
+                  <p className="text-xs text-gray-600">{formatTxDate(tx.createdAt)}</p>
+                </div>
+              </div>
+              <div className="text-right">
+                <p className={`text-sm font-bold ${isEarn ? "text-green-400" : "text-blue-400"}`}>
+                  {isEarn ? "+" : "-"}{tx.amount.toFixed(2)} RCN
+                </p>
+                {tx.description && (
+                  <p className="text-[10px] text-gray-500 max-w-[120px] truncate">
+                    {tx.description}
+                  </p>
                 )}
               </div>
-              <div>
-                <p className="text-sm font-medium text-white capitalize">
-                  {tx.type.replace("_", " ")}
-                </p>
-                <p className="text-xs text-gray-500">{tx.shopName || "Platform"}</p>
-                <p className="text-xs text-gray-600">{formatTxDate(tx.createdAt)}</p>
-              </div>
             </div>
-            <div className="text-right">
-              <p className={`text-sm font-bold ${isEarn ? "text-green-400" : "text-blue-400"}`}>
-                {isEarn ? "+" : "-"}{tx.amount.toFixed(2)} RCN
-              </p>
-              {tx.description && (
-                <p className="text-[10px] text-gray-500 max-w-[120px] truncate">
-                  {tx.description}
-                </p>
-              )}
-            </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
+
+      <PaginationControls
+        currentPage={currentPage}
+        totalPages={pagination.totalPages}
+        totalItems={pagination.totalItems}
+        pageSize={pagination.limit}
+        onPageChange={handlePageChange}
+      />
     </div>
   );
 };
@@ -244,7 +425,6 @@ const RewardsTab: React.FC<{
 
   return (
     <div className="space-y-4">
-      {/* Summary Cards */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         <div className="bg-[#0A0A0A] rounded-xl p-4 border border-[#303236]">
           <p className="text-xs text-gray-500 mb-1">Total Earned</p>
@@ -270,7 +450,6 @@ const RewardsTab: React.FC<{
         </div>
       </div>
 
-      {/* Tier Info */}
       <div className="bg-[#0A0A0A] rounded-xl p-4 border border-[#303236]">
         <div className="flex items-center gap-2 mb-3">
           <Trophy className="w-4 h-4 text-[#FFCC00]" />
@@ -347,21 +526,22 @@ const NotesTab: React.FC<{ shopId: string; customerAddress: string }> = ({
 // --- Main Component ---
 
 export const CustomerProfileTabs: React.FC<CustomerProfileTabsProps> = ({
-  bookings,
-  transactions,
+  shopId,
+  customerAddress,
   analytics,
   customerBalance,
   customerTier,
-  shopId,
-  customerAddress,
+  initialBookings,
+  initialTransactions,
   selectedBookingId,
   onSelectBooking,
+  onBookingsLoaded,
 }) => {
   const [activeTab, setActiveTab] = useState<"bookings" | "transactions" | "rewards" | "notes">("bookings");
 
   const tabs = [
-    { id: "bookings" as const, label: "Bookings", count: bookings.length },
-    { id: "transactions" as const, label: "Transactions", count: transactions.length },
+    { id: "bookings" as const, label: "Bookings", count: initialBookings.pagination.totalItems },
+    { id: "transactions" as const, label: "Transactions", count: initialTransactions.pagination.totalItems },
     { id: "rewards" as const, label: "Rewards" },
     { id: "notes" as const, label: "Notes" },
   ];
@@ -397,12 +577,20 @@ export const CustomerProfileTabs: React.FC<CustomerProfileTabsProps> = ({
       <div className="p-6">
         {activeTab === "bookings" && (
           <BookingsTab
-            bookings={bookings}
+            customerAddress={customerAddress}
+            initialData={initialBookings}
             selectedBookingId={selectedBookingId}
             onSelectBooking={onSelectBooking}
+            onBookingsLoaded={onBookingsLoaded}
           />
         )}
-        {activeTab === "transactions" && <TransactionsTab transactions={transactions} />}
+        {activeTab === "transactions" && (
+          <TransactionsTab
+            customerAddress={customerAddress}
+            shopId={shopId}
+            initialData={initialTransactions}
+          />
+        )}
         {activeTab === "rewards" && (
           <RewardsTab analytics={analytics} balance={customerBalance} tier={customerTier} />
         )}

--- a/frontend/src/components/shop/customers/profile/CustomerProfileView.tsx
+++ b/frontend/src/components/shop/customers/profile/CustomerProfileView.tsx
@@ -36,18 +36,6 @@ interface CustomerAnalytics {
   monthlyActivity: { month: string; earnings: number; redemptions: number }[];
 }
 
-interface Transaction {
-  id: string;
-  type: string;
-  amount: number;
-  shopId?: string;
-  shopName?: string;
-  createdAt: string;
-  description?: string;
-  transactionHash?: string;
-  status?: string;
-}
-
 interface BookingOrder {
   orderId: string;
   serviceName: string;
@@ -66,11 +54,54 @@ interface BookingOrder {
   shopName?: string;
 }
 
+interface PaginationMeta {
+  page: number;
+  limit: number;
+  totalItems: number;
+  totalPages: number;
+  hasMore: boolean;
+}
+
+interface Transaction {
+  id: string;
+  type: string;
+  amount: number;
+  shopId?: string;
+  shopName?: string;
+  createdAt: string;
+  description?: string;
+}
+
+interface ProfileData {
+  customer: CustomerDetails;
+  analytics: CustomerAnalytics;
+  bookings: { items: BookingOrder[]; pagination: PaginationMeta };
+  transactions: { items: Transaction[]; pagination: PaginationMeta };
+}
+
 interface CustomerProfileViewProps {
   customerAddress: string;
   shopId: string;
   onBack: () => void;
 }
+
+const mapBookingOrder = (o: any): BookingOrder => ({
+  orderId: o.orderId || o.order_id,
+  serviceName: o.serviceName || o.service_name || "Unknown Service",
+  serviceDescription: o.serviceDescription || o.service_description,
+  serviceCategory: o.serviceCategory || o.service_category,
+  status: o.status,
+  totalPrice: o.totalPrice || o.total_price || 0,
+  rcnDiscount: o.rcnDiscount || o.rcn_discount || 0,
+  finalPrice: o.finalPrice || o.final_price || 0,
+  rcnEarned: o.rcnEarned || o.rcn_earned || 0,
+  paymentMethod: o.paymentMethod || o.payment_method,
+  bookingTimeSlot: o.bookingTimeSlot || o.booking_time_slot,
+  bookingEndTime: o.bookingEndTime || o.booking_end_time,
+  createdAt: o.createdAt || o.created_at,
+  completedAt: o.completedAt || o.completed_at,
+  shopName: o.shopName || o.shop_name,
+});
 
 export const CustomerProfileView: React.FC<CustomerProfileViewProps> = ({
   customerAddress,
@@ -80,11 +111,10 @@ export const CustomerProfileView: React.FC<CustomerProfileViewProps> = ({
   const router = useRouter();
   const [loading, setLoading] = useState(true);
   const [sendingMessage, setSendingMessage] = useState(false);
-  const [customer, setCustomer] = useState<CustomerDetails | null>(null);
-  const [transactions, setTransactions] = useState<Transaction[]>([]);
-  const [analytics, setAnalytics] = useState<CustomerAnalytics | null>(null);
-  const [bookings, setBookings] = useState<BookingOrder[]>([]);
+  const [profileData, setProfileData] = useState<ProfileData | null>(null);
   const [selectedBookingId, setSelectedBookingId] = useState<string | null>(null);
+  // Keep a flat list of all loaded bookings for the sidebar detail panel
+  const [allBookings, setAllBookings] = useState<BookingOrder[]>([]);
 
   const handleSendMessage = async (address: string) => {
     setSendingMessage(true);
@@ -99,95 +129,56 @@ export const CustomerProfileView: React.FC<CustomerProfileViewProps> = ({
   };
 
   useEffect(() => {
-    loadAllData();
+    loadProfile();
   }, [customerAddress]);
 
-  const loadAllData = async () => {
+  const loadProfile = async () => {
     setLoading(true);
     setSelectedBookingId(null);
 
     try {
-      const [detailsRes, balanceRes, transactionsRes, analyticsRes, bookingsRes] =
-        await Promise.all([
-          fetch(`${process.env.NEXT_PUBLIC_API_URL}/customers/${customerAddress}`, {
-            credentials: "include",
-          }),
-          fetch(`${process.env.NEXT_PUBLIC_API_URL}/tokens/balance/${customerAddress}`, {
-            credentials: "include",
-          }),
-          fetch(
-            `${process.env.NEXT_PUBLIC_API_URL}/customers/${customerAddress}/transactions?limit=20`,
-            { credentials: "include" }
-          ),
-          fetch(
-            `${process.env.NEXT_PUBLIC_API_URL}/customers/${customerAddress}/analytics`,
-            { credentials: "include" }
-          ),
-          fetch(
-            `${process.env.NEXT_PUBLIC_API_URL}/services/orders/shop?customerAddress=${encodeURIComponent(customerAddress)}&limit=50`,
-            { credentials: "include" }
-          ),
-        ]);
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/shops/${shopId}/customer-profile/${customerAddress}?bookingsPage=1&bookingsLimit=5&transactionsPage=1&transactionsLimit=5`,
+        { credentials: "include" }
+      );
 
-      if (!detailsRes.ok) throw new Error("Failed to load customer details");
+      if (!res.ok) throw new Error("Failed to load customer profile");
+      const json = await res.json();
+      const d = json.data;
 
-      const detailsData = await detailsRes.json();
-      const balanceData = balanceRes.ok ? await balanceRes.json() : { data: null };
-      const transactionsData = transactionsRes.ok ? await transactionsRes.json() : { data: [] };
-      const analyticsData = analyticsRes.ok ? await analyticsRes.json() : { data: null };
-      const bookingsData = bookingsRes.ok ? await bookingsRes.json() : { data: [] };
+      const bookingItems = (d.bookings?.items || []).map(mapBookingOrder);
 
-      // Extract customer from response
-      const customerData = detailsData.data?.customer || detailsData.data;
+      const data: ProfileData = {
+        customer: d.customer,
+        analytics: d.analytics,
+        bookings: {
+          items: bookingItems,
+          pagination: d.bookings?.pagination || { page: 1, limit: 5, totalItems: 0, totalPages: 1, hasMore: false },
+        },
+        transactions: {
+          items: d.transactions?.items || [],
+          pagination: d.transactions?.pagination || { page: 1, limit: 5, totalItems: 0, totalPages: 1, hasMore: false },
+        },
+      };
 
-      // Use accurate balance from /tokens/balance endpoint
-      if (balanceData.data) {
-        customerData.currentBalance = balanceData.data.availableBalance;
-        customerData.lifetimeEarnings = balanceData.data.lifetimeEarned;
-        customerData.totalRedemptions = balanceData.data.totalRedeemed;
-      }
-
-      setCustomer(customerData);
-      setTransactions(transactionsData.data?.transactions || transactionsData.data || []);
-      setAnalytics(analyticsData.data);
-
-      // Map bookings from API response
-      const orders = (bookingsData.data || []).map((o: any) => ({
-        orderId: o.orderId || o.order_id,
-        serviceName: o.serviceName || o.service_name || "Unknown Service",
-        serviceDescription: o.serviceDescription || o.service_description,
-        serviceCategory: o.serviceCategory || o.service_category,
-        status: o.status,
-        totalPrice: o.totalPrice || o.total_price || 0,
-        rcnDiscount: o.rcnDiscount || o.rcn_discount || 0,
-        finalPrice: o.finalPrice || o.final_price || 0,
-        rcnEarned: o.rcnEarned || o.rcn_earned || 0,
-        paymentMethod: o.paymentMethod || o.payment_method,
-        bookingTimeSlot: o.bookingTimeSlot || o.booking_time_slot,
-        bookingEndTime: o.bookingEndTime || o.booking_end_time,
-        createdAt: o.createdAt || o.created_at,
-        completedAt: o.completedAt || o.completed_at,
-        shopName: o.shopName || o.shop_name,
-      }));
-      setBookings(orders);
+      setProfileData(data);
+      setAllBookings(bookingItems);
     } catch (error) {
-      console.error("Error loading customer profile data:", error);
+      console.error("Error loading customer profile:", error);
+      toast.error("Failed to load customer profile");
     } finally {
       setLoading(false);
     }
   };
 
-  // Compute derived data
-  const selectedBooking = bookings.find((b) => b.orderId === selectedBookingId) || null;
-  const activeBookingsCount = bookings.filter(
-    (b) => b.status === "pending" || b.status === "paid"
-  ).length;
-  const memberDays = customer?.joinDate
-    ? Math.floor(
-        (Date.now() - new Date(customer.joinDate).getTime()) / (1000 * 60 * 60 * 24)
-      )
-    : 0;
-  const lastCompletedBooking = bookings.find((b) => b.status === "completed");
+  // Callback for when tabs load a new page of bookings — accumulate for sidebar
+  const handleBookingsLoaded = (bookings: BookingOrder[]) => {
+    setAllBookings((prev) => {
+      const ids = new Set(prev.map((b) => b.orderId));
+      const newOnes = bookings.filter((b) => !ids.has(b.orderId));
+      return [...prev, ...newOnes];
+    });
+  };
 
   if (loading) {
     return (
@@ -200,7 +191,7 @@ export const CustomerProfileView: React.FC<CustomerProfileViewProps> = ({
     );
   }
 
-  if (!customer) {
+  if (!profileData) {
     return (
       <div className="text-center py-20">
         <p className="text-white text-lg font-medium mb-2">Customer Not Found</p>
@@ -214,6 +205,20 @@ export const CustomerProfileView: React.FC<CustomerProfileViewProps> = ({
       </div>
     );
   }
+
+  const { customer, analytics } = profileData;
+
+  // Derived data from accumulated bookings
+  const selectedBooking = allBookings.find((b) => b.orderId === selectedBookingId) || null;
+  const activeBookingsCount = allBookings.filter(
+    (b) => b.status === "pending" || b.status === "paid"
+  ).length;
+  const memberDays = customer.joinDate
+    ? Math.floor(
+        (Date.now() - new Date(customer.joinDate).getTime()) / (1000 * 60 * 60 * 24)
+      )
+    : 0;
+  const lastCompletedBooking = allBookings.find((b) => b.status === "completed");
 
   return (
     <div className="space-y-6">
@@ -232,21 +237,22 @@ export const CustomerProfileView: React.FC<CustomerProfileViewProps> = ({
         <div className="lg:col-span-7 space-y-6">
           <CustomerInfoCard
             customer={customer}
-            bookingsCount={bookings.length}
+            bookingsCount={profileData.bookings.pagination.totalItems}
             activeBookingsCount={activeBookingsCount}
             onSendMessage={handleSendMessage}
             sendingMessage={sendingMessage}
           />
           <CustomerProfileTabs
-            bookings={bookings}
-            transactions={transactions}
+            shopId={shopId}
+            customerAddress={customerAddress}
             analytics={analytics}
             customerBalance={customer.currentBalance ?? 0}
             customerTier={customer.tier}
-            shopId={shopId}
-            customerAddress={customerAddress}
+            initialBookings={profileData.bookings}
+            initialTransactions={profileData.transactions}
             selectedBookingId={selectedBookingId}
             onSelectBooking={setSelectedBookingId}
+            onBookingsLoaded={handleBookingsLoaded}
           />
         </div>
 

--- a/frontend/src/components/shop/tabs/CustomersTab.tsx
+++ b/frontend/src/components/shop/tabs/CustomersTab.tsx
@@ -14,6 +14,8 @@ import {
   X,
   Loader2,
   User,
+  ChevronLeft,
+  ChevronRight,
 } from "lucide-react";
 import {
   Select,
@@ -23,8 +25,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { LookupIcon } from "@/components/icon";
+import { useRouter } from "next/navigation";
 import CustomerCard from "@/components/shop/customers/CustomerCard";
-import { CustomerProfileView } from "@/components/shop/customers/profile";
 
 interface Customer {
   address: string;
@@ -117,6 +119,8 @@ const TierBadge: React.FC<{ tier: "BRONZE" | "SILVER" | "GOLD" }> = ({ tier }) =
 };
 
 export const CustomersTab: React.FC<CustomersTabProps> = ({ shopId }) => {
+  const router = useRouter();
+
   // View mode state
   const [viewMode, setViewMode] = useState<"my-customers" | "search-all">("my-customers");
 
@@ -133,6 +137,12 @@ export const CustomersTab: React.FC<CustomersTabProps> = ({ shopId }) => {
   const [growthStats, setGrowthStats] = useState<GrowthStats | null>(null);
   const [growthPeriod] = useState<"7d" | "30d" | "90d">("7d");
 
+  // Server-side pagination state
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState(10);
+  const [totalItems, setTotalItems] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
+
   // Search All Customers state
   const [searchQuery, setSearchQuery] = useState("");
   const [searchState, setSearchState] = useState<SearchState>({
@@ -146,13 +156,12 @@ export const CustomersTab: React.FC<CustomersTabProps> = ({ shopId }) => {
   const [showQRScanner, setShowQRScanner] = useState(false);
   const [qrScanner, setQrScanner] = useState<QrScanner | null>(null);
   const [cameraLoading, setCameraLoading] = useState(false);
-  const [selectedCustomer, setSelectedCustomer] = useState<string | null>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
     loadCustomers();
     loadGrowthStats();
-  }, [shopId]);
+  }, [shopId, currentPage, pageSize, searchTerm]);
 
   useEffect(() => {
     if (shopId) {
@@ -164,9 +173,19 @@ export const CustomersTab: React.FC<CustomersTabProps> = ({ shopId }) => {
     setLoading(true);
 
     try {
-      const result = await apiClient.get(`/shops/${shopId}/customers?limit=100`);
+      const params = new URLSearchParams({
+        page: String(currentPage),
+        limit: String(pageSize),
+      });
+      if (searchTerm.trim()) {
+        params.set("search", searchTerm.trim());
+      }
+
+      const result = await apiClient.get(`/shops/${shopId}/customers?${params.toString()}`);
 
       const customerData = result.data?.customers || [];
+      setTotalItems(result.data?.totalItems ?? customerData.length);
+      setTotalPages(result.data?.totalPages ?? 1);
 
       const transformedCustomers = customerData.map((c: any) => ({
         address: c.address || c.customer_address,
@@ -281,7 +300,7 @@ export const CustomersTab: React.FC<CustomersTabProps> = ({ shopId }) => {
   };
 
   const handleViewProfile = (address: string) => {
-    setSelectedCustomer(address);
+    router.push(`/shop/customers/${address}`);
   };
 
   const handleCopyAddress = (address: string) => {
@@ -393,14 +412,10 @@ export const CustomersTab: React.FC<CustomersTabProps> = ({ shopId }) => {
     }
   };
 
-  const filteredCustomers = customers
+  // Client-side tier filter and sort (applied to server-paginated results)
+  const displayCustomers = customers
     .filter((customer) => {
-      const matchesSearch =
-        searchTerm === "" ||
-        customer.address.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        customer.name?.toLowerCase().includes(searchTerm.toLowerCase());
-      const matchesTier = tierFilter === "all" || customer.tier === tierFilter;
-      return matchesSearch && matchesTier;
+      return tierFilter === "all" || customer.tier === tierFilter;
     })
     .sort((a, b) => {
       switch (sortBy) {
@@ -416,6 +431,11 @@ export const CustomersTab: React.FC<CustomersTabProps> = ({ shopId }) => {
           );
       }
     });
+
+  // Reset to page 1 when filters change
+  React.useEffect(() => {
+    setCurrentPage(1);
+  }, [tierFilter, sortBy]);
 
   const formatAddress = (address: string) => {
     return `${address.slice(0, 8)}...${address.slice(-6)}`;
@@ -434,17 +454,6 @@ export const CustomersTab: React.FC<CustomersTabProps> = ({ shopId }) => {
     const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
     return lastTransaction > weekAgo;
   }).length;
-
-  // If a customer is selected, show full profile view
-  if (selectedCustomer) {
-    return (
-      <CustomerProfileView
-        customerAddress={selectedCustomer}
-        shopId={shopId}
-        onBack={() => setSelectedCustomer(null)}
-      />
-    );
-  }
 
   return (
     <div className="space-y-6">
@@ -587,7 +596,7 @@ export const CustomersTab: React.FC<CustomersTabProps> = ({ shopId }) => {
               <p className="text-gray-400">Loading customers...</p>
             </div>
           </div>
-        ) : filteredCustomers.length === 0 ? (
+        ) : displayCustomers.length === 0 ? (
           <div className="p-12">
             <div className="text-center">
               <div className="inline-flex items-center justify-center w-20 h-20 bg-gray-800 rounded-full mb-4">
@@ -604,61 +613,141 @@ export const CustomersTab: React.FC<CustomersTabProps> = ({ shopId }) => {
             </div>
           </div>
         ) : (
-          <div className="divide-y divide-[rgba(229,234,238,0.55)]">
-            {filteredCustomers.map((customer) => (
-              <div
-                key={customer.address}
-                className="px-7 py-4 hover:bg-[#1a1a1a] transition-colors cursor-pointer"
-                onClick={() => handleViewProfile(customer.address)}
-              >
-                <div className="grid grid-cols-4 gap-4 items-center">
-                  {/* Customer Info */}
-                  <div className="flex items-center gap-3">
-                    <div className="w-9 h-9 rounded-full overflow-hidden flex-shrink-0 bg-gray-700">
-                      {customer.profile_image_url ? (
-                        <img
-                          src={customer.profile_image_url}
-                          alt={customer.name || "Customer"}
-                          className="w-full h-full object-cover"
-                        />
-                      ) : (
-                        <div className="w-full h-full flex items-center justify-center text-gray-400">
-                          <User className="w-5 h-5" />
-                        </div>
-                      )}
+          <>
+            <div className="divide-y divide-[rgba(229,234,238,0.55)]">
+              {displayCustomers.map((customer) => (
+                <div
+                  key={customer.address}
+                  className="px-7 py-4 hover:bg-[#1a1a1a] transition-colors cursor-pointer"
+                  onClick={() => handleViewProfile(customer.address)}
+                >
+                  <div className="grid grid-cols-4 gap-4 items-center">
+                    {/* Customer Info */}
+                    <div className="flex items-center gap-3">
+                      <div className="w-9 h-9 rounded-full overflow-hidden flex-shrink-0 bg-gray-700">
+                        {customer.profile_image_url ? (
+                          <img
+                            src={customer.profile_image_url}
+                            alt={customer.name || "Customer"}
+                            className="w-full h-full object-cover"
+                          />
+                        ) : (
+                          <div className="w-full h-full flex items-center justify-center text-gray-400">
+                            <User className="w-5 h-5" />
+                          </div>
+                        )}
+                      </div>
+                      <div className="flex flex-col">
+                        <p className="text-sm font-semibold text-white">
+                          {customer.name || "Anonymous Customer"}
+                        </p>
+                        <p className="text-sm font-medium text-white/55">
+                          {formatAddress(customer.address)}
+                        </p>
+                      </div>
                     </div>
-                    <div className="flex flex-col">
+
+                    {/* Tier Badge */}
+                    <div>
+                      <TierBadge tier={customer.tier} />
+                    </div>
+
+                    {/* Lifetime RCN */}
+                    <div>
                       <p className="text-sm font-semibold text-white">
-                        {customer.name || "Anonymous Customer"}
-                      </p>
-                      <p className="text-sm font-medium text-white/55">
-                        {formatAddress(customer.address)}
+                        {customer.lifetimeEarnings} RCN
                       </p>
                     </div>
-                  </div>
 
-                  {/* Tier Badge */}
-                  <div>
-                    <TierBadge tier={customer.tier} />
-                  </div>
-
-                  {/* Lifetime RCN */}
-                  <div>
-                    <p className="text-sm font-semibold text-white">
-                      {customer.lifetimeEarnings} RCN
-                    </p>
-                  </div>
-
-                  {/* Transactions */}
-                  <div>
-                    <p className="text-sm font-semibold text-white">
-                      {customer.totalTransactions}
-                    </p>
+                    {/* Transactions */}
+                    <div>
+                      <p className="text-sm font-semibold text-white">
+                        {customer.totalTransactions}
+                      </p>
+                    </div>
                   </div>
                 </div>
+              ))}
+            </div>
+
+            {/* Pagination Controls */}
+            {totalItems > 0 && (
+              <div className="px-7 py-4 border-t border-[#303236] flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <span className="text-sm text-gray-400">
+                    Showing {(currentPage - 1) * pageSize + 1}-{Math.min(currentPage * pageSize, totalItems)} of {totalItems}
+                  </span>
+                  <Select
+                    value={String(pageSize)}
+                    onValueChange={(value) => {
+                      setPageSize(Number(value));
+                      setCurrentPage(1);
+                    }}
+                  >
+                    <SelectTrigger className="w-[80px] h-[32px] bg-[#1a1a1a] border-[#303236] rounded-lg text-sm text-white">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="5">5</SelectItem>
+                      <SelectItem value="10">10</SelectItem>
+                      <SelectItem value="25">25</SelectItem>
+                      <SelectItem value="50">50</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <span className="text-sm text-gray-400">per page</span>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                    disabled={currentPage === 1}
+                    className="p-2 rounded-lg bg-[#1a1a1a] border border-[#303236] text-white disabled:opacity-30 disabled:cursor-not-allowed hover:bg-[#2a2a2a] transition-colors"
+                  >
+                    <ChevronLeft className="w-4 h-4" />
+                  </button>
+
+                  {Array.from({ length: totalPages }, (_, i) => i + 1)
+                    .filter((page) => {
+                      if (totalPages <= 5) return true;
+                      if (page === 1 || page === totalPages) return true;
+                      return Math.abs(page - currentPage) <= 1;
+                    })
+                    .reduce<(number | "ellipsis")[]>((acc, page, idx, arr) => {
+                      if (idx > 0 && page - (arr[idx - 1] as number) > 1) {
+                        acc.push("ellipsis");
+                      }
+                      acc.push(page);
+                      return acc;
+                    }, [])
+                    .map((item, idx) =>
+                      item === "ellipsis" ? (
+                        <span key={`ellipsis-${idx}`} className="px-1 text-gray-500">...</span>
+                      ) : (
+                        <button
+                          key={item}
+                          onClick={() => setCurrentPage(item)}
+                          className={`w-8 h-8 rounded-lg text-sm font-medium transition-colors ${
+                            currentPage === item
+                              ? "bg-[#FFCC00] text-[#101010]"
+                              : "bg-[#1a1a1a] border border-[#303236] text-white hover:bg-[#2a2a2a]"
+                          }`}
+                        >
+                          {item}
+                        </button>
+                      )
+                    )}
+
+                  <button
+                    onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                    disabled={currentPage === totalPages}
+                    className="p-2 rounded-lg bg-[#1a1a1a] border border-[#303236] text-white disabled:opacity-30 disabled:cursor-not-allowed hover:bg-[#2a2a2a] transition-colors"
+                  >
+                    <ChevronRight className="w-4 h-4" />
+                  </button>
+                </div>
               </div>
-            ))}
-          </div>
+            )}
+          </>
         )}
       </div>
         </>

--- a/frontend/src/stores/shopProfileStore.ts
+++ b/frontend/src/stores/shopProfileStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+type ShopProfileTab = "services" | "about" | "gallery" | "reviews" | "analytics" | "appointments" | "customers";
+
+interface ShopProfileState {
+  activeTab: ShopProfileTab;
+  setActiveTab: (tab: ShopProfileTab) => void;
+}
+
+export const useShopProfileStore = create<ShopProfileState>((set) => ({
+  activeTab: "services",
+  setActiveTab: (tab) => set({ activeTab: tab }),
+}));


### PR DESCRIPTION
- Create single backend endpoint GET /shops/:shopId/customer-profile/:customerAddress that returns customer details, balance, analytics, bookings, and transactions
  in one API call, eliminating multiple loading states
- Add server-side pagination to shop customers table (CustomersTab)
- Add server-side pagination to bookings and transactions tabs in customer profile
- Merge balance + analytics into single DB query, remove LOWER() for index usage,
  cache OrderRepository singleton for performance
- Persist shop profile active tab across navigation with Zustand store
- Fix TransactionRepository to return totalItems for proper pagination metadata
- Update all callers of getTransactionsByCustomer for new return shape

https://app.clickup.com/t/86d283uq5

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>