### PR TITLE
Tavie/dev

### DIFF
--- a/backend/docs/plans/web-push-vapid-backend.md
+++ b/backend/docs/plans/web-push-vapid-backend.md
@@ -1,0 +1,135 @@
+# Plan: Add Web Push (VAPID) Support — Backend Only
+
+## Context
+
+RepairCoin's mobile app has push notifications via Expo Push (proxies to FCM/APNs). The Next.js web frontend has **no push notification support**. We're adding Web Push using the `web-push` npm library with VAPID keys — an open standard that works on all browsers including Safari 16.4+, is completely free, and requires no third-party accounts.
+
+The backend currently routes all push through `ExpoPushService`. We need to add a `WebPushService` alongside it, unified behind a `PushNotificationDispatcher` so all existing callers work with both mobile and web transparently.
+
+---
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `backend/migrations/101_add_web_push_support.sql` | Add `'web'` device type, `web_push_subscription` JSONB column |
+| `backend/src/services/WebPushService.ts` | Web Push sender using `web-push` lib, mirrors ExpoPushService API |
+| `backend/src/services/PushNotificationDispatcher.ts` | Routes to ExpoPushService (mobile) and WebPushService (web) |
+| `backend/src/scripts/generate-vapid-keys.ts` | One-time VAPID key generation utility |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `backend/src/config/index.ts` | Add `webPush` config block (VAPID keys) |
+| `backend/src/repositories/PushTokenRepository.ts` | Add web subscription support, `deviceTypes` filter param |
+| `backend/src/services/ExpoPushService.ts` | Pass `['ios', 'android']` filter to repo queries (2 lines) |
+| `backend/src/domains/notification/controllers/PushTokenController.ts` | Accept `'web'` device type, validate subscription JSON |
+| `backend/src/domains/notification/routes/index.ts` | Add `GET /api/notifications/vapid-public-key` (public endpoint) |
+| `backend/src/domains/notification/NotificationDomain.ts` | Use dispatcher instead of ExpoPushService |
+| `backend/src/services/AppointmentReminderService.ts` | Use dispatcher instead of ExpoPushService |
+| `backend/src/services/SubscriptionReminderService.ts` | Use dispatcher instead of ExpoPushService |
+| `backend/src/domains/ServiceDomain/controllers/OrderController.ts` | Use dispatcher instead of ExpoPushService |
+| `backend/package.json` | Add `web-push` + `@types/web-push` |
+
+---
+
+## Implementation Steps
+
+### Step 1: Install dependency
+```bash
+cd backend && npm install web-push && npm install -D @types/web-push
+```
+
+### Step 2: Database migration (`backend/migrations/101_add_web_push_support.sql`)
+
+- Drop and re-add `device_type` CHECK constraint to include `'web'`
+- Add `web_push_subscription JSONB` column (nullable)
+- Make `expo_push_token` nullable (web tokens won't have one)
+- Add CHECK: web rows require `web_push_subscription IS NOT NULL`, mobile rows require `expo_push_token IS NOT NULL`
+- Add unique index on `web_push_subscription->>'endpoint'` for web tokens
+- Update `getTokenStats` query to include `web` platform count
+
+**Key decision:** Web tokens store a synthetic `expo_push_token` value (`web-push:<sha256(endpoint)>`) to satisfy the existing unique constraint without restructuring it. The JSONB column stores the actual subscription `{ endpoint, keys: { p256dh, auth } }`.
+
+### Step 3: VAPID key generation script (`backend/src/scripts/generate-vapid-keys.ts`)
+- Calls `webpush.generateVAPIDKeys()`, prints keys to stdout
+- Add npm script: `"generate:vapid": "ts-node src/scripts/generate-vapid-keys.ts"`
+
+### Step 4: Config update (`backend/src/config/index.ts`)
+- Add `static get webPush()` returning `vapidPublicKey`, `vapidPrivateKey`, `vapidSubject` from env
+- VAPID keys are optional — if missing, WebPushService becomes a no-op (logs warning)
+
+**Env vars to add:**
+```
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_SUBJECT=mailto:hello@repaircoin.ai
+```
+
+### Step 5: Update PushTokenRepository (`backend/src/repositories/PushTokenRepository.ts`)
+- Add `WebPushSubscription` interface: `{ endpoint: string; keys: { p256dh: string; auth: string } }`
+- Update `DevicePushToken` interface: add `webPushSubscription`, extend `deviceType` with `'web'`
+- Update `RegisterTokenParams`: make `expoPushToken` optional, add optional `webPushSubscription`
+- Update `registerToken()`: for web, generate synthetic expo token from endpoint hash, store subscription JSON
+- Add optional `deviceTypes?: string[]` filter to `getActiveTokensByWallet()` and `getActiveTokensForUsers()`
+- Update `getTokenStats()`: add web count
+
+### Step 6: Minimal ExpoPushService change (`backend/src/services/ExpoPushService.ts`)
+- In `sendToUser()`: pass `['ios', 'android']` to `getActiveTokensByWallet()`
+- In `sendToMultipleUsers()`: pass `['ios', 'android']` to `getActiveTokensForUsers()`
+- **Why:** Prevents web tokens from leaking into Expo pipeline where they'd be deactivated as invalid
+
+### Step 7: Create WebPushService (`backend/src/services/WebPushService.ts`)
+- Mirrors ExpoPushService structure: same `PushNotificationPayload` interface, same `SendPushResult` return type
+- Initializes `web-push` with VAPID keys from Config; if keys missing, all sends return empty result
+- `sendToUser()` calls repo with `['web']` filter, sends via `webpush.sendNotification()`
+- Handles 410 Gone (expired subscription) by deactivating token — same pattern as Expo's `DeviceNotRegistered`
+- Enforces 4KB payload limit (Web Push spec)
+- Same 11 convenience methods as ExpoPushService (they just call `sendToUser` with the right payload)
+- Singleton via `getWebPushService()`
+
+### Step 8: Create PushNotificationDispatcher (`backend/src/services/PushNotificationDispatcher.ts`)
+- Holds refs to both `ExpoPushService` and `WebPushService` singletons
+- `sendToUser()` calls both services in parallel via `Promise.all`, merges `SendPushResult`
+- `sendToMultipleUsers()` same pattern
+- Same 11 convenience methods (delegate to `sendToUser`)
+- Singleton via `getPushNotificationDispatcher()`
+
+### Step 9: Update PushTokenController (`backend/src/domains/notification/controllers/PushTokenController.ts`)
+- `registerToken()`: accept `deviceType: 'ios' | 'android' | 'web'`
+- For `web`: require `webPushSubscription` body field (validate `endpoint`, `keys.p256dh`, `keys.auth`), skip Expo token validation
+- For `ios`/`android`: existing validation unchanged
+
+### Step 10: Update routes (`backend/src/domains/notification/routes/index.ts`)
+- Add **before** `router.use(authMiddleware)`:
+  ```
+  GET /api/notifications/vapid-public-key -> returns { vapidPublicKey }
+  ```
+  This is public — the frontend needs it before auth to subscribe.
+
+### Step 11: Swap callers to use dispatcher
+Mechanical replacement in 4 files — same method signatures, just different import:
+
+- `NotificationDomain.ts`: `expoPushService` -> `pushDispatcher` (via `getPushNotificationDispatcher()`)
+- `AppointmentReminderService.ts`: same swap
+- `SubscriptionReminderService.ts`: same swap
+- `OrderController.ts`: same swap
+
+---
+
+## Deployment Order
+
+Steps 1-6 can deploy independently with **zero behavior change** (mobile push keeps working exactly as before). Steps 7-8 add new code with no callers. Steps 9-10 enable web registration. Step 11 activates dispatching.
+
+---
+
+## Verification
+
+1. **Migration:** Run `npm run db:migrate`, verify `device_push_tokens` table accepts `'web'` device type
+2. **VAPID keys:** Run `npm run generate:vapid`, add to `.env`, verify `Config.webPush` returns them
+3. **Public endpoint:** `curl http://localhost:4000/api/notifications/vapid-public-key` returns the public key
+4. **Token registration:** POST to `/api/notifications/push-tokens` with `deviceType: 'web'` and a mock subscription JSON — verify row created in DB
+5. **Mobile unaffected:** Existing Expo push token registration still works, mobile notifications still send
+6. **Type check:** `cd backend && npm run typecheck`
+7. **Existing tests:** `cd backend && npm run test`

--- a/backend/docs/plans/web-push-vapid-frontend.md
+++ b/backend/docs/plans/web-push-vapid-frontend.md
@@ -1,0 +1,170 @@
+# Plan: Add Web Push (VAPID) Support — Frontend
+
+## Context
+
+The backend VAPID/Web Push implementation is complete (committed `69b0a57f`). The backend exposes:
+- `GET /api/notifications/vapid-public-key` — public, returns `{ vapidPublicKey }`
+- `POST /api/notifications/push-tokens` — auth required, accepts `{ deviceType: 'web', webPushSubscription: { endpoint, keys: { p256dh, auth } } }`
+- `DELETE /api/notifications/push-tokens` — deactivate all tokens for user
+
+The frontend currently has **no service worker, no Push API usage, no PWA config**. It uses WebSocket for real-time in-app notifications and the basic browser `Notification` API for foreground alerts. We need to add the Push API subscription flow so users receive notifications even when the tab is closed/backgrounded.
+
+No new npm packages needed — Service Worker + Push API are browser-native.
+
+---
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `frontend/public/sw.js` | Service worker: handles `push` and `notificationclick` events |
+| `frontend/src/hooks/usePushSubscription.ts` | Hook: SW registration, push subscribe/unsubscribe, token sync |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `frontend/src/services/api/notifications.ts` | Add `getVapidPublicKey`, `registerPushToken`, `deactivateAllPushTokens` |
+| `frontend/src/hooks/useNotifications.ts` | Call `subscribeToPush()` on auth, `unsubscribeFromPush()` on logout |
+| `frontend/src/stores/authStore.ts` | Add push token cleanup in `logout()` before `resetAuth()` |
+| `frontend/src/components/notifications/GeneralNotificationSettings.tsx` | Replace SMS "Coming Soon" card with Push Notifications status card |
+
+---
+
+## Implementation Steps
+
+### Step 1: Service Worker (`frontend/public/sw.js`)
+
+Plain JS file (no TypeScript, no imports). Next.js serves it at `/sw.js` automatically.
+
+**`push` event handler:**
+- Parse `event.data.json()` → `{ title, body, data }`
+- Deduplicate with active tabs: check `clients.matchAll({ type: 'window', includeUncontrolled: true })` — if a **focused** client exists, skip `showNotification` (the WebSocket handler in `useNotifications.ts` already shows a browser notification for foreground)
+- Call `self.registration.showNotification(title, { body, icon: '/logo.png', badge: '/logo.png', data, tag: data?.type || 'default' })`
+- `tag` groups by notification type so duplicates replace rather than stack
+
+**`notificationclick` event handler:**
+- Read `event.notification.data` for payload
+- Build target URL from `data.type`:
+  - `new_booking`, `reschedule_request` → `/shop/orders`
+  - `booking_confirmed`, `appointment_reminder`, `order_completed` → `/customer/bookings`
+  - `reward_issued`, `token_gifted` → `/customer/dashboard`
+  - `subscription_expiring` → `/shop/settings`
+  - Default → `/`
+- Close notification, then: find existing tab via `clients.matchAll()` → focus it + navigate, or `clients.openWindow(url)` if no tab
+
+**`activate` event handler:**
+- `self.clients.claim()` to take control of open tabs immediately on first install
+
+**No `fetch` handler** — this is not a PWA cache worker.
+
+### Step 2: API Functions (`frontend/src/services/api/notifications.ts`)
+
+Add 3 functions to the existing file + update the `notificationsApi` export:
+
+```typescript
+// Public endpoint — no auth needed
+export const getVapidPublicKey = async (): Promise<string> => {
+  const response = await apiClient.get('/notifications/vapid-public-key');
+  return response.vapidPublicKey;
+};
+
+export const registerPushToken = async (params: {
+  deviceType: 'web';
+  deviceName?: string;
+  webPushSubscription: { endpoint: string; keys: { p256dh: string; auth: string } };
+}): Promise<void> => {
+  await apiClient.post('/notifications/push-tokens', params);
+};
+
+export const deactivateAllPushTokens = async (): Promise<void> => {
+  await apiClient.delete('/notifications/push-tokens');
+};
+```
+
+### Step 3: Push Subscription Hook (`frontend/src/hooks/usePushSubscription.ts`)
+
+Exports two imperative functions (no useEffect — the caller decides when):
+
+**`subscribeToPush()`:**
+1. Guard: `if (!('serviceWorker' in navigator) || !('PushManager' in window)) return`
+2. Register SW: `navigator.serviceWorker.register('/sw.js')`
+3. Wait for `registration.active` (handle `installing`/`waiting` states)
+4. Fetch VAPID key: `await getVapidPublicKey()`
+5. Convert to `Uint8Array` via `urlBase64ToUint8Array()` helper
+6. Check existing subscription: `await registration.pushManager.getSubscription()`
+7. If existing endpoint matches `localStorage('rc_push_endpoint')` → skip (already registered)
+8. If no subscription or endpoint changed → `pushManager.subscribe({ userVisibleOnly: true, applicationServerKey })`
+9. POST to backend: `await registerPushToken({ deviceType: 'web', webPushSubscription: { endpoint, keys: { p256dh, auth } } })`
+10. Store endpoint in `localStorage('rc_push_endpoint')`
+11. If permission `'denied'` → log and return silently (no toast nagging)
+
+**`unsubscribeFromPush()`:**
+1. Get registration: `navigator.serviceWorker.getRegistration()`
+2. Get subscription: `registration.pushManager.getSubscription()`
+3. If exists: `subscription.unsubscribe()`
+4. Call `deactivateAllPushTokens()` (backend cleanup)
+5. Remove `rc_push_endpoint` from localStorage
+
+**Internal helpers:**
+- `urlBase64ToUint8Array(base64)` — standard VAPID key conversion (padding + atob + Uint8Array)
+- `arrayBufferToBase64(buffer)` — convert `getKey()` ArrayBuffer to base64 string
+
+### Step 4: Wire into useNotifications (`frontend/src/hooks/useNotifications.ts`)
+
+In the main initialization `useEffect` (line 336):
+- Import and call `usePushSubscription()` to get `{ subscribeToPush, unsubscribeFromPush }`
+- After `connectWebSocket()` on line 355, add: `subscribeToPush()` (fire-and-forget)
+- In the `!isAuthenticated` branch (line 359), after `disconnectWebSocket()`, add: `unsubscribeFromPush()`
+- Return `subscribeToPush` from the hook so settings components can trigger re-subscription
+
+### Step 5: Logout Cleanup (`frontend/src/stores/authStore.ts`)
+
+In the `logout` function (line 366), **before** `get().resetAuth()` on line 386:
+
+```typescript
+// Deactivate web push tokens
+try {
+  await deactivateAllPushTokens();
+  const registration = await navigator.serviceWorker?.getRegistration();
+  const subscription = await registration?.pushManager?.getSubscription();
+  await subscription?.unsubscribe();
+  localStorage.removeItem('rc_push_endpoint');
+} catch (e) {
+  // Non-critical — tokens expire naturally
+}
+```
+
+This is needed here (not just in the hook) because `logout()` calls `window.location.href = '/'` which unmounts all hooks before they can clean up.
+
+### Step 6: Settings UI (`frontend/src/components/notifications/GeneralNotificationSettings.tsx`)
+
+Replace the SMS "Coming Soon" card (line 510-516) with a Push Notifications card:
+
+- Check `Notification.permission` on mount via a small `useState`/`useEffect`
+- **`'granted'`** → green dot + "Active" label
+- **`'default'`** → "Enable" button that calls `subscribeToPush()`
+- **`'denied'`** → "Blocked" label + note to enable in browser settings
+
+---
+
+## Edge Cases
+
+- **Subscription rotation**: Push API can silently change endpoints. On each auth'd app load, `subscribeToPush()` compares current endpoint with localStorage — re-registers if changed.
+- **Multiple tabs**: `serviceWorker.register('/sw.js')` is idempotent. Multiple tabs get the same registration/subscription. Backend upserts by endpoint.
+- **Duplicate notifications (foreground)**: The SW's `push` handler checks `clients.matchAll()` — if a focused client exists, it skips `showNotification` since the WebSocket handler already fires `new Notification()`.
+- **Browser support**: Safari 16.4+, Chrome, Edge, Firefox all support Web Push. `'PushManager' in window` guard handles older browsers.
+- **HTTPS requirement**: Web Push requires HTTPS (or localhost for dev). Production already uses HTTPS.
+
+---
+
+## Verification
+
+1. Start frontend dev server: `cd frontend && npm run dev`
+2. Open browser, log in, check DevTools > Application > Service Workers — `sw.js` should be registered
+3. Check DevTools > Application > Push Messaging — subscription should be active
+4. Verify backend received the token: check `device_push_tokens` table for a `device_type = 'web'` row
+5. Trigger a test notification from another tab/backend — should appear as a system notification even if tab is backgrounded
+6. Log out → verify the push subscription is deactivated (token row marked inactive in DB)
+7. Check Notification Settings page — Push Notifications card shows correct status
+8. Type check: `cd frontend && npx tsc --noEmit`

--- a/backend/migrations/101_add_web_push_support.sql
+++ b/backend/migrations/101_add_web_push_support.sql
@@ -1,0 +1,28 @@
+-- Migration: Add Web Push (VAPID) support to device_push_tokens
+-- Extends the push notification system to support browser-based web push alongside mobile (Expo)
+
+-- 1. Add 'web' to device_type CHECK constraint
+ALTER TABLE device_push_tokens DROP CONSTRAINT device_push_tokens_device_type_check;
+ALTER TABLE device_push_tokens ADD CONSTRAINT device_push_tokens_device_type_check
+  CHECK (device_type IN ('ios', 'android', 'web'));
+
+-- 2. Add JSONB column for web push subscription data
+-- Stores: { endpoint: string, keys: { p256dh: string, auth: string } }
+ALTER TABLE device_push_tokens ADD COLUMN web_push_subscription JSONB;
+
+-- 3. Make expo_push_token nullable (web tokens don't have one)
+ALTER TABLE device_push_tokens ALTER COLUMN expo_push_token DROP NOT NULL;
+
+-- 4. Add integrity check: mobile rows need expo_push_token, web rows need web_push_subscription
+ALTER TABLE device_push_tokens ADD CONSTRAINT push_token_type_check CHECK (
+  (device_type IN ('ios', 'android') AND expo_push_token IS NOT NULL)
+  OR
+  (device_type = 'web' AND web_push_subscription IS NOT NULL)
+);
+
+-- 5. Unique index on web push endpoint to prevent duplicate subscriptions
+CREATE UNIQUE INDEX IF NOT EXISTS idx_push_tokens_web_endpoint
+  ON device_push_tokens ((web_push_subscription->>'endpoint'))
+  WHERE device_type = 'web';
+
+COMMENT ON COLUMN device_push_tokens.web_push_subscription IS 'Web Push subscription JSON (endpoint + VAPID keys). Only for device_type=web.';

--- a/backend/migrations/102_dedupe_web_push_tokens.sql
+++ b/backend/migrations/102_dedupe_web_push_tokens.sql
@@ -1,0 +1,22 @@
+-- Migration: Enforce one web push row per wallet
+-- Collapses legacy duplicates, then adds a partial unique index so the
+-- database enforces the invariant going forward.
+
+-- Step A: For each wallet with multiple web rows, keep only the newest
+-- and delete the rest. "Newest" by last_used_at DESC, created_at DESC tiebreaker.
+DELETE FROM device_push_tokens
+WHERE device_type = 'web'
+  AND id NOT IN (
+    SELECT DISTINCT ON (wallet_address) id
+    FROM device_push_tokens
+    WHERE device_type = 'web'
+    ORDER BY wallet_address, last_used_at DESC, created_at DESC
+  );
+
+-- Step B: Partial unique index — one web row per wallet
+CREATE UNIQUE INDEX IF NOT EXISTS idx_push_tokens_wallet_web
+  ON device_push_tokens (wallet_address)
+  WHERE device_type = 'web';
+
+COMMENT ON INDEX idx_push_tokens_wallet_web IS
+  'One web push row per wallet. Registrations UPSERT this row.';

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -46,6 +46,7 @@
         "uuid": "^11.1.0",
         "validator": "^13.11.0",
         "viem": "^2.41.2",
+        "web-push": "^3.6.7",
         "winston": "^3.11.0",
         "ws": "^8.18.3"
       },
@@ -72,6 +73,7 @@
         "@types/swagger-ui-express": "^4.1.6",
         "@types/uuid": "^10.0.0",
         "@types/validator": "^13.11.7",
+        "@types/web-push": "^3.6.4",
         "@typescript-eslint/eslint-plugin": "^6.13.1",
         "@typescript-eslint/parser": "^6.13.1",
         "concurrently": "^8.2.2",
@@ -7948,6 +7950,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -9214,6 +9226,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -9633,6 +9657,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
       "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "license": "MIT"
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -13114,6 +13144,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -15913,6 +15952,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "9.0.3",
@@ -20017,6 +20062,46 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/web-push/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/web-push/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -46,6 +46,7 @@
     "admin:list": "ts-node src/cli/admin.ts list",
     "admin:add": "ts-node src/cli/admin.ts add",
     "admin:check": "ts-node src/cli/admin.ts check",
+    "generate:vapid": "ts-node src/scripts/generate-vapid-keys.ts",
     "mint:rcg": "ts-node scripts/mint-rcg-tokens.ts",
     "logger": "bash scripts/logger.sh",
     "_comment_test_reminders": "# Test Reminder Commands - Usage: npm run test:subscription-reminder:shop -- shop-3 1",
@@ -103,6 +104,7 @@
     "uuid": "^11.1.0",
     "validator": "^13.11.0",
     "viem": "^2.41.2",
+    "web-push": "^3.6.7",
     "winston": "^3.11.0",
     "ws": "^8.18.3"
   },
@@ -126,6 +128,7 @@
     "@types/swagger-ui-express": "^4.1.6",
     "@types/uuid": "^10.0.0",
     "@types/validator": "^13.11.7",
+    "@types/web-push": "^3.6.4",
     "@typescript-eslint/eslint-plugin": "^6.13.1",
     "@typescript-eslint/parser": "^6.13.1",
     "concurrently": "^8.2.2",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -210,6 +210,11 @@ class RepairCoinApp {
     // SUBDOMAIN SETUP: Backend at api.repaircoin.ai, Frontend at repaircoin.ai/www.repaircoin.ai
     this.app.use(cors({
       origin: function(origin, callback) {
+        // CORS_DISABLED=true bypasses all origin checks (for local dev/testing)
+        if (process.env.CORS_DISABLED === 'true') {
+          return callback(null, true);
+        }
+
         const allowedOrigins = [
           // Local development
           'http://localhost:3000',

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -40,6 +40,14 @@ export class Config {
     return addresses.split(',').map(addr => addr.trim().toLowerCase());
   }
 
+  static get webPush() {
+    return {
+      vapidPublicKey: process.env.VAPID_PUBLIC_KEY || '',
+      vapidPrivateKey: process.env.VAPID_PRIVATE_KEY || '',
+      vapidSubject: process.env.VAPID_SUBJECT || 'mailto:hello@repaircoin.ai',
+    };
+  }
+
   static validate(): void {
     // Validate required environment variables
     const required = ['JWT_SECRET'];

--- a/backend/src/docs/swagger.ts
+++ b/backend/src/docs/swagger.ts
@@ -3898,6 +3898,81 @@ const options = {
         }
       },
 
+      '/api/notifications/test-push': {
+        post: {
+          tags: ['Notifications'],
+          summary: 'Send test push notification',
+          description: 'Send a test push notification to a specific wallet address to verify web push is working. Only walletAddress is required — title, body, and type are optional.',
+          security: [{ bearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['walletAddress'],
+                  properties: {
+                    walletAddress: {
+                      type: 'string',
+                      description: 'Wallet address to send the test notification to',
+                      example: '0x13d9299e30626e2e97d8940988786bbc5676fd7a'
+                    },
+                    title: {
+                      type: 'string',
+                      description: 'Notification title (defaults to "Test Push Notification")',
+                      example: 'Test Push Notification'
+                    },
+                    body: {
+                      type: 'string',
+                      description: 'Notification body message (defaults to "This is a test notification from RepairCoin.")',
+                      example: 'This is a test notification from RepairCoin.'
+                    },
+                    type: {
+                      type: 'string',
+                      description: 'Notification type — controls click routing in the browser (uses predefined routes map)',
+                      example: 'test',
+                      enum: ['test', 'new_booking', 'reschedule_request', 'booking_confirmed', 'appointment_reminder', 'order_completed', 'reward_issued', 'token_gifted', 'redemption_approved', 'redemption_rejected', 'subscription_expiring']
+                    },
+                    route: {
+                      type: 'string',
+                      description: 'Custom navigation path when notification is clicked. Overrides the default type-based routing. Example: /customer/bookings, /shop/orders',
+                      example: '/customer/dashboard'
+                    }
+                  }
+                }
+              }
+            }
+          },
+          responses: {
+            200: {
+              description: 'Test push notification sent',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      success: { type: 'boolean', example: true },
+                      message: { type: 'string', example: 'Test push notification sent' },
+                      data: {
+                        type: 'object',
+                        properties: {
+                          successCount: { type: 'number', example: 1 },
+                          failureCount: { type: 'number', example: 0 },
+                          invalidTokens: { type: 'array', items: { type: 'string' } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            400: {
+              description: 'walletAddress is required'
+            }
+          }
+        }
+      },
+
       // Shop - Additional endpoints
       '/api/shops/{shopId}/details': {
         put: {

--- a/backend/src/domains/ServiceDomain/controllers/OrderController.ts
+++ b/backend/src/domains/ServiceDomain/controllers/OrderController.ts
@@ -9,7 +9,7 @@ import { customerRepository } from '../../../repositories';
 import { logger } from '../../../utils/logger';
 import { eventBus, createDomainEvent } from '../../../events/EventBus';
 import { AffiliateShopGroupService } from '../../../services/AffiliateShopGroupService';
-import { getExpoPushService } from '../../../services/ExpoPushService';
+import { getPushNotificationDispatcher } from '../../../services/PushNotificationDispatcher';
 import noShowPolicyService from '../../../services/NoShowPolicyService';
 import { EmailService } from '../../../services/EmailService';
 import { getExpiredOrderService } from '../../../services/ExpiredOrderService';
@@ -396,7 +396,7 @@ export class OrderController {
                 );
 
                 // Send push notification to customer
-                await getExpoPushService().sendOrderCompleted(
+                await getPushNotificationDispatcher().sendOrderCompleted(
                   updatedOrder.customerAddress,
                   shop.name,
                   service.serviceName,

--- a/backend/src/domains/notification/NotificationDomain.ts
+++ b/backend/src/domains/notification/NotificationDomain.ts
@@ -4,7 +4,8 @@ import { logger } from '../../utils/logger';
 import notificationRoutes from './routes/index';
 import { NotificationService } from './services/NotificationService';
 import { WebSocketManager } from '../../services/WebSocketManager';
-import { getExpoPushService, ExpoPushService, NotificationChannels } from '../../services/ExpoPushService';
+import { NotificationChannels } from '../../services/ExpoPushService';
+import { getPushNotificationDispatcher, PushNotificationDispatcher } from '../../services/PushNotificationDispatcher';
 import { EmailService } from '../../services/EmailService';
 import { CustomerRepository } from '../../repositories/CustomerRepository';
 
@@ -13,7 +14,7 @@ export class NotificationDomain implements DomainModule {
   routes = notificationRoutes;
   private notificationService!: NotificationService;
   private wsManager!: WebSocketManager;
-  private expoPushService!: ExpoPushService;
+  private pushDispatcher!: PushNotificationDispatcher;
   private emailService!: EmailService;
   private customerRepository!: CustomerRepository;
 
@@ -25,7 +26,7 @@ export class NotificationDomain implements DomainModule {
 
   async initialize(): Promise<void> {
     this.notificationService = new NotificationService();
-    this.expoPushService = getExpoPushService();
+    this.pushDispatcher = getPushNotificationDispatcher();
     this.emailService = new EmailService();
     this.customerRepository = new CustomerRepository();
     this.setupEventSubscriptions();
@@ -99,7 +100,7 @@ export class NotificationDomain implements DomainModule {
       }
 
       // Send push notification
-      await this.expoPushService.sendRewardNotification(customerAddress, shopName, amount, transactionId);
+      await this.pushDispatcher.sendRewardNotification(customerAddress, shopName, amount, transactionId);
     } catch (error: any) {
       logger.error('Error handling reward issued event:', error);
     }
@@ -125,7 +126,7 @@ export class NotificationDomain implements DomainModule {
       }
 
       // Send push notification
-      await this.expoPushService.sendRedemptionApprovalRequest(customerAddress, shopName, amount, redemptionSessionId);
+      await this.pushDispatcher.sendRedemptionApprovalRequest(customerAddress, shopName, amount, redemptionSessionId);
     } catch (error: any) {
       logger.error('Error handling redemption approval request event:', error);
     }
@@ -222,7 +223,7 @@ export class NotificationDomain implements DomainModule {
       }
 
       // Send push notification
-      await this.expoPushService.sendTokenGiftedNotification(toCustomerAddress, fromCustomerName, amount, transactionId);
+      await this.pushDispatcher.sendTokenGiftedNotification(toCustomerAddress, fromCustomerName, amount, transactionId);
     } catch (error: any) {
       logger.error('Error handling token gifted event:', error);
     }
@@ -696,7 +697,7 @@ export class NotificationDomain implements DomainModule {
       }
 
       // Send push notification using existing reschedule approved method
-      await this.expoPushService.sendRescheduleApproved(
+      await this.pushDispatcher.sendRescheduleApproved(
         customerAddress,
         shopName || 'Shop',
         serviceName || 'Service',

--- a/backend/src/domains/notification/controllers/PushTokenController.ts
+++ b/backend/src/domains/notification/controllers/PushTokenController.ts
@@ -23,35 +23,55 @@ export class PushTokenController {
         return;
       }
 
-      const { expoPushToken, deviceId, deviceType, deviceName, appVersion } = req.body;
+      const { expoPushToken, deviceId, deviceType, deviceName, appVersion, webPushSubscription } = req.body;
 
-      // Validate required fields
-      if (!expoPushToken) {
-        res.status(400).json({ error: 'expoPushToken is required' });
+      if (!deviceType || !['ios', 'android', 'web'].includes(deviceType)) {
+        res.status(400).json({ error: 'deviceType must be "ios", "android", or "web"' });
         return;
       }
 
-      if (!deviceType || !['ios', 'android'].includes(deviceType)) {
-        res.status(400).json({ error: 'deviceType must be "ios" or "android"' });
-        return;
-      }
+      let params: RegisterTokenParams;
 
-      // Validate Expo push token format
-      if (!Expo.isExpoPushToken(expoPushToken)) {
-        res.status(400).json({
-          error: 'Invalid Expo push token format. Expected format: ExponentPushToken[xxx] or ExpoPushToken[xxx]',
-        });
-        return;
-      }
+      if (deviceType === 'web') {
+        // Validate web push subscription
+        if (!webPushSubscription || !webPushSubscription.endpoint || !webPushSubscription.keys?.p256dh || !webPushSubscription.keys?.auth) {
+          res.status(400).json({
+            error: 'webPushSubscription with endpoint, keys.p256dh, and keys.auth is required for web device type',
+          });
+          return;
+        }
 
-      const params: RegisterTokenParams = {
-        walletAddress,
-        expoPushToken,
-        deviceId,
-        deviceType,
-        deviceName,
-        appVersion,
-      };
+        params = {
+          walletAddress,
+          deviceId,
+          deviceType,
+          deviceName: deviceName || 'Web Browser',
+          appVersion,
+          webPushSubscription,
+        };
+      } else {
+        // Validate mobile push token
+        if (!expoPushToken) {
+          res.status(400).json({ error: 'expoPushToken is required' });
+          return;
+        }
+
+        if (!Expo.isExpoPushToken(expoPushToken)) {
+          res.status(400).json({
+            error: 'Invalid Expo push token format. Expected format: ExponentPushToken[xxx] or ExpoPushToken[xxx]',
+          });
+          return;
+        }
+
+        params = {
+          walletAddress,
+          expoPushToken,
+          deviceId,
+          deviceType,
+          deviceName,
+          appVersion,
+        };
+      }
 
       const token = await this.repository.registerToken(params);
 

--- a/backend/src/domains/notification/routes/index.ts
+++ b/backend/src/domains/notification/routes/index.ts
@@ -5,6 +5,8 @@ import { PushTokenController } from '../controllers/PushTokenController';
 import { GeneralPreferencesController } from '../controllers/GeneralPreferencesController';
 import { NotificationService } from '../services/NotificationService';
 import { Config } from '../../../config';
+import { getPushNotificationDispatcher } from '../../../services/PushNotificationDispatcher';
+import { logger } from '../../../utils/logger';
 
 const router = Router();
 
@@ -58,6 +60,44 @@ router.get('/unread/count', (req, res) => notificationController.getUnreadCount(
  * @access  Private
  */
 router.patch('/read-all', (req, res) => notificationController.markAllAsRead(req, res));
+
+// ============================================
+// Test Push Notification Route
+// ============================================
+
+/**
+ * @route   POST /api/notifications/test-push
+ * @desc    Send a test push notification to a wallet address
+ * @access  Private
+ */
+router.post('/test-push', async (req, res) => {
+  try {
+    const { walletAddress, title, body, type, route } = req.body;
+
+    if (!walletAddress) {
+      res.status(400).json({ success: false, error: 'walletAddress is required' });
+      return;
+    }
+
+    const dispatcher = getPushNotificationDispatcher();
+    const result = await dispatcher.sendToUser(walletAddress, {
+      title: title || 'Test Push Notification',
+      body: body || 'This is a test notification from RepairCoin.',
+      data: { type: type || 'test', ...(route && { route }) }
+    });
+
+    logger.info('Test push notification sent', {
+      walletAddress,
+      senderAddress: req.user?.address,
+      result
+    });
+
+    res.json({ success: true, message: 'Test push notification sent', data: result });
+  } catch (error: any) {
+    logger.error('Error sending test push notification:', error);
+    res.status(500).json({ success: false, error: error.message });
+  }
+});
 
 // ============================================
 // Push Token Routes (must be before :id routes)

--- a/backend/src/domains/notification/routes/index.ts
+++ b/backend/src/domains/notification/routes/index.ts
@@ -4,6 +4,7 @@ import { NotificationController } from '../controllers/NotificationController';
 import { PushTokenController } from '../controllers/PushTokenController';
 import { GeneralPreferencesController } from '../controllers/GeneralPreferencesController';
 import { NotificationService } from '../services/NotificationService';
+import { Config } from '../../../config';
 
 const router = Router();
 
@@ -13,7 +14,21 @@ const notificationController = new NotificationController(notificationService);
 const pushTokenController = new PushTokenController();
 const generalPreferencesController = new GeneralPreferencesController();
 
-// All notification routes require authentication
+/**
+ * @route   GET /api/notifications/vapid-public-key
+ * @desc    Get VAPID public key for web push subscription (no auth required)
+ * @access  Public
+ */
+router.get('/vapid-public-key', (_req, res) => {
+  const { vapidPublicKey } = Config.webPush;
+  if (!vapidPublicKey) {
+    res.status(503).json({ error: 'Web push notifications not configured' });
+    return;
+  }
+  res.json({ vapidPublicKey });
+});
+
+// All remaining notification routes require authentication
 router.use(authMiddleware);
 
 /**

--- a/backend/src/repositories/PushTokenRepository.ts
+++ b/backend/src/repositories/PushTokenRepository.ts
@@ -114,15 +114,17 @@ export class PushTokenRepository extends BaseRepository {
 
     const syntheticToken = generateWebTokenId(webPushSubscription.endpoint);
 
+    // Enforce one web push row per wallet via the partial unique index
+    // idx_push_tokens_wallet_web (see migration 102). Endpoint rotations
+    // on the same wallet UPSERT this row instead of creating a new one.
     const query = `
       INSERT INTO device_push_tokens (
         wallet_address, expo_push_token, device_id, device_type, device_name, app_version,
         web_push_subscription, is_active, last_used_at
       ) VALUES ($1, $2, $3, 'web', $4, $5, $6, TRUE, NOW())
-      ON CONFLICT (expo_push_token)
+      ON CONFLICT (wallet_address) WHERE device_type = 'web'
       DO UPDATE SET
-        wallet_address = EXCLUDED.wallet_address,
-        device_id = EXCLUDED.device_id,
+        expo_push_token = EXCLUDED.expo_push_token,
         device_name = EXCLUDED.device_name,
         app_version = EXCLUDED.app_version,
         web_push_subscription = EXCLUDED.web_push_subscription,

--- a/backend/src/repositories/PushTokenRepository.ts
+++ b/backend/src/repositories/PushTokenRepository.ts
@@ -1,14 +1,24 @@
+import { createHash } from 'crypto';
 import { BaseRepository } from './BaseRepository';
 import { logger } from '../utils/logger';
+
+export interface WebPushSubscription {
+  endpoint: string;
+  keys: {
+    p256dh: string;
+    auth: string;
+  };
+}
 
 export interface DevicePushToken {
   id: string;
   walletAddress: string;
-  expoPushToken: string;
+  expoPushToken: string | null;
   deviceId: string | null;
-  deviceType: 'ios' | 'android';
+  deviceType: 'ios' | 'android' | 'web';
   deviceName: string | null;
   appVersion: string | null;
+  webPushSubscription: WebPushSubscription | null;
   isActive: boolean;
   lastUsedAt: Date;
   createdAt: Date;
@@ -17,11 +27,21 @@ export interface DevicePushToken {
 
 export interface RegisterTokenParams {
   walletAddress: string;
-  expoPushToken: string;
+  expoPushToken?: string;
   deviceId?: string;
-  deviceType: 'ios' | 'android';
+  deviceType: 'ios' | 'android' | 'web';
   deviceName?: string;
   appVersion?: string;
+  webPushSubscription?: WebPushSubscription;
+}
+
+/**
+ * Generate a synthetic expo_push_token for web subscriptions.
+ * This satisfies the existing unique constraint on expo_push_token.
+ */
+function generateWebTokenId(endpoint: string): string {
+  const hash = createHash('sha256').update(endpoint).digest('hex');
+  return `web-push:${hash}`;
 }
 
 export class PushTokenRepository extends BaseRepository {
@@ -30,12 +50,16 @@ export class PushTokenRepository extends BaseRepository {
    * Handles account switching: same device token can be reassigned to different users
    */
   async registerToken(params: RegisterTokenParams): Promise<DevicePushToken> {
-    const { walletAddress, expoPushToken, deviceId, deviceType, deviceName, appVersion } = params;
+    const { walletAddress, deviceId, deviceType, deviceName, appVersion } = params;
     const normalizedAddress = walletAddress.toLowerCase();
 
     try {
-      // Always upsert based on expo_push_token since it's device-unique
-      // This handles account switching on the same device
+      if (deviceType === 'web') {
+        return await this.registerWebToken(normalizedAddress, params);
+      }
+
+      // Mobile token registration (existing behavior)
+      const { expoPushToken } = params;
       const query = `
         INSERT INTO device_push_tokens (
           wallet_address, expo_push_token, device_id, device_type, device_name, app_version, is_active, last_used_at
@@ -76,35 +100,100 @@ export class PushTokenRepository extends BaseRepository {
   }
 
   /**
-   * Get all active push tokens for a user
-   * Used when sending push notifications to reach all user devices
+   * Register a web push subscription token
    */
-  async getActiveTokensByWallet(walletAddress: string): Promise<DevicePushToken[]> {
+  private async registerWebToken(
+    normalizedAddress: string,
+    params: RegisterTokenParams
+  ): Promise<DevicePushToken> {
+    const { webPushSubscription, deviceId, deviceName, appVersion } = params;
+
+    if (!webPushSubscription) {
+      throw new Error('webPushSubscription is required for web device type');
+    }
+
+    const syntheticToken = generateWebTokenId(webPushSubscription.endpoint);
+
+    const query = `
+      INSERT INTO device_push_tokens (
+        wallet_address, expo_push_token, device_id, device_type, device_name, app_version,
+        web_push_subscription, is_active, last_used_at
+      ) VALUES ($1, $2, $3, 'web', $4, $5, $6, TRUE, NOW())
+      ON CONFLICT (expo_push_token)
+      DO UPDATE SET
+        wallet_address = EXCLUDED.wallet_address,
+        device_id = EXCLUDED.device_id,
+        device_name = EXCLUDED.device_name,
+        app_version = EXCLUDED.app_version,
+        web_push_subscription = EXCLUDED.web_push_subscription,
+        is_active = TRUE,
+        last_used_at = NOW(),
+        updated_at = NOW()
+      RETURNING *
+    `;
+
+    const result = await this.pool.query(query, [
+      normalizedAddress,
+      syntheticToken,
+      deviceId || null,
+      deviceName || null,
+      appVersion || null,
+      JSON.stringify(webPushSubscription),
+    ]);
+
+    logger.info('Web push token registered', {
+      walletAddress: normalizedAddress,
+      endpoint: webPushSubscription.endpoint.substring(0, 50) + '...',
+    });
+
+    return this.mapSnakeToCamel(result.rows[0]) as DevicePushToken;
+  }
+
+  /**
+   * Get all active push tokens for a user
+   * Optionally filter by device types
+   */
+  async getActiveTokensByWallet(walletAddress: string, deviceTypes?: string[]): Promise<DevicePushToken[]> {
     const normalizedAddress = walletAddress.toLowerCase();
 
-    const result = await this.pool.query(
-      `SELECT * FROM device_push_tokens
-       WHERE wallet_address = $1 AND is_active = TRUE
-       ORDER BY last_used_at DESC`,
-      [normalizedAddress]
-    );
+    let query = `SELECT * FROM device_push_tokens
+       WHERE wallet_address = $1 AND is_active = TRUE`;
+    const queryParams: any[] = [normalizedAddress];
+
+    if (deviceTypes && deviceTypes.length > 0) {
+      query += ` AND device_type = ANY($2)`;
+      queryParams.push(deviceTypes);
+    }
+
+    query += ` ORDER BY last_used_at DESC`;
+
+    const result = await this.pool.query(query, queryParams);
 
     return result.rows.map((row) => this.mapSnakeToCamel(row) as DevicePushToken);
   }
 
   /**
    * Get active tokens for multiple users (batch operation)
-   * Used for sending notifications to multiple recipients efficiently
+   * Optionally filter by device types
    */
-  async getActiveTokensForUsers(walletAddresses: string[]): Promise<Map<string, DevicePushToken[]>> {
+  async getActiveTokensForUsers(
+    walletAddresses: string[],
+    deviceTypes?: string[]
+  ): Promise<Map<string, DevicePushToken[]>> {
     const normalizedAddresses = walletAddresses.map((addr) => addr.toLowerCase());
 
-    const result = await this.pool.query(
-      `SELECT * FROM device_push_tokens
-       WHERE wallet_address = ANY($1) AND is_active = TRUE
-       ORDER BY wallet_address, last_used_at DESC`,
-      [normalizedAddresses]
-    );
+    let query = `SELECT * FROM device_push_tokens
+       WHERE wallet_address = ANY($1) AND is_active = TRUE`;
+    const queryParams: any[] = [normalizedAddresses];
+
+    if (deviceTypes && deviceTypes.length > 0) {
+      query += ` AND device_type = ANY($2)`;
+      queryParams.push(deviceTypes);
+    }
+
+    query += ` ORDER BY wallet_address, last_used_at DESC`;
+
+    const result = await this.pool.query(query, queryParams);
 
     const tokenMap = new Map<string, DevicePushToken[]>();
     for (const row of result.rows) {
@@ -119,7 +208,7 @@ export class PushTokenRepository extends BaseRepository {
 
   /**
    * Deactivate a specific push token
-   * Called when Expo reports the token as invalid
+   * Called when Expo reports the token as invalid or web push returns 410 Gone
    */
   async deactivateToken(expoPushToken: string): Promise<boolean> {
     const result = await this.pool.query(
@@ -135,6 +224,14 @@ export class PushTokenRepository extends BaseRepository {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Deactivate a web push token by endpoint
+   */
+  async deactivateWebTokenByEndpoint(endpoint: string): Promise<boolean> {
+    const syntheticToken = generateWebTokenId(endpoint);
+    return this.deactivateToken(syntheticToken);
   }
 
   /**
@@ -238,7 +335,8 @@ export class PushTokenRepository extends BaseRepository {
         COUNT(*) FILTER (WHERE is_active = TRUE) as total_active,
         COUNT(*) FILTER (WHERE is_active = FALSE) as total_inactive,
         COUNT(*) FILTER (WHERE is_active = TRUE AND device_type = 'ios') as ios_active,
-        COUNT(*) FILTER (WHERE is_active = TRUE AND device_type = 'android') as android_active
+        COUNT(*) FILTER (WHERE is_active = TRUE AND device_type = 'android') as android_active,
+        COUNT(*) FILTER (WHERE is_active = TRUE AND device_type = 'web') as web_active
       FROM device_push_tokens
     `);
 
@@ -249,6 +347,7 @@ export class PushTokenRepository extends BaseRepository {
       byPlatform: {
         ios: parseInt(row.ios_active, 10),
         android: parseInt(row.android_active, 10),
+        web: parseInt(row.web_active, 10),
       },
     };
   }

--- a/backend/src/scripts/generate-vapid-keys.ts
+++ b/backend/src/scripts/generate-vapid-keys.ts
@@ -1,0 +1,10 @@
+import webpush from 'web-push';
+
+const vapidKeys = webpush.generateVAPIDKeys();
+
+console.log('VAPID Keys Generated');
+console.log('====================');
+console.log('Add these to your .env file:\n');
+console.log(`VAPID_PUBLIC_KEY=${vapidKeys.publicKey}`);
+console.log(`VAPID_PRIVATE_KEY=${vapidKeys.privateKey}`);
+console.log(`VAPID_SUBJECT=mailto:hello@repaircoin.ai`);

--- a/backend/src/services/AppointmentReminderService.ts
+++ b/backend/src/services/AppointmentReminderService.ts
@@ -2,7 +2,7 @@
 import { logger } from '../utils/logger';
 import { EmailService } from './EmailService';
 import { NotificationService } from '../domains/notification/services/NotificationService';
-import { getExpoPushService, ExpoPushService } from './ExpoPushService';
+import { getPushNotificationDispatcher, PushNotificationDispatcher } from './PushNotificationDispatcher';
 import { OrderRepository } from '../repositories/OrderRepository';
 import { ShopRepository } from '../repositories/ShopRepository';
 import { CustomerRepository } from '../repositories/CustomerRepository';
@@ -90,7 +90,7 @@ const EMAIL_RETRY_CONFIG = {
 export class AppointmentReminderService {
   private emailService: EmailService;
   private notificationService: NotificationService;
-  private expoPushService: ExpoPushService;
+  private pushDispatcher: PushNotificationDispatcher;
   private orderRepository: OrderRepository;
   private shopRepository: ShopRepository;
   private customerRepository: CustomerRepository;
@@ -101,7 +101,7 @@ export class AppointmentReminderService {
   constructor() {
     this.emailService = new EmailService();
     this.notificationService = new NotificationService();
-    this.expoPushService = getExpoPushService();
+    this.pushDispatcher = getPushNotificationDispatcher();
     this.orderRepository = new OrderRepository();
     this.shopRepository = new ShopRepository();
     this.customerRepository = new CustomerRepository();
@@ -320,7 +320,7 @@ export class AppointmentReminderService {
       });
 
       // Send push notification
-      await this.expoPushService.sendAppointmentReminder(
+      await this.pushDispatcher.sendAppointmentReminder(
         data.customerAddress,
         data.shopName,
         data.serviceName,
@@ -569,7 +569,7 @@ export class AppointmentReminderService {
       // Send push notification to customer
       const formattedTime = bookingTime ? this.formatTime(bookingTime) : 'TBD';
 
-      await this.expoPushService.sendBookingConfirmation(
+      await this.pushDispatcher.sendBookingConfirmation(
         order.customerAddress,
         shop.name,
         service.serviceName,
@@ -581,7 +581,7 @@ export class AppointmentReminderService {
       // Send push notification to shop
       const shopWalletAddress = shop.walletAddress;
       if (shopWalletAddress) {
-        await this.expoPushService.sendNewBookingToShop(
+        await this.pushDispatcher.sendNewBookingToShop(
           shopWalletAddress,
           customer?.name || 'Customer',
           service.serviceName,

--- a/backend/src/services/ExpoPushService.ts
+++ b/backend/src/services/ExpoPushService.ts
@@ -42,7 +42,7 @@ export class ExpoPushService {
    * Send push notification to a single user (all their devices)
    */
   async sendToUser(walletAddress: string, notification: PushNotificationPayload): Promise<SendPushResult> {
-    const tokens = await this.pushTokenRepository.getActiveTokensByWallet(walletAddress);
+    const tokens = await this.pushTokenRepository.getActiveTokensByWallet(walletAddress, ['ios', 'android']);
 
     if (tokens.length === 0) {
       logger.debug('No active push tokens for user', { walletAddress });
@@ -59,7 +59,7 @@ export class ExpoPushService {
     walletAddresses: string[],
     notification: PushNotificationPayload
   ): Promise<SendPushResult> {
-    const tokenMap = await this.pushTokenRepository.getActiveTokensForUsers(walletAddresses);
+    const tokenMap = await this.pushTokenRepository.getActiveTokensForUsers(walletAddresses, ['ios', 'android']);
 
     const allTokens: DevicePushToken[] = [];
     tokenMap.forEach((tokens) => allTokens.push(...tokens));

--- a/backend/src/services/PushNotificationDispatcher.ts
+++ b/backend/src/services/PushNotificationDispatcher.ts
@@ -1,0 +1,252 @@
+import { getExpoPushService, ExpoPushService, PushNotificationPayload, SendPushResult, NotificationChannels } from './ExpoPushService';
+import { getWebPushService, WebPushService } from './WebPushService';
+import { logger } from '../utils/logger';
+
+/**
+ * Dispatches push notifications to both mobile (Expo) and web (VAPID) push services.
+ * All callers use this instead of ExpoPushService directly.
+ */
+export class PushNotificationDispatcher {
+  private expoPushService: ExpoPushService;
+  private webPushService: WebPushService;
+
+  constructor() {
+    this.expoPushService = getExpoPushService();
+    this.webPushService = getWebPushService();
+  }
+
+  /**
+   * Merge two SendPushResult objects
+   */
+  private mergeResults(a: SendPushResult, b: SendPushResult): SendPushResult {
+    return {
+      successCount: a.successCount + b.successCount,
+      failureCount: a.failureCount + b.failureCount,
+      invalidTokens: [...a.invalidTokens, ...b.invalidTokens],
+    };
+  }
+
+  /**
+   * Send push notification to a single user across all platforms
+   */
+  async sendToUser(walletAddress: string, notification: PushNotificationPayload): Promise<SendPushResult> {
+    const [expoResult, webResult] = await Promise.all([
+      this.expoPushService.sendToUser(walletAddress, notification),
+      this.webPushService.sendToUser(walletAddress, notification),
+    ]);
+
+    return this.mergeResults(expoResult, webResult);
+  }
+
+  /**
+   * Send push notification to multiple users across all platforms
+   */
+  async sendToMultipleUsers(
+    walletAddresses: string[],
+    notification: PushNotificationPayload
+  ): Promise<SendPushResult> {
+    const [expoResult, webResult] = await Promise.all([
+      this.expoPushService.sendToMultipleUsers(walletAddresses, notification),
+      this.webPushService.sendToMultipleUsers(walletAddresses, notification),
+    ]);
+
+    return this.mergeResults(expoResult, webResult);
+  }
+
+  // ============================================
+  // Convenience methods (delegate to sendToUser)
+  // ============================================
+
+  async sendRewardNotification(
+    customerAddress: string,
+    shopName: string,
+    amount: number,
+    transactionId?: string
+  ): Promise<SendPushResult> {
+    return this.sendToUser(customerAddress, {
+      title: 'Reward Received!',
+      body: `You received ${amount} RCN from ${shopName}`,
+      channelId: NotificationChannels.REWARDS,
+      data: { type: 'reward_issued', transactionId, amount, shopName },
+    });
+  }
+
+  async sendRedemptionApprovalRequest(
+    customerAddress: string,
+    shopName: string,
+    amount: number,
+    sessionId: string
+  ): Promise<SendPushResult> {
+    return this.sendToUser(customerAddress, {
+      title: 'Redemption Request',
+      body: `${shopName} wants to redeem ${amount} RCN from your balance`,
+      channelId: NotificationChannels.REDEMPTIONS,
+      priority: 'high',
+      data: { type: 'redemption_approval_requested', sessionId, amount, shopName },
+    });
+  }
+
+  async sendBookingConfirmation(
+    customerAddress: string,
+    shopName: string,
+    serviceName: string,
+    appointmentDate: string,
+    appointmentTime: string,
+    orderId: string
+  ): Promise<SendPushResult> {
+    return this.sendToUser(customerAddress, {
+      title: 'Booking Confirmed',
+      body: `Your ${serviceName} at ${shopName} is confirmed for ${appointmentDate} at ${appointmentTime}`,
+      channelId: NotificationChannels.APPOINTMENTS,
+      data: { type: 'booking_confirmed', orderId, shopName, serviceName, appointmentDate, appointmentTime },
+    });
+  }
+
+  async sendAppointmentReminder(
+    customerAddress: string,
+    shopName: string,
+    serviceName: string,
+    appointmentTime: string,
+    orderId: string
+  ): Promise<SendPushResult> {
+    return this.sendToUser(customerAddress, {
+      title: 'Appointment Tomorrow',
+      body: `Reminder: ${serviceName} at ${shopName} at ${appointmentTime}`,
+      channelId: NotificationChannels.APPOINTMENTS,
+      priority: 'high',
+      data: { type: 'appointment_reminder', orderId, shopName, serviceName, appointmentTime },
+    });
+  }
+
+  async sendOrderCompleted(
+    customerAddress: string,
+    shopName: string,
+    serviceName: string,
+    rcnEarned: number,
+    orderId: string
+  ): Promise<SendPushResult> {
+    return this.sendToUser(customerAddress, {
+      title: 'Service Complete',
+      body: `${shopName} completed your ${serviceName}. You earned ${rcnEarned} RCN!`,
+      channelId: NotificationChannels.REWARDS,
+      data: { type: 'order_completed', orderId, shopName, serviceName, rcnEarned },
+    });
+  }
+
+  async sendNewBookingToShop(
+    shopAddress: string,
+    customerName: string,
+    serviceName: string,
+    appointmentDate: string,
+    appointmentTime: string,
+    orderId: string
+  ): Promise<SendPushResult> {
+    return this.sendToUser(shopAddress, {
+      title: 'New Booking',
+      body: `${customerName} booked ${serviceName} for ${appointmentDate} at ${appointmentTime}`,
+      channelId: NotificationChannels.APPOINTMENTS,
+      data: { type: 'new_booking', orderId, customerName, serviceName, appointmentDate, appointmentTime },
+    });
+  }
+
+  async sendTokenGiftedNotification(
+    toCustomerAddress: string,
+    fromCustomerName: string,
+    amount: number,
+    transactionId: string
+  ): Promise<SendPushResult> {
+    return this.sendToUser(toCustomerAddress, {
+      title: 'Gift Received!',
+      body: `${fromCustomerName} gifted you ${amount} RCN`,
+      channelId: NotificationChannels.REWARDS,
+      data: { type: 'token_gifted', transactionId, amount, fromCustomerName },
+    });
+  }
+
+  async sendRescheduleRequestToShop(
+    shopAddress: string,
+    customerName: string,
+    serviceName: string,
+    originalDate: string,
+    originalTime: string,
+    requestedDate: string,
+    requestedTime: string,
+    requestId: string
+  ): Promise<SendPushResult> {
+    return this.sendToUser(shopAddress, {
+      title: 'Reschedule Request',
+      body: `${customerName} wants to reschedule ${serviceName} from ${originalDate} to ${requestedDate}`,
+      channelId: NotificationChannels.APPOINTMENTS,
+      data: {
+        type: 'reschedule_request',
+        requestId,
+        customerName,
+        serviceName,
+        originalDate,
+        originalTime,
+        requestedDate,
+        requestedTime,
+      },
+    });
+  }
+
+  async sendRescheduleApproved(
+    customerAddress: string,
+    shopName: string,
+    serviceName: string,
+    newDate: string,
+    newTime: string,
+    requestId: string
+  ): Promise<SendPushResult> {
+    return this.sendToUser(customerAddress, {
+      title: 'Reschedule Approved',
+      body: `${shopName} approved your reschedule for ${serviceName}. New time: ${newDate} at ${newTime}`,
+      channelId: NotificationChannels.APPOINTMENTS,
+      data: { type: 'reschedule_approved', requestId, shopName, serviceName, newDate, newTime },
+    });
+  }
+
+  async sendRescheduleRejected(
+    customerAddress: string,
+    shopName: string,
+    serviceName: string,
+    reason: string | undefined,
+    requestId: string
+  ): Promise<SendPushResult> {
+    const reasonText = reason ? `: ${reason}` : '';
+    return this.sendToUser(customerAddress, {
+      title: 'Reschedule Declined',
+      body: `${shopName} declined your reschedule request for ${serviceName}${reasonText}`,
+      channelId: NotificationChannels.APPOINTMENTS,
+      data: { type: 'reschedule_rejected', requestId, shopName, serviceName, reason },
+    });
+  }
+
+  async sendSubscriptionExpiringNotification(
+    shopAddress: string,
+    shopName: string,
+    daysRemaining: number,
+    expirationDate: string
+  ): Promise<SendPushResult> {
+    const urgency = daysRemaining <= 1 ? 'tomorrow' : `in ${daysRemaining} days`;
+    const title = daysRemaining <= 1 ? 'Subscription Expires Tomorrow!' : 'Subscription Expiring Soon';
+
+    return this.sendToUser(shopAddress, {
+      title,
+      body: `Your RepairCoin subscription expires ${urgency}. Renew now to keep earning rewards.`,
+      channelId: NotificationChannels.DEFAULT,
+      priority: daysRemaining <= 1 ? 'high' : 'default',
+      data: { type: 'subscription_expiring', shopName, daysRemaining, expirationDate },
+    });
+  }
+}
+
+// Singleton instance
+let dispatcherInstance: PushNotificationDispatcher | null = null;
+
+export function getPushNotificationDispatcher(): PushNotificationDispatcher {
+  if (!dispatcherInstance) {
+    dispatcherInstance = new PushNotificationDispatcher();
+  }
+  return dispatcherInstance;
+}

--- a/backend/src/services/SubscriptionReminderService.ts
+++ b/backend/src/services/SubscriptionReminderService.ts
@@ -2,7 +2,7 @@
 import { logger } from '../utils/logger';
 import { EmailService } from './EmailService';
 import { NotificationService } from '../domains/notification/services/NotificationService';
-import { getExpoPushService, ExpoPushService } from './ExpoPushService';
+import { getPushNotificationDispatcher, PushNotificationDispatcher } from './PushNotificationDispatcher';
 import { getSharedPool } from '../utils/database-pool';
 import { generalNotificationPreferencesRepository } from '../repositories/GeneralNotificationPreferencesRepository';
 
@@ -77,14 +77,14 @@ const REMINDER_CONFIGS: ReminderConfig[] = [
 export class SubscriptionReminderService {
   private emailService: EmailService;
   private notificationService: NotificationService;
-  private expoPushService: ExpoPushService;
+  private pushDispatcher: PushNotificationDispatcher;
   private scheduledIntervalId: NodeJS.Timeout | null = null;
   private isRunning: boolean = false;
 
   constructor() {
     this.emailService = new EmailService();
     this.notificationService = new NotificationService();
-    this.expoPushService = getExpoPushService();
+    this.pushDispatcher = getPushNotificationDispatcher();
   }
 
   /**
@@ -261,7 +261,7 @@ export class SubscriptionReminderService {
         return false;
       }
 
-      const result = await this.expoPushService.sendSubscriptionExpiringNotification(
+      const result = await this.pushDispatcher.sendSubscriptionExpiringNotification(
         data.walletAddress,
         data.shopName,
         data.daysRemaining,

--- a/backend/src/services/WebPushService.ts
+++ b/backend/src/services/WebPushService.ts
@@ -1,0 +1,359 @@
+import webpush from 'web-push';
+import { PushTokenRepository, DevicePushToken, WebPushSubscription } from '../repositories/PushTokenRepository';
+import { PushNotificationPayload, SendPushResult, NotificationChannels } from './ExpoPushService';
+import { Config } from '../config';
+import { logger } from '../utils/logger';
+
+const MAX_PAYLOAD_BYTES = 4000; // Web Push spec limit is 4KB, leave some headroom
+
+export class WebPushService {
+  private pushTokenRepository: PushTokenRepository;
+  private disabled: boolean;
+
+  constructor() {
+    this.pushTokenRepository = new PushTokenRepository();
+    this.disabled = false;
+
+    const { vapidPublicKey, vapidPrivateKey, vapidSubject } = Config.webPush;
+
+    if (!vapidPublicKey || !vapidPrivateKey) {
+      logger.warn('[WebPush] VAPID keys not configured — web push notifications disabled');
+      this.disabled = true;
+      return;
+    }
+
+    webpush.setVapidDetails(vapidSubject, vapidPublicKey, vapidPrivateKey);
+    logger.info('[WebPush] Initialized with VAPID keys');
+  }
+
+  /**
+   * Send web push notification to a single user (all their web browsers)
+   */
+  async sendToUser(walletAddress: string, notification: PushNotificationPayload): Promise<SendPushResult> {
+    if (this.disabled) {
+      return { successCount: 0, failureCount: 0, invalidTokens: [] };
+    }
+
+    const tokens = await this.pushTokenRepository.getActiveTokensByWallet(walletAddress, ['web']);
+
+    if (tokens.length === 0) {
+      return { successCount: 0, failureCount: 0, invalidTokens: [] };
+    }
+
+    return this.sendToTokens(tokens, notification);
+  }
+
+  /**
+   * Send web push notification to multiple users
+   */
+  async sendToMultipleUsers(
+    walletAddresses: string[],
+    notification: PushNotificationPayload
+  ): Promise<SendPushResult> {
+    if (this.disabled) {
+      return { successCount: 0, failureCount: 0, invalidTokens: [] };
+    }
+
+    const tokenMap = await this.pushTokenRepository.getActiveTokensForUsers(walletAddresses, ['web']);
+
+    const allTokens: DevicePushToken[] = [];
+    tokenMap.forEach((tokens) => allTokens.push(...tokens));
+
+    if (allTokens.length === 0) {
+      return { successCount: 0, failureCount: 0, invalidTokens: [] };
+    }
+
+    return this.sendToTokens(allTokens, notification);
+  }
+
+  /**
+   * Send web push notifications to specific tokens
+   */
+  private async sendToTokens(
+    tokens: DevicePushToken[],
+    notification: PushNotificationPayload
+  ): Promise<SendPushResult> {
+    const result: SendPushResult = {
+      successCount: 0,
+      failureCount: 0,
+      invalidTokens: [],
+    };
+
+    const payload = this.buildPayload(notification);
+
+    for (const token of tokens) {
+      if (!token.webPushSubscription) {
+        result.failureCount++;
+        if (token.expoPushToken) {
+          result.invalidTokens.push(token.expoPushToken);
+          await this.pushTokenRepository.deactivateToken(token.expoPushToken);
+        }
+        continue;
+      }
+
+      try {
+        await webpush.sendNotification(token.webPushSubscription as webpush.PushSubscription, payload, {
+          TTL: notification.ttl || 86400, // default 24 hours
+          urgency: notification.priority === 'high' ? 'high' : 'normal',
+        });
+
+        result.successCount++;
+        if (token.expoPushToken) {
+          await this.pushTokenRepository.updateLastUsed(token.expoPushToken);
+        }
+      } catch (error: any) {
+        result.failureCount++;
+
+        // 410 Gone or 404 Not Found = subscription expired
+        if (error.statusCode === 410 || error.statusCode === 404) {
+          if (token.expoPushToken) {
+            result.invalidTokens.push(token.expoPushToken);
+            await this.pushTokenRepository.deactivateToken(token.expoPushToken);
+          }
+          logger.info('[WebPush] Subscription expired, deactivated', {
+            statusCode: error.statusCode,
+            endpoint: token.webPushSubscription.endpoint.substring(0, 50),
+          });
+        } else {
+          logger.warn('[WebPush] Failed to send notification', {
+            statusCode: error.statusCode,
+            message: error.message,
+          });
+        }
+      }
+    }
+
+    if (result.successCount > 0 || result.failureCount > 0) {
+      logger.info('[WebPush] Notifications sent', {
+        success: result.successCount,
+        failure: result.failureCount,
+        invalidated: result.invalidTokens.length,
+      });
+    }
+
+    return result;
+  }
+
+  /**
+   * Build JSON payload for web push, enforcing 4KB limit
+   */
+  private buildPayload(notification: PushNotificationPayload): string {
+    const payload = JSON.stringify({
+      title: notification.title,
+      body: notification.body,
+      data: notification.data || {},
+      channelId: notification.channelId || NotificationChannels.DEFAULT,
+    });
+
+    if (Buffer.byteLength(payload) > MAX_PAYLOAD_BYTES) {
+      // Truncate data to fit within limit
+      const minimal = JSON.stringify({
+        title: notification.title,
+        body: notification.body.substring(0, 200),
+        data: { type: notification.data?.type },
+        channelId: notification.channelId || NotificationChannels.DEFAULT,
+      });
+      logger.warn('[WebPush] Payload truncated to fit 4KB limit');
+      return minimal;
+    }
+
+    return payload;
+  }
+
+  // ============================================
+  // Convenience methods (mirror ExpoPushService)
+  // ============================================
+
+  async sendRewardNotification(
+    customerAddress: string,
+    shopName: string,
+    amount: number,
+    transactionId?: string
+  ): Promise<SendPushResult> {
+    return this.sendToUser(customerAddress, {
+      title: 'Reward Received!',
+      body: `You received ${amount} RCN from ${shopName}`,
+      channelId: NotificationChannels.REWARDS,
+      data: { type: 'reward_issued', transactionId, amount, shopName },
+    });
+  }
+
+  async sendRedemptionApprovalRequest(
+    customerAddress: string,
+    shopName: string,
+    amount: number,
+    sessionId: string
+  ): Promise<SendPushResult> {
+    return this.sendToUser(customerAddress, {
+      title: 'Redemption Request',
+      body: `${shopName} wants to redeem ${amount} RCN from your balance`,
+      channelId: NotificationChannels.REDEMPTIONS,
+      priority: 'high',
+      data: { type: 'redemption_approval_requested', sessionId, amount, shopName },
+    });
+  }
+
+  async sendBookingConfirmation(
+    customerAddress: string,
+    shopName: string,
+    serviceName: string,
+    appointmentDate: string,
+    appointmentTime: string,
+    orderId: string
+  ): Promise<SendPushResult> {
+    return this.sendToUser(customerAddress, {
+      title: 'Booking Confirmed',
+      body: `Your ${serviceName} at ${shopName} is confirmed for ${appointmentDate} at ${appointmentTime}`,
+      channelId: NotificationChannels.APPOINTMENTS,
+      data: { type: 'booking_confirmed', orderId, shopName, serviceName, appointmentDate, appointmentTime },
+    });
+  }
+
+  async sendAppointmentReminder(
+    customerAddress: string,
+    shopName: string,
+    serviceName: string,
+    appointmentTime: string,
+    orderId: string
+  ): Promise<SendPushResult> {
+    return this.sendToUser(customerAddress, {
+      title: 'Appointment Tomorrow',
+      body: `Reminder: ${serviceName} at ${shopName} at ${appointmentTime}`,
+      channelId: NotificationChannels.APPOINTMENTS,
+      priority: 'high',
+      data: { type: 'appointment_reminder', orderId, shopName, serviceName, appointmentTime },
+    });
+  }
+
+  async sendOrderCompleted(
+    customerAddress: string,
+    shopName: string,
+    serviceName: string,
+    rcnEarned: number,
+    orderId: string
+  ): Promise<SendPushResult> {
+    return this.sendToUser(customerAddress, {
+      title: 'Service Complete',
+      body: `${shopName} completed your ${serviceName}. You earned ${rcnEarned} RCN!`,
+      channelId: NotificationChannels.REWARDS,
+      data: { type: 'order_completed', orderId, shopName, serviceName, rcnEarned },
+    });
+  }
+
+  async sendNewBookingToShop(
+    shopAddress: string,
+    customerName: string,
+    serviceName: string,
+    appointmentDate: string,
+    appointmentTime: string,
+    orderId: string
+  ): Promise<SendPushResult> {
+    return this.sendToUser(shopAddress, {
+      title: 'New Booking',
+      body: `${customerName} booked ${serviceName} for ${appointmentDate} at ${appointmentTime}`,
+      channelId: NotificationChannels.APPOINTMENTS,
+      data: { type: 'new_booking', orderId, customerName, serviceName, appointmentDate, appointmentTime },
+    });
+  }
+
+  async sendTokenGiftedNotification(
+    toCustomerAddress: string,
+    fromCustomerName: string,
+    amount: number,
+    transactionId: string
+  ): Promise<SendPushResult> {
+    return this.sendToUser(toCustomerAddress, {
+      title: 'Gift Received!',
+      body: `${fromCustomerName} gifted you ${amount} RCN`,
+      channelId: NotificationChannels.REWARDS,
+      data: { type: 'token_gifted', transactionId, amount, fromCustomerName },
+    });
+  }
+
+  async sendRescheduleRequestToShop(
+    shopAddress: string,
+    customerName: string,
+    serviceName: string,
+    originalDate: string,
+    originalTime: string,
+    requestedDate: string,
+    requestedTime: string,
+    requestId: string
+  ): Promise<SendPushResult> {
+    return this.sendToUser(shopAddress, {
+      title: 'Reschedule Request',
+      body: `${customerName} wants to reschedule ${serviceName} from ${originalDate} to ${requestedDate}`,
+      channelId: NotificationChannels.APPOINTMENTS,
+      data: {
+        type: 'reschedule_request',
+        requestId,
+        customerName,
+        serviceName,
+        originalDate,
+        originalTime,
+        requestedDate,
+        requestedTime,
+      },
+    });
+  }
+
+  async sendRescheduleApproved(
+    customerAddress: string,
+    shopName: string,
+    serviceName: string,
+    newDate: string,
+    newTime: string,
+    requestId: string
+  ): Promise<SendPushResult> {
+    return this.sendToUser(customerAddress, {
+      title: 'Reschedule Approved',
+      body: `${shopName} approved your reschedule for ${serviceName}. New time: ${newDate} at ${newTime}`,
+      channelId: NotificationChannels.APPOINTMENTS,
+      data: { type: 'reschedule_approved', requestId, shopName, serviceName, newDate, newTime },
+    });
+  }
+
+  async sendRescheduleRejected(
+    customerAddress: string,
+    shopName: string,
+    serviceName: string,
+    reason: string | undefined,
+    requestId: string
+  ): Promise<SendPushResult> {
+    const reasonText = reason ? `: ${reason}` : '';
+    return this.sendToUser(customerAddress, {
+      title: 'Reschedule Declined',
+      body: `${shopName} declined your reschedule request for ${serviceName}${reasonText}`,
+      channelId: NotificationChannels.APPOINTMENTS,
+      data: { type: 'reschedule_rejected', requestId, shopName, serviceName, reason },
+    });
+  }
+
+  async sendSubscriptionExpiringNotification(
+    shopAddress: string,
+    shopName: string,
+    daysRemaining: number,
+    expirationDate: string
+  ): Promise<SendPushResult> {
+    const urgency = daysRemaining <= 1 ? 'tomorrow' : `in ${daysRemaining} days`;
+    const title = daysRemaining <= 1 ? 'Subscription Expires Tomorrow!' : 'Subscription Expiring Soon';
+
+    return this.sendToUser(shopAddress, {
+      title,
+      body: `Your RepairCoin subscription expires ${urgency}. Renew now to keep earning rewards.`,
+      channelId: NotificationChannels.DEFAULT,
+      priority: daysRemaining <= 1 ? 'high' : 'default',
+      data: { type: 'subscription_expiring', shopName, daysRemaining, expirationDate },
+    });
+  }
+}
+
+// Singleton instance
+let webPushServiceInstance: WebPushService | null = null;
+
+export function getWebPushService(): WebPushService {
+  if (!webPushServiceInstance) {
+    webPushServiceInstance = new WebPushService();
+  }
+  return webPushServiceInstance;
+}

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,71 @@
+// RepairCoin Web Push Service Worker
+// Handles push notifications and notification click routing
+
+// Notification type → URL routing map
+const NOTIFICATION_ROUTES = {
+  // Shop-facing
+  new_booking: '/shop/orders',
+  reschedule_request: '/shop/orders',
+  subscription_expiring: '/shop/settings',
+  new_order: '/shop/orders',
+  // Customer-facing
+  booking_confirmed: '/customer/bookings',
+  appointment_reminder: '/customer/bookings',
+  order_completed: '/customer/bookings',
+  reward_issued: '/customer/dashboard',
+  token_gifted: '/customer/dashboard',
+  redemption_approved: '/customer/dashboard',
+  redemption_rejected: '/customer/dashboard',
+};
+
+self.addEventListener('push', (event) => {
+  if (!event.data) return;
+
+  let payload;
+  try {
+    payload = event.data.json();
+  } catch {
+    payload = { title: 'RepairCoin', body: event.data.text() };
+  }
+
+  const { title = 'RepairCoin', body = '', data = {} } = payload;
+
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body,
+      icon: '/img/favicon-logo.png',
+      badge: '/img/favicon-logo.png',
+      data,
+      tag: data.type || 'default',
+    })
+  );
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+
+  const data = event.notification.data || {};
+  const targetPath = data.route || NOTIFICATION_ROUTES[data.type] || '/';
+
+  const handleClick = self.clients
+    .matchAll({ type: 'window', includeUncontrolled: true })
+    .then((clientList) => {
+      // Try to focus an existing tab at our origin
+      for (const client of clientList) {
+        if (new URL(client.url).origin === self.location.origin) {
+          client.focus();
+          client.navigate(targetPath);
+          return;
+        }
+      }
+      // No existing tab — open a new one
+      return self.clients.openWindow(targetPath);
+    });
+
+  event.waitUntil(handleClick);
+});
+
+self.addEventListener('activate', (event) => {
+  // Take control of all open tabs immediately
+  event.waitUntil(self.clients.claim());
+});

--- a/frontend/src/components/notifications/GeneralNotificationSettings.tsx
+++ b/frontend/src/components/notifications/GeneralNotificationSettings.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Bell, MessageSquare, Gift, Wallet, Store, AlertCircle, Mail, Smartphone } from "lucide-react";
+import { Bell, MessageSquare, Gift, Wallet, Store, AlertCircle, Mail, MonitorSmartphone } from "lucide-react";
 import toast from "react-hot-toast";
 import { notificationsApi } from "@/services/api/notifications";
 import { GeneralNotificationPreferences } from "@/constants/types";
+import { usePushSubscription } from "@/hooks/usePushSubscription";
 
 interface ToggleSwitchProps {
   label: string;
@@ -75,6 +76,8 @@ export function GeneralNotificationSettings({ userType = 'customer' }: GeneralNo
   const [saving, setSaving] = useState(false);
   const [backendPreferences, setBackendPreferences] = useState<GeneralNotificationPreferences | null>(null);
   const [originalPreferences, setOriginalPreferences] = useState<typeof preferences | null>(null);
+  const [pushPermission, setPushPermission] = useState<NotificationPermission | 'unsupported'>('default');
+  const { subscribeToPush } = usePushSubscription();
 
   // Form state - these will be connected to API
   const [preferences, setPreferences] = useState({
@@ -172,6 +175,24 @@ export function GeneralNotificationSettings({ userType = 'customer' }: GeneralNo
 
     loadPreferences();
   }, []);
+
+  // Check push notification permission status
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!('Notification' in window) || !('PushManager' in window)) {
+      setPushPermission('unsupported');
+      return;
+    }
+    setPushPermission(Notification.permission);
+  }, []);
+
+  const handleEnablePush = async () => {
+    await subscribeToPush();
+    // Re-check permission after subscription attempt
+    if ('Notification' in window) {
+      setPushPermission(Notification.permission);
+    }
+  };
 
   const handleToggle = (key: keyof typeof preferences) => {
     setPreferences(prev => ({
@@ -507,11 +528,21 @@ export function GeneralNotificationSettings({ userType = 'customer' }: GeneralNo
                 <p className="text-xs text-gray-400">Real-time alerts</p>
               </div>
             </div>
-            <div className="flex items-center gap-3 p-3 bg-[#2F2F2F] rounded-lg border border-gray-700 opacity-50">
-              <Smartphone className="w-5 h-5 text-gray-400" />
+            <div
+              className={`flex items-center gap-3 p-3 bg-[#2F2F2F] rounded-lg border border-gray-700 ${
+                pushPermission === 'default' ? 'cursor-pointer hover:border-[#FFCC00]/50 transition-colors' : ''
+              } ${pushPermission === 'unsupported' ? 'opacity-50' : ''}`}
+              onClick={pushPermission === 'default' ? handleEnablePush : undefined}
+            >
+              <MonitorSmartphone className={`w-5 h-5 ${pushPermission === 'granted' ? 'text-green-400' : pushPermission === 'default' ? 'text-[#FFCC00]' : 'text-gray-400'}`} />
               <div>
-                <p className="text-sm font-medium text-gray-400">SMS</p>
-                <p className="text-xs text-gray-500">Coming soon</p>
+                <p className="text-sm font-medium text-white">Push</p>
+                <p className="text-xs text-gray-400">
+                  {pushPermission === 'granted' && 'Active'}
+                  {pushPermission === 'default' && 'Click to enable'}
+                  {pushPermission === 'denied' && 'Blocked in browser'}
+                  {pushPermission === 'unsupported' && 'Not supported'}
+                </p>
               </div>
             </div>
           </div>

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import { useNotificationStore, Notification as NotificationType } from '../stores/notificationStore';
 import { useAuthStore } from '../stores/authStore';
 import apiClient from '@/services/api/client';
+import { usePushSubscription } from './usePushSubscription';
 
 // WebSocket URL - explicitly use api.repaircoin.ai subdomain in production
 const WS_URL = typeof window !== 'undefined' && window.location.hostname.includes('repaircoin.ai')
@@ -19,6 +20,7 @@ export const useNotifications = (options: UseNotificationsOptions = {}) => {
   const reconnectAttemptsRef = useRef(0);
   const manuallyClosedRef = useRef(false); // Track if we manually closed due to auth errors
   const maxReconnectAttempts = 5;
+  const { subscribeToPush, unsubscribeFromPush } = usePushSubscription();
 
   const {
     addNotification,
@@ -353,11 +355,13 @@ export const useNotifications = (options: UseNotificationsOptions = {}) => {
         fetchNotifications();
         fetchUnreadCount();
         connectWebSocket();
+        subscribeToPush();
       }
     } else {
       // Disconnect if user logged out
       if (!isAuthenticated) {
         disconnectWebSocket();
+        unsubscribeFromPush();
       }
     }
 
@@ -380,6 +384,7 @@ export const useNotifications = (options: UseNotificationsOptions = {}) => {
     requestNotificationPermission,
     connectWebSocket,
     disconnectWebSocket,
+    subscribeToPush,
   };
 };
 

--- a/frontend/src/hooks/usePushSubscription.ts
+++ b/frontend/src/hooks/usePushSubscription.ts
@@ -1,0 +1,127 @@
+import { useCallback, useRef } from 'react';
+import { getVapidPublicKey, registerPushToken, deactivateAllPushTokens } from '@/services/api/notifications';
+
+const PUSH_ENDPOINT_KEY = 'rc_push_endpoint';
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; i++) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer | null): string {
+  if (!buffer) return '';
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+async function waitForServiceWorkerActive(registration: ServiceWorkerRegistration): Promise<void> {
+  if (registration.active) return;
+
+  const sw = registration.installing || registration.waiting;
+  if (!sw) return;
+
+  return new Promise<void>((resolve) => {
+    if (sw.state === 'activated') {
+      resolve();
+      return;
+    }
+    sw.addEventListener('statechange', () => {
+      if (sw.state === 'activated') resolve();
+    });
+  });
+}
+
+export function usePushSubscription() {
+  const subscribingRef = useRef(false);
+
+  const subscribeToPush = useCallback(async () => {
+    if (subscribingRef.current) return;
+    if (typeof window === 'undefined') return;
+    if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
+
+    subscribingRef.current = true;
+    try {
+      const registration = await navigator.serviceWorker.register('/sw.js');
+      await waitForServiceWorkerActive(registration);
+
+      // Check if already subscribed with the same endpoint
+      const existingSubscription = await registration.pushManager.getSubscription();
+      const storedEndpoint = localStorage.getItem(PUSH_ENDPOINT_KEY);
+
+      if (existingSubscription && existingSubscription.endpoint === storedEndpoint) {
+        return; // Already registered with backend
+      }
+
+      // If permission was previously denied, don't prompt again
+      if (Notification.permission === 'denied') {
+        console.log('[push] Notification permission denied, skipping subscription');
+        return;
+      }
+
+      const vapidPublicKey = await getVapidPublicKey();
+      if (!vapidPublicKey) {
+        console.warn('[push] VAPID public key not configured on server');
+        return;
+      }
+
+      const applicationServerKey = urlBase64ToUint8Array(vapidPublicKey);
+
+      // This triggers the browser permission prompt if permission is 'default'
+      const subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey,
+      });
+
+      const p256dh = arrayBufferToBase64(subscription.getKey('p256dh'));
+      const auth = arrayBufferToBase64(subscription.getKey('auth'));
+
+      await registerPushToken({
+        deviceType: 'web',
+        deviceName: (navigator.userAgent || 'Web Browser').substring(0, 100),
+        webPushSubscription: {
+          endpoint: subscription.endpoint,
+          keys: { p256dh, auth },
+        },
+      });
+
+      localStorage.setItem(PUSH_ENDPOINT_KEY, subscription.endpoint);
+      console.log('[push] Web push subscription registered');
+    } catch (error) {
+      console.error('[push] Failed to subscribe:', error);
+    } finally {
+      subscribingRef.current = false;
+    }
+  }, []);
+
+  const unsubscribeFromPush = useCallback(async () => {
+    if (typeof window === 'undefined') return;
+    if (!('serviceWorker' in navigator)) return;
+
+    try {
+      const registration = await navigator.serviceWorker.getRegistration();
+      if (registration) {
+        const subscription = await registration.pushManager.getSubscription();
+        if (subscription) {
+          await subscription.unsubscribe();
+        }
+      }
+      await deactivateAllPushTokens();
+      localStorage.removeItem(PUSH_ENDPOINT_KEY);
+      console.log('[push] Web push subscription removed');
+    } catch (error) {
+      console.error('[push] Failed to unsubscribe:', error);
+    }
+  }, []);
+
+  return { subscribeToPush, unsubscribeFromPush };
+}

--- a/frontend/src/services/api/notifications.ts
+++ b/frontend/src/services/api/notifications.ts
@@ -34,8 +34,37 @@ export const resetGeneralNotificationPreferences = async (): Promise<GeneralNoti
   return response.data;
 };
 
+/**
+ * Get VAPID public key for web push subscription (public endpoint)
+ */
+export const getVapidPublicKey = async (): Promise<string> => {
+  const response = await apiClient.get('/notifications/vapid-public-key');
+  return response.vapidPublicKey;
+};
+
+/**
+ * Register a web push subscription token
+ */
+export const registerPushToken = async (params: {
+  deviceType: 'web';
+  deviceName?: string;
+  webPushSubscription: { endpoint: string; keys: { p256dh: string; auth: string } };
+}): Promise<void> => {
+  await apiClient.post('/notifications/push-tokens', params);
+};
+
+/**
+ * Deactivate all push tokens for the current user
+ */
+export const deactivateAllPushTokens = async (): Promise<void> => {
+  await apiClient.delete('/notifications/push-tokens');
+};
+
 export const notificationsApi = {
   getGeneralNotificationPreferences,
   updateGeneralNotificationPreferences,
   resetGeneralNotificationPreferences,
+  getVapidPublicKey,
+  registerPushToken,
+  deactivateAllPushTokens,
 };

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { authApi } from '@/services/api/auth';
+import { deactivateAllPushTokens } from '@/services/api/notifications';
 import { clearAllAuthCaches } from '@/hooks/useAuthInitializer';
 import { setAccountSwitchingState } from '@/services/api/client';
 
@@ -380,6 +381,17 @@ export const useAuthStore = create<AuthState>()(
           await authApi.logout();
         } catch (error) {
           console.error('[authStore] Logout error:', error);
+        }
+
+        // Deactivate web push tokens before reset
+        try {
+          await deactivateAllPushTokens();
+          const registration = await navigator.serviceWorker?.getRegistration();
+          const subscription = await registration?.pushManager?.getSubscription();
+          await subscription?.unsubscribe();
+          localStorage.removeItem('rc_push_endpoint');
+        } catch {
+          // Non-critical — tokens expire naturally
         }
 
         // Reset state regardless of API call result


### PR DESCRIPTION
Logout rotates the FCM endpoint; the prior UPSERT keyed on endpoint hash treated every rotation as a new row, letting a single wallet accumulate stale subscriptions across logout/login cycles. The DB now enforces "one web push row per wallet" via a partial unique index, and the registration query upserts against that index so endpoint rotations refresh the existing row instead of inserting a new one.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>