### PR TITLE
fix: server-side pagination and filtering for bookings tabs

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -102,7 +102,8 @@
       "Read(//tmp/**)",
       "Bash(test:*)",
       "Bash(psql:*)",
-      "Bash(sed:*)"
+      "Bash(sed:*)",
+      "Bash(grep -E \"\\\\.\\(tsx|ts\\)$\")"
     ],
     "deny": [],
     "ask": []

--- a/backend/src/domains/ServiceDomain/controllers/OrderController.ts
+++ b/backend/src/domains/ServiceDomain/controllers/OrderController.ts
@@ -224,6 +224,32 @@ export class OrderController {
   };
 
   /**
+   * Get shop order counts by status (Shop only)
+   * GET /api/services/orders/shop/counts
+   */
+  getShopOrderCounts = async (req: Request, res: Response) => {
+    try {
+      const shopId = req.user?.shopId;
+      if (!shopId) {
+        return res.status(401).json({ success: false, error: 'Shop authentication required' });
+      }
+
+      const counts = await this.orderRepository.getOrderCountsByShop(shopId);
+
+      res.json({
+        success: true,
+        data: counts
+      });
+    } catch (error: unknown) {
+      logger.error('Error in getShopOrderCounts controller:', error);
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to get order counts'
+      });
+    }
+  };
+
+  /**
    * Get order by ID (Customer or Shop)
    * GET /api/services/orders/:id
    */

--- a/backend/src/domains/ServiceDomain/routes.ts
+++ b/backend/src/domains/ServiceDomain/routes.ts
@@ -622,6 +622,26 @@ export function initializeRoutes(stripe: StripeService): Router {
 
   /**
    * @swagger
+   * /api/services/orders/shop/counts:
+   *   get:
+   *     summary: Get shop order counts by status
+   *     description: Returns count of orders grouped by status for the authenticated shop
+   *     tags: [Service Orders]
+   *     security:
+   *       - bearerAuth: []
+   *     responses:
+   *       200:
+   *         description: Order counts by status
+   */
+  router.get(
+    '/orders/shop/counts',
+    authMiddleware,
+    requireRole(['shop']),
+    orderController.getShopOrderCounts
+  );
+
+  /**
+   * @swagger
    * /api/services/orders/{id}:
    *   get:
    *     summary: Get order by ID

--- a/backend/src/repositories/OrderRepository.ts
+++ b/backend/src/repositories/OrderRepository.ts
@@ -411,6 +411,29 @@ export class OrderRepository extends BaseRepository {
   }
 
   /**
+   * Get order counts by status for a shop
+   */
+  async getOrderCountsByShop(shopId: string): Promise<Record<string, number>> {
+    try {
+      const query = `
+        SELECT status, COUNT(*)::int as count
+        FROM service_orders
+        WHERE shop_id = $1
+        GROUP BY status
+      `;
+      const result = await this.pool.query(query, [shopId]);
+      const counts: Record<string, number> = {};
+      for (const row of result.rows) {
+        counts[row.status] = row.count;
+      }
+      return counts;
+    } catch (error) {
+      logger.error('Error fetching order counts by shop:', error);
+      throw error;
+    }
+  }
+
+  /**
    * Update order status
    */
   async updateOrderStatus(orderId: string, status: OrderStatus): Promise<ServiceOrder> {

--- a/frontend/src/components/shop/bookings/BookingFilters.tsx
+++ b/frontend/src/components/shop/bookings/BookingFilters.tsx
@@ -4,6 +4,14 @@ import React from "react";
 import { Search, MessageSquare } from "lucide-react";
 import { BookingStatus, MockBooking } from "./mockData";
 
+interface FilterCounts {
+  all: number;
+  pending: number;
+  paid: number;
+  completed: number;
+  cancelled: number;
+}
+
 interface BookingFiltersProps {
   activeFilter: string;
   onFilterChange: (filter: string) => void;
@@ -13,6 +21,7 @@ interface BookingFiltersProps {
   activeTab: 'bookings' | 'messages';
   onTabChange: (tab: 'bookings' | 'messages') => void;
   unreadMessagesCount: number;
+  filterCounts?: FilterCounts;
 }
 
 export const BookingFilters: React.FC<BookingFiltersProps> = ({
@@ -23,9 +32,10 @@ export const BookingFilters: React.FC<BookingFiltersProps> = ({
   bookings,
   activeTab,
   onTabChange,
-  unreadMessagesCount
+  unreadMessagesCount,
+  filterCounts: filterCountsProp
 }) => {
-  const filterCounts = {
+  const filterCounts = filterCountsProp || {
     all: bookings.length,
     pending: bookings.filter(b => b.status === 'requested').length,
     paid: bookings.filter(b => b.status === 'paid' || b.status === 'approved' || b.status === 'scheduled').length,

--- a/frontend/src/components/shop/bookings/BookingStatsCards.tsx
+++ b/frontend/src/components/shop/bookings/BookingStatsCards.tsx
@@ -4,14 +4,21 @@ import React from "react";
 import { Clock, CheckCircle, DollarSign, Receipt } from "lucide-react";
 import { MockBooking } from "./mockData";
 
-interface BookingStatsCardsProps {
-  bookings: MockBooking[];
+interface StatusCounts {
+  pending: number;
+  paid: number;
+  completed: number;
 }
 
-export const BookingStatsCards: React.FC<BookingStatsCardsProps> = ({ bookings }) => {
-  const pendingCount = bookings.filter(b => b.status === 'requested').length;
-  const paidCount = bookings.filter(b => b.status === 'paid' || b.status === 'approved' || b.status === 'scheduled').length;
-  const completedCount = bookings.filter(b => b.status === 'completed').length;
+interface BookingStatsCardsProps {
+  bookings: MockBooking[];
+  statusCounts?: StatusCounts;
+}
+
+export const BookingStatsCards: React.FC<BookingStatsCardsProps> = ({ bookings, statusCounts }) => {
+  const pendingCount = statusCounts?.pending ?? bookings.filter(b => b.status === 'requested').length;
+  const paidCount = statusCounts?.paid ?? bookings.filter(b => b.status === 'paid' || b.status === 'approved' || b.status === 'scheduled').length;
+  const completedCount = statusCounts?.completed ?? bookings.filter(b => b.status === 'completed').length;
   const totalRevenue = bookings
     .filter(b => b.status === 'paid' || b.status === 'approved' || b.status === 'scheduled' || b.status === 'completed')
     .reduce((sum, b) => sum + b.amount, 0);

--- a/frontend/src/components/shop/bookings/BookingsTabV2.tsx
+++ b/frontend/src/components/shop/bookings/BookingsTabV2.tsx
@@ -18,6 +18,7 @@ import { CancelBookingModal } from "./CancelBookingModal";
 import { toast } from "react-hot-toast";
 import {
   getShopOrders,
+  getShopOrderCounts,
   updateOrderStatus,
   approveBooking,
   ServiceOrderWithDetails,
@@ -115,14 +116,38 @@ export const BookingsTabV2: React.FC<BookingsTabV2Props> = ({
   const [isRescheduling, setIsRescheduling] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
-  const ITEMS_PER_PAGE = 10;
+  const [statusCounts, setStatusCounts] = useState<Record<string, number>>({});
+  const ITEMS_PER_PAGE = 5;
+
+  // Map frontend filter key to backend status value
+  const getApiStatus = (filter: string): string | undefined => {
+    if (filter === "all") return undefined;
+    return filter; // "pending", "paid", "completed", "cancelled" map directly
+  };
+
+  // Load status counts from API
+  const loadCounts = async () => {
+    try {
+      const counts = await getShopOrderCounts();
+      if (counts) {
+        setStatusCounts(counts);
+      }
+    } catch (err) {
+      console.error("Error loading order counts:", err);
+    }
+  };
 
   // Load bookings from API
-  const loadBookings = async (page: number = currentPage) => {
+  const loadBookings = async (page: number = currentPage, filter: string = activeFilter) => {
     setLoading(true);
     setError(null);
     try {
-      const response = await getShopOrders({ limit: ITEMS_PER_PAGE, page });
+      const apiStatus = getApiStatus(filter);
+      const response = await getShopOrders({
+        limit: ITEMS_PER_PAGE,
+        page,
+        ...(apiStatus ? { status: apiStatus as 'pending' | 'paid' | 'completed' | 'cancelled' } : {}),
+      });
       if (response && response.data) {
         // Transform API data to UI format
         const transformedBookings = response.data.map(transformApiOrder);
@@ -131,9 +156,11 @@ export const BookingsTabV2: React.FC<BookingsTabV2Props> = ({
           setTotalPages(response.pagination.totalPages);
           setCurrentPage(response.pagination.page);
         }
-        // Select first booking if none selected
-        if (!selectedBookingId && transformedBookings.length > 0) {
+        // Select first booking automatically
+        if (transformedBookings.length > 0) {
           setSelectedBookingId(transformedBookings[0].bookingId);
+        } else {
+          setSelectedBookingId(null);
         }
       }
     } catch (err) {
@@ -154,9 +181,17 @@ export const BookingsTabV2: React.FC<BookingsTabV2Props> = ({
     loadBookings(page);
   };
 
-  // Load bookings on mount
+  const handleFilterChange = (filter: string) => {
+    setActiveFilter(filter);
+    setCurrentPage(1);
+    setSelectedBookingId(null);
+    loadBookings(1, filter);
+  };
+
+  // Load bookings and counts on mount
   useEffect(() => {
     loadBookings(1);
+    loadCounts();
   }, [shopId]);
 
   // Handle URL search parameter for filtering and selecting booking
@@ -193,39 +228,33 @@ export const BookingsTabV2: React.FC<BookingsTabV2Props> = ({
     return bookings.reduce((sum, b) => sum + b.unreadCount, 0);
   }, [bookings]);
 
-  // Filter bookings based on filter and search
+  // Compute filter counts from API status counts
+  const filterCounts = useMemo(() => {
+    const pending = statusCounts["pending"] || 0;
+    const paid = statusCounts["paid"] || 0;
+    const completed = statusCounts["completed"] || 0;
+    const cancelled = (statusCounts["cancelled"] || 0) + (statusCounts["refunded"] || 0) + (statusCounts["no_show"] || 0);
+    return {
+      all: pending + paid + completed + cancelled,
+      pending,
+      paid,
+      completed,
+      cancelled,
+    };
+  }, [statusCounts]);
+
+  // Filter bookings by search only (status filtering is done server-side)
   const filteredBookings = useMemo(() => {
-    let filtered = [...bookings];
+    if (!searchQuery.trim()) return bookings;
 
-    // Apply status filter
-    if (activeFilter !== "all") {
-      if (activeFilter === "pending") {
-        filtered = filtered.filter((b) => b.status === "requested");
-      } else if (activeFilter === "paid") {
-        filtered = filtered.filter(
-          (b) =>
-            b.status === "paid" ||
-            b.status === "approved" ||
-            b.status === "scheduled",
-        );
-      } else {
-        filtered = filtered.filter((b) => b.status === activeFilter);
-      }
-    }
-
-    // Apply search
-    if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase();
-      filtered = filtered.filter(
-        (b) =>
-          b.bookingId.toLowerCase().includes(query) ||
-          b.customerName.toLowerCase().includes(query) ||
-          b.serviceName.toLowerCase().includes(query),
-      );
-    }
-
-    return filtered;
-  }, [bookings, activeFilter, searchQuery]);
+    const query = searchQuery.toLowerCase();
+    return bookings.filter(
+      (b) =>
+        b.bookingId.toLowerCase().includes(query) ||
+        b.customerName.toLowerCase().includes(query) ||
+        b.serviceName.toLowerCase().includes(query),
+    );
+  }, [bookings, searchQuery]);
 
   // Get selected booking
   const selectedBooking = useMemo(() => {
@@ -261,6 +290,7 @@ export const BookingsTabV2: React.FC<BookingsTabV2Props> = ({
         }),
       );
       toast.success(`Booking ${bookingId} approved!`);
+      loadCounts();
     } catch (error: unknown) {
       console.error("Error approving booking:", error);
       const errorMessage =
@@ -386,6 +416,7 @@ export const BookingsTabV2: React.FC<BookingsTabV2Props> = ({
         toast.success(
           `Booking ${bookingId} marked as completed! Customer will receive their RCN rewards.`,
         );
+        loadCounts();
       } else {
         // Revert optimistic update on failure
         setBookings((prev) =>
@@ -443,6 +474,7 @@ export const BookingsTabV2: React.FC<BookingsTabV2Props> = ({
           return b;
         }),
       );
+      loadCounts();
     }
     setCancelModalBooking(null);
   };
@@ -456,7 +488,7 @@ export const BookingsTabV2: React.FC<BookingsTabV2Props> = ({
           <p className="text-gray-400">View and manage your bookings</p>
         </div>
         <button
-          onClick={loadBookings}
+          onClick={() => { loadBookings(); loadCounts(); }}
           disabled={loading}
           className="flex items-center gap-2 px-4 py-2 bg-[#1A1A1A] border border-gray-800 rounded-lg text-gray-300 hover:border-gray-600 transition-colors disabled:opacity-50"
         >
@@ -486,18 +518,26 @@ export const BookingsTabV2: React.FC<BookingsTabV2Props> = ({
       )}
 
       {/* Stats Cards */}
-      <BookingStatsCards bookings={bookings} />
+      <BookingStatsCards
+        bookings={bookings}
+        statusCounts={{
+          pending: filterCounts.pending,
+          paid: filterCounts.paid,
+          completed: filterCounts.completed,
+        }}
+      />
 
       {/* Filters */}
       <BookingFilters
         activeFilter={activeFilter}
-        onFilterChange={setActiveFilter}
+        onFilterChange={handleFilterChange}
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
         bookings={bookings}
         activeTab={activeTab}
         onTabChange={setActiveTab}
         unreadMessagesCount={unreadMessagesCount}
+        filterCounts={filterCounts}
       />
 
       {/* Main Content - Split Panel Layout */}

--- a/frontend/src/services/api/services.ts
+++ b/frontend/src/services/api/services.ts
@@ -373,6 +373,19 @@ export const getShopOrders = async (
 };
 
 /**
+ * Get shop order counts by status (Shop only)
+ */
+export const getShopOrderCounts = async (): Promise<Record<string, number> | null> => {
+  try {
+    const response = await apiClient.get<Record<string, number>>('/services/orders/shop/counts');
+    return response.data || null;
+  } catch (error) {
+    console.error('Error getting shop order counts:', error);
+    return null;
+  }
+};
+
+/**
  * Get order by ID (Customer or Shop)
  */
 export const getOrderById = async (orderId: string): Promise<ServiceOrderWithDetails | null> => {


### PR DESCRIPTION
Bookings pagination was broken when switching status tabs because the API fetched all orders without a status filter, then filtered client-side. Now passes the active status filter to the backend API, adds a counts endpoint for accurate filter pill and stats card totals, resets to page 1 on tab switch, and auto-selects the first booking when navigating tabs.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>