### PR TITLE
Tavie/dev

### DIFF
--- a/backend/docs/plans/websocket-message-unread-count.md
+++ b/backend/docs/plans/websocket-message-unread-count.md
@@ -1,0 +1,188 @@
+# Plan: Replace Message Unread-Count Polling with WebSocket Push
+
+## Context
+
+The web frontend polls `GET /api/messages/unread-count` every 10 seconds via `setInterval` in `MessageIcon.tsx`. The backend already has full WebSocket infrastructure (`WebSocketManager`), used for notifications, subscription status, shop status, and manual booking payments — but messaging is not wired in.
+
+When a message is sent, `MessageService.sendMessage` increments the receiver's unread count in DB but does not push anything over WebSocket, so the UI is stale until the next poll tick.
+
+Goal: push a lightweight `message:new` signal to the receiver over WebSocket when a message is sent, and have `MessageIcon` refetch the unread count on receipt. Drop the 10-second polling entirely.
+
+Mobile is out of scope — mobile uses `useFocusEffect` (no polling, no WS) and has a separate tracked task (`mobile/docs/tasks/enhancements/websocket-realtime-messaging.md`).
+
+---
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `backend/src/domains/messaging/index.ts` | Add `setWebSocketManager()` method, hold `wsManager` reference, forward to `MessageService` |
+| `backend/src/domains/messaging/services/MessageService.ts` | Accept `wsManager` via setter; emit `message:new` WS event after `incrementUnreadCount` |
+| `backend/src/app.ts` | Attach `wsManager` to `messagingDomain` (mirror existing `notificationDomain` attachment) |
+| `frontend/src/hooks/useNotifications.ts` | Add `message:new` case in WS message handler, dispatch `new-message-received` DOM event |
+| `frontend/src/components/messaging/MessageIcon.tsx` | Remove `setInterval(fetchUnreadCount, 10000)`, add `new-message-received` window listener |
+
+No new files. No new env vars. No DB changes.
+
+---
+
+## Implementation Steps
+
+### Step 1: Backend — `MessagingDomain.setWebSocketManager`
+
+`backend/src/domains/messaging/index.ts`
+
+Mirror the pattern in `NotificationDomain.setWebSocketManager` (see `backend/src/domains/notification/NotificationDomain.ts:37-40`).
+
+```ts
+import { WebSocketManager } from '../../services/WebSocketManager';
+
+export class MessagingDomain implements DomainModule {
+  // ...
+  private wsManager?: WebSocketManager;
+
+  public setWebSocketManager(wsManager: WebSocketManager): void {
+    this.wsManager = wsManager;
+    this.messageService.setWebSocketManager(wsManager);
+    logger.info('WebSocket manager attached to MessagingDomain');
+  }
+}
+```
+
+### Step 2: Backend — `MessageService.sendMessage` emits `message:new`
+
+`backend/src/domains/messaging/services/MessageService.ts`
+
+Add a setter and an emit call after the existing `incrementUnreadCount` block (around line 138):
+
+```ts
+import { WebSocketManager } from '../../../services/WebSocketManager';
+
+export class MessageService {
+  private wsManager?: WebSocketManager;
+
+  public setWebSocketManager(wsManager: WebSocketManager): void {
+    this.wsManager = wsManager;
+  }
+
+  async sendMessage(request: SendMessageRequest): Promise<Message> {
+    // ... existing code through incrementUnreadCount ...
+
+    // Emit WebSocket signal so the receiver's MessageIcon refreshes its badge
+    try {
+      const receiverAddress = request.senderType === 'customer'
+        ? conversation.shopId
+        : conversation.customerAddress;
+
+      this.wsManager?.sendToAddresses([receiverAddress], {
+        type: 'message:new',
+        payload: { conversationId: conversation.conversationId }
+      });
+    } catch (wsError) {
+      logger.error('Failed to send message:new WS event:', wsError);
+      // Non-fatal — the message was already saved and DB unread count incremented
+    }
+
+    // ... rest of existing code (email notification, etc.) ...
+  }
+}
+```
+
+The payload intentionally carries only `conversationId`. The frontend refetches the authoritative unread total via the existing REST endpoint — same pattern `useNotifications` already uses for `shop_status_changed` and `subscription_status_changed`.
+
+### Step 3: Backend — Attach `wsManager` in `app.ts`
+
+`backend/src/app.ts`, immediately after the existing `notificationDomain.setWebSocketManager` block (lines 672-675):
+
+```ts
+const messagingDomain = this.domainRegistry.getDomain('messages') as any;
+if (messagingDomain?.setWebSocketManager) {
+  messagingDomain.setWebSocketManager(this.wsManager);
+  logger.info('✅ WebSocket manager attached to MessagingDomain');
+}
+```
+
+### Step 4: Frontend — `useNotifications` handles `message:new`
+
+`frontend/src/hooks/useNotifications.ts`, add a new case in the `ws.onmessage` switch (next to the existing `manual_booking_payment_completed` case around line 252):
+
+```ts
+case 'message:new':
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('new-message-received', {
+      detail: message.payload
+    }));
+  }
+  break;
+```
+
+### Step 5: Frontend — `MessageIcon` replaces polling with listener
+
+`frontend/src/components/messaging/MessageIcon.tsx`
+
+- Remove `const pollInterval = setInterval(fetchUnreadCount, 10000);` and its `clearInterval` cleanup.
+- Keep the initial `fetchUnreadCount()` call (runs on mount, covers reconnect-after-disconnect because `useNotifications` disconnects and clears state on logout/switch).
+- Add a `new-message-received` window listener that calls `fetchUnreadCount()`.
+
+```tsx
+useEffect(() => {
+  if (!userType || (userType !== 'customer' && userType !== 'shop') || switchingAccount) {
+    return;
+  }
+
+  const fetchUnreadCount = async () => {
+    try {
+      const count = await messagingApi.getUnreadCount();
+      setUnreadCount(count);
+    } catch (err) {
+      console.error('[MessageIcon] Error fetching unread message count:', err);
+    }
+  };
+
+  fetchUnreadCount();
+
+  const handleNewMessage = () => fetchUnreadCount();
+  window.addEventListener('new-message-received', handleNewMessage);
+
+  return () => window.removeEventListener('new-message-received', handleNewMessage);
+}, [userType, switchingAccount]);
+```
+
+---
+
+## Event Contract
+
+**Type:** `message:new`
+
+**Payload:**
+```ts
+{ conversationId: string }
+```
+
+**Sent to:** `[receiverAddress]` (shop address if sender is customer, customer address if sender is shop).
+
+**Frontend behavior:** dispatches `new-message-received` window event. `MessageIcon` refetches `GET /api/messages/unread-count`. Other components (conversation list, active chat) can subscribe to the same window event later if we want incremental updates without more WS wiring.
+
+---
+
+## Out of Scope
+
+- Real-time new-message rendering inside an open conversation view (still uses existing mechanism).
+- Typing indicators over WebSocket.
+- Read-receipt propagation over WebSocket (reads are user-initiated; local state already reflects them).
+- Mobile integration — tracked separately in `mobile/docs/tasks/enhancements/websocket-realtime-messaging.md`.
+
+---
+
+## Testing
+
+Manual:
+1. Log in as Customer A in one browser and Shop B in another.
+2. From Shop B, send a message to Customer A.
+3. Customer A's `MessageIcon` badge should update within ~1 second (WS round-trip + refetch) — no 10-second wait.
+4. Kill the backend WS connection (e.g., restart backend). Confirm the frontend reconnects via the existing exponential-backoff path in `useNotifications` and badge updates resume on next message.
+5. Log out Customer A. Confirm no `new-message-received` listener remains attached (no badge updates on subsequent messages).
+
+Regression checks:
+- Existing `subscription_status_changed`, `shop_status_changed`, and `manual_booking_payment_completed` flows still work.
+- Message send flow still creates DB row, increments unread count, sends shop email when customer messages.

--- a/backend/migrations/103_add_client_message_id.sql
+++ b/backend/migrations/103_add_client_message_id.sql
@@ -1,0 +1,14 @@
+-- Migration: Add client_message_id for optimistic send idempotency
+-- The frontend generates a UUID per send and retries on failure. The backend
+-- uses this column to dedupe retries so a message is inserted at most once.
+
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS client_message_id VARCHAR(64);
+
+-- Partial unique index: scoped to (conversation_id, client_message_id) so two
+-- different conversations can independently reuse IDs if they ever collide.
+-- WHERE clause skips existing rows (client_message_id IS NULL).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_messages_client_message_id
+  ON messages (conversation_id, client_message_id)
+  WHERE client_message_id IS NOT NULL;
+
+COMMENT ON COLUMN messages.client_message_id IS 'Client-generated UUID used to dedupe optimistic-send retries. Nullable for legacy/server-initiated messages.';

--- a/backend/migrations/104_fix_unread_count_double_increment.sql
+++ b/backend/migrations/104_fix_unread_count_double_increment.sql
@@ -1,0 +1,48 @@
+-- Migration 104: Fix unread count double-increment
+--
+-- Migration 079 installed an AFTER INSERT trigger that increments
+-- unread_count_* on every new message AND sets last_message_preview via
+-- LEFT(NEW.message_text, 100). The application code in
+-- MessageService.incrementUnreadCount does the same two things again
+-- immediately after. Every message send = +2 to the counter, and the
+-- trigger's preview leaks encrypted ciphertext into the conversation row
+-- before the app's encryption-aware preview overwrites it.
+--
+-- Fix: trim the trigger to only touch timestamps. The app stays in charge
+-- of the counter and preview so it can produce encryption-safe and
+-- attachment-aware preview text (e.g. "🔒 Locked message",
+-- "Sent 2 attachment(s)"). Then reconcile existing drift by recomputing
+-- each conversation's unread_count_* from the messages table.
+
+CREATE OR REPLACE FUNCTION update_conversation_on_message()
+RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE conversations
+  SET
+    last_message_at = NEW.created_at,
+    updated_at = NOW()
+  WHERE conversation_id = NEW.conversation_id;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Reconcile existing drift: recompute each conversation's unread counters
+-- from the actual unread messages on the other side.
+UPDATE conversations c
+SET unread_count_customer = COALESCE((
+  SELECT COUNT(*) FROM messages m
+  WHERE m.conversation_id = c.conversation_id
+    AND m.sender_type = 'shop'
+    AND m.is_read = FALSE
+    AND m.is_deleted = FALSE
+), 0);
+
+UPDATE conversations c
+SET unread_count_shop = COALESCE((
+  SELECT COUNT(*) FROM messages m
+  WHERE m.conversation_id = c.conversation_id
+    AND m.sender_type = 'customer'
+    AND m.is_read = FALSE
+    AND m.is_deleted = FALSE
+), 0);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -675,6 +675,16 @@ class RepairCoinApp {
       logger.info('✅ WebSocket manager attached to NotificationDomain');
     }
 
+    // Attach WebSocket manager to MessagingDomain
+    const messagingDomain = domainRegistry.getAllDomains().find(
+      d => d.name === 'messages'
+    ) as any;
+
+    if (messagingDomain && messagingDomain.setWebSocketManager) {
+      messagingDomain.setWebSocketManager(this.wsManager);
+      logger.info('✅ WebSocket manager attached to MessagingDomain');
+    }
+
     this.server.listen(port, () => {
       console.log('\n==============================================');
       console.log('🚀 RepairCoin Backend API Started Successfully');

--- a/backend/src/domains/messaging/controllers/MessageController.ts
+++ b/backend/src/domains/messaging/controllers/MessageController.ts
@@ -1,6 +1,6 @@
 // backend/src/domains/messaging/controllers/MessageController.ts
 import { Request, Response } from 'express';
-import { MessageService } from '../services/MessageService';
+import { MessageService, messageService } from '../services/MessageService';
 import { QuickReplyRepository } from '../../../repositories/QuickReplyRepository';
 import { imageStorageService } from '../../../services/ImageStorageService';
 import { logger } from '../../../utils/logger';
@@ -10,7 +10,7 @@ export class MessageController {
   private quickReplyRepo: QuickReplyRepository;
 
   constructor() {
-    this.messageService = new MessageService();
+    this.messageService = messageService;
     this.quickReplyRepo = new QuickReplyRepository();
   }
 

--- a/backend/src/domains/messaging/controllers/MessageController.ts
+++ b/backend/src/domains/messaging/controllers/MessageController.ts
@@ -34,10 +34,17 @@ export class MessageController {
         return res.status(401).json({ success: false, error: 'Shop ID required' });
       }
 
-      const { conversationId, customerAddress, shopId, messageText, messageType, metadata, attachments, isEncrypted } = req.body;
+      const { conversationId, customerAddress, shopId, messageText, messageType, metadata, attachments, isEncrypted, clientMessageId } = req.body;
 
       if (!messageText && (!attachments || attachments.length === 0)) {
         return res.status(400).json({ success: false, error: 'Message text or attachments required' });
+      }
+
+      // Validate clientMessageId shape if provided (64-char cap matches DB column)
+      if (clientMessageId !== undefined && clientMessageId !== null) {
+        if (typeof clientMessageId !== 'string' || clientMessageId.length === 0 || clientMessageId.length > 64) {
+          return res.status(400).json({ success: false, error: 'Invalid clientMessageId' });
+        }
       }
 
       // Determine sender type based on role
@@ -56,7 +63,8 @@ export class MessageController {
         messageType,
         metadata,
         attachments,
-        isEncrypted: isEncrypted || false
+        isEncrypted: isEncrypted || false,
+        clientMessageId: clientMessageId || undefined
       });
 
       res.status(201).json({

--- a/backend/src/domains/messaging/index.ts
+++ b/backend/src/domains/messaging/index.ts
@@ -2,7 +2,8 @@
 import { DomainModule } from '../types';
 import { logger } from '../../utils/logger';
 import messagingRoutes from './routes';
-import { MessageService } from './services/MessageService';
+import { MessageService, messageService } from './services/MessageService';
+import { WebSocketManager } from '../../services/WebSocketManager';
 import { eventBus } from '../../events/EventBus';
 import { autoMessageSchedulerService } from '../../services/AutoMessageSchedulerService';
 import { getSharedPool } from '../../utils/database-pool';
@@ -10,14 +11,20 @@ import { getSharedPool } from '../../utils/database-pool';
 export class MessagingDomain implements DomainModule {
   name = 'messages';
   routes = messagingRoutes;
-  private messageService!: MessageService;
+  private messageService: MessageService = messageService;
+  private wsManager?: WebSocketManager;
   private cleanupInterval?: NodeJS.Timeout;
 
   async initialize(): Promise<void> {
-    this.messageService = new MessageService();
     this.setupPeriodicCleanup();
     this.setupEventSubscriptions();
     logger.info('Messaging domain initialized');
+  }
+
+  public setWebSocketManager(wsManager: WebSocketManager): void {
+    this.wsManager = wsManager;
+    this.messageService.setWebSocketManager(wsManager);
+    logger.info('WebSocket manager attached to MessagingDomain');
   }
 
   /**

--- a/backend/src/domains/messaging/services/MessageService.ts
+++ b/backend/src/domains/messaging/services/MessageService.ts
@@ -2,6 +2,8 @@
 import { MessageRepository, Conversation, Message, CreateMessageParams } from '../../../repositories/MessageRepository';
 import { NotificationService } from '../../notification/services/NotificationService';
 import { WebSocketManager } from '../../../services/WebSocketManager';
+import { conversationPresenceService } from '../../../services/ConversationPresenceService';
+import { emailCooldownService } from '../../../services/EmailCooldownService';
 import { logger } from '../../../utils/logger';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -16,6 +18,7 @@ export interface SendMessageRequest {
   metadata?: Record<string, any>;
   attachments?: any[];
   isEncrypted?: boolean;
+  clientMessageId?: string;
 }
 
 export class MessageService {
@@ -121,10 +124,17 @@ export class MessageService {
         messageType: request.messageType || 'text',
         metadata: request.metadata || {},
         attachments: request.attachments || [],
-        isEncrypted: request.isEncrypted || false
+        isEncrypted: request.isEncrypted || false,
+        clientMessageId: request.clientMessageId
       };
 
-      const message = await this.messageRepo.createMessage(messageParams);
+      const { message, created } = await this.messageRepo.createMessage(messageParams);
+
+      // Duplicate retry: return the existing row without re-running side effects
+      // (unread increment, email, WS push) that already ran for the original send.
+      if (!created) {
+        return message;
+      }
 
       // Increment unread count for the receiver and update last message preview
       try {
@@ -174,36 +184,55 @@ export class MessageService {
       }
       */
 
-      // Send email notification to shop when customer sends a message
-      if (request.senderType === 'customer') {
-        try {
+      // Resolve receiver wallet once — used for both the email-gate presence check
+      // and the WS emit below. For customer→shop we need shop.walletAddress + shop.email;
+      // for shop→customer we only need conversation.customerAddress.
+      let receiverAddress: string | undefined;
+      let shopForEmail: { email?: string; name: string; shopId: string } | undefined;
+
+      try {
+        if (request.senderType === 'customer') {
           const { shopRepository } = await import('../../../repositories');
           const shop = await shopRepository.getShop(conversation.shopId);
-          if (shop?.email) {
-            const { EmailService } = await import('../../../services/EmailService');
-            const emailService = new EmailService();
-            await emailService.sendCustomerMessageNotification(shop.email, shop.shopId, {
-              shopName: shop.name,
-              customerName: conversation.customerName || 'Customer',
-              messagePreview: request.isEncrypted ? '🔒 Locked message' : request.messageText,
-            });
+          receiverAddress = shop?.walletAddress?.toLowerCase();
+          if (shop) {
+            shopForEmail = { email: shop.email, name: shop.name, shopId: shop.shopId };
           }
-        } catch (emailError) {
-          logger.error('Failed to send customer message email to shop:', emailError);
+        } else {
+          receiverAddress = conversation.customerAddress?.toLowerCase();
+        }
+      } catch (lookupError) {
+        logger.error('Failed to resolve receiver for post-send notifications:', lookupError);
+      }
+
+      // Email notification (customer → shop only). Skipped when the shop is actively
+      // viewing this conversation, or when we've already emailed this (shop, convo)
+      // pair within the cooldown window. Non-blocking — fire and forget so the HTTP
+      // response doesn't wait on SendGrid.
+      if (request.senderType === 'customer' && shopForEmail?.email) {
+        const isShopViewing = receiverAddress
+          ? conversationPresenceService.isViewing(receiverAddress, conversation.conversationId)
+          : false;
+
+        if (!isShopViewing && emailCooldownService.shouldSend(shopForEmail.shopId, conversation.conversationId)) {
+          (async () => {
+            try {
+              const { EmailService } = await import('../../../services/EmailService');
+              const emailService = new EmailService();
+              await emailService.sendCustomerMessageNotification(shopForEmail!.email!, shopForEmail!.shopId, {
+                shopName: shopForEmail!.name,
+                customerName: conversation.customerName || 'Customer',
+                messagePreview: request.isEncrypted ? '🔒 Locked message' : request.messageText,
+              });
+            } catch (emailError) {
+              logger.error('Failed to send customer message email to shop:', emailError);
+            }
+          })();
         }
       }
 
       // Push lightweight WS signal so the receiver's MessageIcon refetches unread count
       try {
-        let receiverAddress: string | undefined;
-        if (request.senderType === 'customer') {
-          const { shopRepository } = await import('../../../repositories');
-          const shop = await shopRepository.getShop(conversation.shopId);
-          receiverAddress = shop?.walletAddress?.toLowerCase();
-        } else {
-          receiverAddress = conversation.customerAddress?.toLowerCase();
-        }
-
         if (receiverAddress && this.wsManager) {
           this.wsManager.sendToAddresses([receiverAddress], {
             type: 'message:new',

--- a/backend/src/domains/messaging/services/MessageService.ts
+++ b/backend/src/domains/messaging/services/MessageService.ts
@@ -1,6 +1,7 @@
 // backend/src/domains/messaging/services/MessageService.ts
 import { MessageRepository, Conversation, Message, CreateMessageParams } from '../../../repositories/MessageRepository';
 import { NotificationService } from '../../notification/services/NotificationService';
+import { WebSocketManager } from '../../../services/WebSocketManager';
 import { logger } from '../../../utils/logger';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -20,10 +21,15 @@ export interface SendMessageRequest {
 export class MessageService {
   private messageRepo: MessageRepository;
   private notificationService: NotificationService;
+  private wsManager?: WebSocketManager;
 
   constructor() {
     this.messageRepo = new MessageRepository();
     this.notificationService = new NotificationService();
+  }
+
+  public setWebSocketManager(wsManager: WebSocketManager): void {
+    this.wsManager = wsManager;
   }
 
   /**
@@ -185,6 +191,27 @@ export class MessageService {
         } catch (emailError) {
           logger.error('Failed to send customer message email to shop:', emailError);
         }
+      }
+
+      // Push lightweight WS signal so the receiver's MessageIcon refetches unread count
+      try {
+        let receiverAddress: string | undefined;
+        if (request.senderType === 'customer') {
+          const { shopRepository } = await import('../../../repositories');
+          const shop = await shopRepository.getShop(conversation.shopId);
+          receiverAddress = shop?.walletAddress?.toLowerCase();
+        } else {
+          receiverAddress = conversation.customerAddress?.toLowerCase();
+        }
+
+        if (receiverAddress && this.wsManager) {
+          this.wsManager.sendToAddresses([receiverAddress], {
+            type: 'message:new',
+            payload: { conversationId: conversation.conversationId }
+          });
+        }
+      } catch (wsError) {
+        logger.error('Failed to send message:new WS event:', wsError);
       }
 
       logger.info('Message sent successfully', {
@@ -615,3 +642,5 @@ export class MessageService {
     }
   }
 }
+
+export const messageService = new MessageService();

--- a/backend/src/domains/messaging/services/MessageService.ts
+++ b/backend/src/domains/messaging/services/MessageService.ts
@@ -136,13 +136,17 @@ export class MessageService {
         return message;
       }
 
+      // Preview text shared by unread-count update and the web push payload.
+      // Encryption + attachment aware so we never leak ciphertext into
+      // conversation rows or push notifications.
+      const preview = request.isEncrypted
+        ? '🔒 Locked message'
+        : hasText
+          ? request.messageText.trim()
+          : `Sent ${request.attachments!.length} attachment(s)`;
+
       // Increment unread count for the receiver and update last message preview
       try {
-        const preview = request.isEncrypted
-          ? '🔒 Locked message'
-          : hasText
-            ? request.messageText.trim()
-            : `Sent ${request.attachments!.length} attachment(s)`;
         await this.messageRepo.incrementUnreadCount(
           conversation.conversationId,
           request.senderType === 'customer' ? 'shop' : 'customer',
@@ -226,6 +230,44 @@ export class MessageService {
               });
             } catch (emailError) {
               logger.error('Failed to send customer message email to shop:', emailError);
+            }
+          })();
+        }
+      }
+
+      // Web Push notification to the receiver. Skipped when the receiver is
+      // actively viewing this conversation (same presence gate as email).
+      // Fire-and-forget so the HTTP response doesn't wait on push delivery.
+      if (receiverAddress) {
+        const isReceiverViewing = conversationPresenceService.isViewing(
+          receiverAddress,
+          conversation.conversationId
+        );
+
+        if (!isReceiverViewing) {
+          const receiverType: 'customer' | 'shop' =
+            request.senderType === 'customer' ? 'shop' : 'customer';
+          const senderName = request.senderType === 'customer'
+            ? (conversation.customerName || 'Customer')
+            : (conversation.shopName || 'Shop');
+          // Sender avatar — shop logo for shop senders, customer profile image
+          // for customer senders. Both are joined into the conversation row.
+          const senderImageUrl = request.senderType === 'shop'
+            ? conversation.shopImageUrl
+            : conversation.customerImageUrl;
+
+          (async () => {
+            try {
+              const { getWebPushService } = await import('../../../services/WebPushService');
+              await getWebPushService().sendNewMessageNotification(receiverAddress!, {
+                conversationId: conversation.conversationId,
+                senderName,
+                preview,
+                receiverType,
+                senderImageUrl,
+              });
+            } catch (pushError) {
+              logger.error('Failed to send web push for new message:', pushError);
             }
           })();
         }

--- a/backend/src/repositories/MessageRepository.ts
+++ b/backend/src/repositories/MessageRepository.ts
@@ -43,6 +43,7 @@ export interface Message {
   deletedBy?: string;
   createdAt: Date;
   updatedAt: Date;
+  clientMessageId?: string;
   // Joined data
   senderName?: string;
 }
@@ -71,6 +72,12 @@ export interface CreateMessageParams {
   metadata?: Record<string, any>;
   attachments?: any[];
   isEncrypted?: boolean;
+  clientMessageId?: string;
+}
+
+export interface CreateMessageResult {
+  message: Message;
+  created: boolean;
 }
 
 export class MessageRepository extends BaseRepository {
@@ -292,11 +299,16 @@ export class MessageRepository extends BaseRepository {
   }
 
   /**
-   * Create a message
+   * Create a message.
+   *
+   * When `clientMessageId` is supplied, the insert is idempotent: on conflict
+   * against the (conversation_id, client_message_id) partial unique index the
+   * existing row is returned with `created: false`. Callers can use this flag
+   * to skip duplicate side-effects (unread count, email, WS push).
    */
-  async createMessage(params: CreateMessageParams): Promise<Message> {
+  async createMessage(params: CreateMessageParams): Promise<CreateMessageResult> {
     try {
-      const query = `
+      const insertQuery = `
         INSERT INTO messages (
           message_id,
           conversation_id,
@@ -306,12 +318,15 @@ export class MessageRepository extends BaseRepository {
           message_type,
           metadata,
           attachments,
-          is_encrypted
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+          is_encrypted,
+          client_message_id
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        ON CONFLICT (conversation_id, client_message_id) WHERE client_message_id IS NOT NULL
+          DO NOTHING
         RETURNING *
       `;
 
-      const result = await this.pool.query(query, [
+      const insertResult = await this.pool.query(insertQuery, [
         params.messageId,
         params.conversationId,
         params.senderAddress.toLowerCase(),
@@ -320,16 +335,36 @@ export class MessageRepository extends BaseRepository {
         params.messageType || 'text',
         JSON.stringify(params.metadata || {}),
         JSON.stringify(params.attachments || []),
-        params.isEncrypted || false
+        params.isEncrypted || false,
+        params.clientMessageId || null
       ]);
 
-      logger.info('Message created', {
-        messageId: params.messageId,
+      if (insertResult.rows.length > 0) {
+        logger.info('Message created', {
+          messageId: params.messageId,
+          conversationId: params.conversationId,
+          senderType: params.senderType
+        });
+        return { message: this.mapMessageRow(insertResult.rows[0]), created: true };
+      }
+
+      // Conflict: a row already exists for (conversation_id, client_message_id).
+      // Fetch and return it so the caller sees a Message, but flag as duplicate.
+      const selectResult = await this.pool.query(
+        `SELECT * FROM messages WHERE conversation_id = $1 AND client_message_id = $2 LIMIT 1`,
+        [params.conversationId, params.clientMessageId]
+      );
+
+      if (selectResult.rows.length === 0) {
+        throw new Error('createMessage: conflict hit but no existing row found');
+      }
+
+      logger.info('Message dedup: existing row returned', {
         conversationId: params.conversationId,
-        senderType: params.senderType
+        clientMessageId: params.clientMessageId
       });
 
-      return this.mapMessageRow(result.rows[0]);
+      return { message: this.mapMessageRow(selectResult.rows[0]), created: false };
     } catch (error) {
       logger.error('Error in createMessage:', error);
       throw error;
@@ -763,6 +798,7 @@ export class MessageRepository extends BaseRepository {
       deletedBy: row.deleted_by,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
+      clientMessageId: row.client_message_id || undefined,
       senderName: row.sender_name
     };
   }

--- a/backend/src/repositories/MessageRepository.ts
+++ b/backend/src/repositories/MessageRepository.ts
@@ -20,6 +20,7 @@ export interface Conversation {
   updatedAt: Date;
   // Joined data
   customerName?: string;
+  customerImageUrl?: string;
   shopName?: string;
   shopImageUrl?: string;
 }
@@ -94,6 +95,7 @@ export class MessageRepository extends BaseRepository {
         SELECT
           c.*,
           cust.name as customer_name,
+          cust.profile_image_url as customer_image_url,
           s.name as shop_name,
           s.logo_url as shop_image_url
         FROM conversations c
@@ -143,6 +145,7 @@ export class MessageRepository extends BaseRepository {
         SELECT
           c.*,
           cust.name as customer_name,
+          cust.profile_image_url as customer_image_url,
           s.name as shop_name,
           s.logo_url as shop_image_url
         FROM conversations c
@@ -272,7 +275,8 @@ export class MessageRepository extends BaseRepository {
       const query = `
         SELECT
           c.*,
-          cust.name as customer_name
+          cust.name as customer_name,
+          cust.profile_image_url as customer_image_url
         FROM conversations c
         LEFT JOIN customers cust ON c.customer_address = cust.address
         ${whereClause}
@@ -770,6 +774,7 @@ export class MessageRepository extends BaseRepository {
       createdAt: row.created_at,
       updatedAt: row.updated_at,
       customerName: row.customer_name,
+      customerImageUrl: row.customer_image_url,
       shopName: row.shop_name,
       shopImageUrl: row.shop_image_url
     };

--- a/backend/src/services/AutoMessageSchedulerService.ts
+++ b/backend/src/services/AutoMessageSchedulerService.ts
@@ -219,7 +219,7 @@ export class AutoMessageSchedulerService {
 
       // Create the message
       const messageId = `msg_${uuidv4()}`;
-      const message = await this.messageRepo.createMessage({
+      const { message } = await this.messageRepo.createMessage({
         messageId,
         conversationId: conversation.conversationId,
         senderAddress: rule.shopId,
@@ -567,7 +567,7 @@ export class AutoMessageSchedulerService {
               });
 
               const messageId = `msg_${uuidv4()}`;
-              const message = await this.messageRepo.createMessage({
+              const { message } = await this.messageRepo.createMessage({
                 messageId,
                 conversationId: conversation.conversationId,
                 senderAddress: rule.shopId,

--- a/backend/src/services/ConversationPresenceService.ts
+++ b/backend/src/services/ConversationPresenceService.ts
@@ -1,0 +1,49 @@
+import { logger } from '../utils/logger';
+
+/**
+ * Tracks which wallet addresses are actively viewing which conversations.
+ * Populated by WebSocketManager handling conversation:open/close frames.
+ * Cleared on WS disconnect.
+ *
+ * Used by MessageService to suppress email notifications when the recipient
+ * is already looking at the thread.
+ *
+ * In-memory only — fine for single-node backend. Migrate to Redis when we
+ * horizontally scale.
+ */
+export class ConversationPresenceService {
+  private viewing: Map<string, Set<string>> = new Map();
+
+  markOpen(address: string, conversationId: string): void {
+    const key = address.toLowerCase();
+    let set = this.viewing.get(key);
+    if (!set) {
+      set = new Set();
+      this.viewing.set(key, set);
+    }
+    set.add(conversationId);
+    logger.debug('Presence: open', { address: key, conversationId });
+  }
+
+  markClosed(address: string, conversationId: string): void {
+    const key = address.toLowerCase();
+    const set = this.viewing.get(key);
+    if (!set) return;
+    set.delete(conversationId);
+    if (set.size === 0) {
+      this.viewing.delete(key);
+    }
+    logger.debug('Presence: close', { address: key, conversationId });
+  }
+
+  isViewing(address: string, conversationId: string): boolean {
+    const set = this.viewing.get(address.toLowerCase());
+    return !!set && set.has(conversationId);
+  }
+
+  clearAddress(address: string): void {
+    this.viewing.delete(address.toLowerCase());
+  }
+}
+
+export const conversationPresenceService = new ConversationPresenceService();

--- a/backend/src/services/EmailCooldownService.ts
+++ b/backend/src/services/EmailCooldownService.ts
@@ -1,0 +1,36 @@
+/**
+ * Per-(shop, conversation) in-memory cooldown to prevent email spam when a
+ * customer sends many messages in a short window and the shop is not
+ * actively viewing the thread.
+ *
+ * First send passes; subsequent sends within cooldownMs are suppressed.
+ * After cooldownMs elapses, the next send is allowed again.
+ */
+export class EmailCooldownService {
+  private lastSent: Map<string, number> = new Map();
+  private readonly cooldownMs: number;
+  private readonly sweepIntervalMs = 10 * 60 * 1000;
+
+  constructor(cooldownMs: number = 15 * 60 * 1000) {
+    this.cooldownMs = cooldownMs;
+    setInterval(() => this.sweep(), this.sweepIntervalMs).unref?.();
+  }
+
+  shouldSend(shopId: string, conversationId: string): boolean {
+    const key = `${shopId}:${conversationId}`;
+    const last = this.lastSent.get(key) ?? 0;
+    const now = Date.now();
+    if (now - last < this.cooldownMs) return false;
+    this.lastSent.set(key, now);
+    return true;
+  }
+
+  private sweep(): void {
+    const cutoff = Date.now() - this.cooldownMs;
+    for (const [key, ts] of this.lastSent.entries()) {
+      if (ts < cutoff) this.lastSent.delete(key);
+    }
+  }
+}
+
+export const emailCooldownService = new EmailCooldownService();

--- a/backend/src/services/ExpoPushService.ts
+++ b/backend/src/services/ExpoPushService.ts
@@ -26,6 +26,7 @@ export const NotificationChannels = {
   APPOINTMENTS: 'appointments',
   REWARDS: 'rewards',
   REDEMPTIONS: 'redemptions',
+  MESSAGES: 'messages',
 } as const;
 
 export class ExpoPushService {

--- a/backend/src/services/WebPushService.ts
+++ b/backend/src/services/WebPushService.ts
@@ -329,6 +329,36 @@ export class WebPushService {
     });
   }
 
+  async sendNewMessageNotification(
+    receiverAddress: string,
+    params: {
+      conversationId: string;
+      senderName: string;
+      preview: string;
+      receiverType: 'customer' | 'shop';
+      senderImageUrl?: string;
+    }
+  ): Promise<SendPushResult> {
+    const { conversationId, senderName, preview, receiverType, senderImageUrl } = params;
+    const route = receiverType === 'customer'
+      ? `/customer?tab=messages&conversation=${conversationId}`
+      : `/shop?tab=messages&conversation=${conversationId}`;
+
+    return this.sendToUser(receiverAddress, {
+      title: senderName,
+      body: preview,
+      channelId: NotificationChannels.MESSAGES,
+      priority: 'high',
+      data: {
+        type: 'new_message',
+        conversationId,
+        tag: `new_message:${conversationId}`,
+        route,
+        ...(senderImageUrl ? { icon: senderImageUrl } : {}),
+      },
+    });
+  }
+
   async sendSubscriptionExpiringNotification(
     shopAddress: string,
     shopName: string,

--- a/backend/src/services/WebSocketManager.ts
+++ b/backend/src/services/WebSocketManager.ts
@@ -3,6 +3,7 @@ import { IncomingMessage } from 'http';
 import { logger } from '../utils/logger';
 import jwt from 'jsonwebtoken';
 import { Notification } from '../repositories/NotificationRepository';
+import { conversationPresenceService } from './ConversationPresenceService';
 
 type WebSocketClient = WebSocket & {
   walletAddress?: string;
@@ -121,6 +122,20 @@ export class WebSocketManager {
       case 'ping':
         this.send(ws, { type: 'pong' });
         break;
+
+      case 'conversation:open':
+      case 'conversation:close': {
+        const conversationId = message.payload?.conversationId;
+        if (!ws.walletAddress || typeof conversationId !== 'string' || !conversationId) {
+          return;
+        }
+        if (message.type === 'conversation:open') {
+          conversationPresenceService.markOpen(ws.walletAddress, conversationId);
+        } else {
+          conversationPresenceService.markClosed(ws.walletAddress, conversationId);
+        }
+        break;
+      }
 
       default:
         logger.warn(`Unknown message type: ${message.type}`);
@@ -295,6 +310,7 @@ export class WebSocketManager {
         addressClients.delete(ws);
         if (addressClients.size === 0) {
           this.clients.delete(ws.walletAddress);
+          conversationPresenceService.clearAddress(ws.walletAddress);
         }
       }
       logger.info(`WebSocket disconnected for wallet: ${ws.walletAddress}`);

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -30,13 +30,20 @@ self.addEventListener('push', (event) => {
 
   const { title = 'RepairCoin', body = '', data = {} } = payload;
 
+  // `icon` is the small corner image (OS-controlled size ~48-96px).
+  // `image` is the big hero banner under the text — Chromium/Edge/Firefox
+  // desktop show it in full, so reuse the sender image here so message
+  // pushes get a visibly large logo.
+  const heroImage = data.image || data.icon;
+
   event.waitUntil(
     self.registration.showNotification(title, {
       body,
-      icon: '/img/favicon-logo.png',
+      icon: data.icon || '/img/favicon-logo.png',
       badge: '/img/favicon-logo.png',
+      ...(heroImage ? { image: heroImage } : {}),
       data,
-      tag: data.type || 'default',
+      tag: data.tag || data.type || 'default',
     })
   );
 });

--- a/frontend/src/components/messaging/ConversationThread.tsx
+++ b/frontend/src/components/messaging/ConversationThread.tsx
@@ -31,7 +31,7 @@ export interface Message {
   senderType: "customer" | "shop";
   content: string;
   timestamp: string;
-  status: "sending" | "sent" | "delivered" | "read";
+  status: "sending" | "sent" | "delivered" | "read" | "failed";
   attachments?: {
     type: "image" | "file";
     url: string;
@@ -58,6 +58,8 @@ interface ConversationThreadProps {
   isLoadingMore?: boolean;
   conversationStatus?: "active" | "resolved" | "archived";
   onArchiveConversation?: (archived: boolean) => Promise<void>;
+  onRetryMessage?: (messageId: string) => void;
+  onDiscardMessage?: (messageId: string) => void;
   conversationDetails?: {
     id: string;
     customerId?: string;
@@ -85,6 +87,8 @@ export const ConversationThread: React.FC<ConversationThreadProps> = ({
   isLoadingMore,
   conversationStatus,
   onArchiveConversation,
+  onRetryMessage,
+  onDiscardMessage,
   conversationDetails,
 }) => {
   const [messageInput, setMessageInput] = useState("");
@@ -636,13 +640,33 @@ export const ConversationThread: React.FC<ConversationThreadProps> = ({
                             {formatTime(message.timestamp)}
                           </span>
                           {isOwnMessage && (
-                            <span>
+                            <span className="flex items-center gap-1">
                               {message.status === "read" ? (
                                 <CheckCheck className="w-3 h-3 text-blue-500" />
                               ) : message.status === "delivered" ? (
                                 <CheckCheck className="w-3 h-3 text-gray-500" />
                               ) : message.status === "sent" ? (
                                 <Check className="w-3 h-3 text-gray-500" />
+                              ) : message.status === "failed" ? (
+                                <>
+                                  <span className="text-[11px] text-red-400">Failed</span>
+                                  {onRetryMessage && (
+                                    <button
+                                      onClick={() => onRetryMessage(message.id)}
+                                      className="text-[11px] text-red-400 hover:text-red-300 underline"
+                                    >
+                                      Retry
+                                    </button>
+                                  )}
+                                  {onDiscardMessage && (
+                                    <button
+                                      onClick={() => onDiscardMessage(message.id)}
+                                      className="text-[11px] text-gray-500 hover:text-gray-400 underline"
+                                    >
+                                      Discard
+                                    </button>
+                                  )}
+                                </>
                               ) : (
                                 <div className="w-3 h-3 border-2 border-gray-500 border-t-transparent rounded-full animate-spin"></div>
                               )}

--- a/frontend/src/components/messaging/MessageIcon.tsx
+++ b/frontend/src/components/messaging/MessageIcon.tsx
@@ -11,16 +11,14 @@ export const MessageIcon: React.FC = () => {
   const [unreadCount, setUnreadCount] = useState(0);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
-  // Fetch unread message count
+  // Fetch unread message count on mount and whenever a new-message WS event fires
   useEffect(() => {
-    // Don't fetch if userType is not set or during account switch
     if (!userType || (userType !== 'customer' && userType !== 'shop') || switchingAccount) {
       return;
     }
 
     const fetchUnreadCount = async () => {
       try {
-        // Use lightweight endpoint instead of fetching all conversations
         const count = await messagingApi.getUnreadCount();
         setUnreadCount(count);
       } catch (err) {
@@ -28,14 +26,12 @@ export const MessageIcon: React.FC = () => {
       }
     };
 
-    // Initial fetch
     fetchUnreadCount();
 
-    // Poll for updates every 10 seconds
-    const pollInterval = setInterval(fetchUnreadCount, 10000);
+    const handleNewMessage = () => fetchUnreadCount();
+    window.addEventListener('new-message-received', handleNewMessage);
 
-    // Cleanup interval on unmount
-    return () => clearInterval(pollInterval);
+    return () => window.removeEventListener('new-message-received', handleNewMessage);
   }, [userType, switchingAccount]);
 
   const buttonRef = React.useRef<HTMLButtonElement>(null);

--- a/frontend/src/components/messaging/MessageIcon.tsx
+++ b/frontend/src/components/messaging/MessageIcon.tsx
@@ -28,10 +28,14 @@ export const MessageIcon: React.FC = () => {
 
     fetchUnreadCount();
 
-    const handleNewMessage = () => fetchUnreadCount();
-    window.addEventListener('new-message-received', handleNewMessage);
+    const handleRefresh = () => fetchUnreadCount();
+    window.addEventListener('new-message-received', handleRefresh);
+    window.addEventListener('conversation-marked-read', handleRefresh);
 
-    return () => window.removeEventListener('new-message-received', handleNewMessage);
+    return () => {
+      window.removeEventListener('new-message-received', handleRefresh);
+      window.removeEventListener('conversation-marked-read', handleRefresh);
+    };
   }, [userType, switchingAccount]);
 
   const buttonRef = React.useRef<HTMLButtonElement>(null);

--- a/frontend/src/components/messaging/MessagesContainer.tsx
+++ b/frontend/src/components/messaging/MessagesContainer.tsx
@@ -6,6 +6,8 @@ import { ConversationThread, type Message } from "./ConversationThread";
 import { MessageCircle, ArrowLeft } from "lucide-react";
 import * as messagingApi from "@/services/api/messaging";
 import { useAuthStore } from "@/stores/authStore";
+import { useConversationPresence } from "@/hooks/useConversationPresence";
+import { messageOutbox } from "@/services/messageOutbox";
 
 interface MessagesContainerProps {
   userType: "customer" | "shop";
@@ -35,6 +37,8 @@ export const MessagesContainer: React.FC<MessagesContainerProps> = ({
   const currentPageRef = useRef(1);
   const [error, setError] = useState<string | null>(null);
   const { switchingAccount } = useAuthStore();
+
+  useConversationPresence(selectedConversationId);
 
   // Fetch conversations from API
   useEffect(() => {
@@ -185,14 +189,78 @@ export const MessagesContainer: React.FC<MessagesContainerProps> = ({
 
     const handleNewMessage = (e: Event) => {
       const ce = e as CustomEvent<{ conversationId?: string }>;
-      if (selectedConversationId && ce.detail?.conversationId === selectedConversationId) {
-        fetchMessages(false);
-      }
+      if (!selectedConversationId || ce.detail?.conversationId !== selectedConversationId) return;
+      fetchMessages(false);
     };
     window.addEventListener('new-message-received', handleNewMessage);
 
     return () => window.removeEventListener('new-message-received', handleNewMessage);
   }, [selectedConversationId, currentUserId, transformMsg]);
+
+  // Subscribe to outbox updates: reconcile optimistic messages with server state.
+  useEffect(() => {
+    messageOutbox.hydrateOnce();
+    const unsub = messageOutbox.subscribe(update => {
+      if (update.conversationId !== selectedConversationId) {
+        // Update conversation preview/unread for other threads if any
+        setConversations(prev =>
+          prev.map(c => {
+            if (c.id !== update.conversationId) return c;
+            if (update.status === 'sent' && update.message) {
+              return {
+                ...c,
+                lastMessage: update.message.messageText,
+                lastMessageTime: update.message.createdAt,
+              };
+            }
+            return c;
+          })
+        );
+        return;
+      }
+
+      setMessages(prev => {
+        if (update.status === 'sent' && update.message) {
+          return prev.map(m =>
+            m.id === update.clientMessageId
+              ? {
+                  ...m,
+                  id: update.message!.messageId,
+                  status: 'delivered',
+                  timestamp: update.message!.createdAt,
+                }
+              : m
+          );
+        }
+        if (update.status === 'failed') {
+          return prev.map(m =>
+            m.id === update.clientMessageId ? { ...m, status: 'failed' } : m
+          );
+        }
+        if (update.status === 'sending') {
+          return prev.map(m =>
+            m.id === update.clientMessageId ? { ...m, status: 'sending' } : m
+          );
+        }
+        return prev;
+      });
+
+      if (update.status === 'sent' && update.message) {
+        setConversations(prev =>
+          prev.map(c =>
+            c.id === update.conversationId
+              ? {
+                  ...c,
+                  lastMessage: update.message!.messageText,
+                  lastMessageTime: update.message!.createdAt,
+                }
+              : c
+          )
+        );
+      }
+    });
+    return unsub;
+  }, [selectedConversationId]);
 
   // Load older messages
   const handleLoadMore = useCallback(async () => {
@@ -260,60 +328,64 @@ export const MessagesContainer: React.FC<MessagesContainerProps> = ({
   const handleSendMessage = async (content: string, attachments?: File[]): Promise<void> => {
     if (!selectedConversationId || (!content.trim() && (!attachments || attachments.length === 0))) return;
 
-    // Upload attachments first if any
+    // Upload attachments first (still blocking — attachments must exist server-side
+    // before the message row references them).
     let uploadedAttachments: messagingApi.MessageAttachment[] = [];
     if (attachments && attachments.length > 0) {
       uploadedAttachments = await messagingApi.uploadAttachments(attachments);
     }
 
-    const newMessage = await messagingApi.sendMessage({
+    // Enqueue via outbox: returns the optimistic placeholder immediately.
+    // The UI appends it right away; the outbox handles the HTTP in the background
+    // and emits 'sent' / 'failed' updates we reconcile in the subscribe effect above.
+    const item = messageOutbox.enqueue({
       conversationId: selectedConversationId,
       messageText: content || '',
-      messageType: "text",
+      messageType: 'text',
       ...(uploadedAttachments.length > 0 && { attachments: uploadedAttachments }),
     });
 
-    // Add the new message to the messages list
-    const transformedMessage: Message = {
-      id: newMessage.messageId,
-      conversationId: newMessage.conversationId,
-      senderId: newMessage.senderAddress,
-      senderName: newMessage.senderName || "You",
-      senderType: newMessage.senderType,
-      content: newMessage.messageText,
-      timestamp: newMessage.createdAt,
-      status: "delivered",
+    const optimistic: Message = {
+      id: item.clientMessageId,
+      conversationId: selectedConversationId,
+      senderId: currentUserId,
+      senderName: 'You',
+      senderType: userType,
+      content: content || '',
+      timestamp: new Date(item.createdAt).toISOString(),
+      status: 'sending',
       isSystemMessage: false,
-      attachments: (newMessage.attachments || []).map((a: any) => ({
-        type: a.type || 'file',
+      attachments: uploadedAttachments.map(a => ({
+        type: (a.type as 'image' | 'file') || 'file',
         url: a.url,
         name: a.name || 'attachment',
       })),
     };
 
-    setMessages((prev) => [...prev, transformedMessage]);
+    setMessages(prev => [...prev, optimistic]);
 
-    // Refresh conversations to update last message preview
-    const response = await messagingApi.getConversations({ page: 1, limit: 50 });
-    const transformedConversations: Conversation[] = response.data.map((conv) => ({
-      id: conv.conversationId,
-      serviceId: "",
-      serviceName: "",
-      shopId: userType === "customer" ? conv.shopId : undefined,
-      shopName: userType === "customer" ? conv.shopName : undefined,
-      customerId: userType === "shop" ? conv.customerAddress : undefined,
-      customerName: userType === "shop" ? conv.customerName : undefined,
-      participantName: userType === "customer" ? (conv.shopName || "Shop") : (conv.customerName || "Customer"),
-      participantAvatar: userType === "customer" ? conv.shopImageUrl : undefined, // Shop logo for customers
-      lastMessage: conv.lastMessagePreview || "",
-      lastMessageTime: conv.lastMessageAt || conv.createdAt,
-      unreadCount: userType === "customer" ? conv.unreadCountCustomer : conv.unreadCountShop,
-      status: conv.isArchivedCustomer || conv.isArchivedShop ? "resolved" : "active",
-      hasAttachment: false,
-      isOnline: false,
-    }));
-    setConversations(transformedConversations);
+    // Update the inbox preview locally rather than refetching every send.
+    setConversations(prev =>
+      prev.map(c =>
+        c.id === selectedConversationId
+          ? {
+              ...c,
+              lastMessage: content || c.lastMessage,
+              lastMessageTime: optimistic.timestamp,
+            }
+          : c
+      )
+    );
   };
+
+  const handleRetryMessage = useCallback((messageId: string) => {
+    messageOutbox.retry(messageId);
+  }, []);
+
+  const handleDiscardMessage = useCallback((messageId: string) => {
+    messageOutbox.discard(messageId);
+    setMessages(prev => prev.filter(m => m.id !== messageId));
+  }, []);
 
   return (
     <div className="h-full flex bg-[#0A0A0A]">
@@ -362,6 +434,8 @@ export const MessagesContainer: React.FC<MessagesContainerProps> = ({
               hasMore={hasMore}
               isLoadingMore={isLoadingMore}
               conversationStatus={selectedConversation.status}
+              onRetryMessage={handleRetryMessage}
+              onDiscardMessage={handleDiscardMessage}
               {...(userType === "shop" && { onArchiveConversation: handleArchiveConversation })}
               conversationDetails={{
                 id: selectedConversation.id,
@@ -418,6 +492,8 @@ export const MessagesContainer: React.FC<MessagesContainerProps> = ({
               hasMore={hasMore}
               isLoadingMore={isLoadingMore}
               conversationStatus={selectedConversation.status}
+              onRetryMessage={handleRetryMessage}
+              onDiscardMessage={handleDiscardMessage}
               {...(userType === "shop" && { onArchiveConversation: handleArchiveConversation })}
               conversationDetails={{
                 id: selectedConversation.id,

--- a/frontend/src/components/messaging/MessagesContainer.tsx
+++ b/frontend/src/components/messaging/MessagesContainer.tsx
@@ -89,16 +89,12 @@ export const MessagesContainer: React.FC<MessagesContainerProps> = ({
       }
     };
 
-    // Initial fetch
     fetchConversations(true);
 
-    // Poll for conversation updates every 5 seconds
-    const pollInterval = setInterval(() => {
-      fetchConversations(false);
-    }, 5000);
+    const handleNewMessage = () => fetchConversations(false);
+    window.addEventListener('new-message-received', handleNewMessage);
 
-    // Cleanup interval on unmount
-    return () => clearInterval(pollInterval);
+    return () => window.removeEventListener('new-message-received', handleNewMessage);
   }, [userType, switchingAccount]);
 
   // Auto-select conversation from prop (passed from URL query param)
@@ -182,18 +178,17 @@ export const MessagesContainer: React.FC<MessagesContainerProps> = ({
       }
     };
 
-    // Initial fetch
     fetchMessages(true);
 
-    // Poll for new messages every 3 seconds
-    const pollInterval = setInterval(() => {
-      if (selectedConversationId) {
+    const handleNewMessage = (e: Event) => {
+      const ce = e as CustomEvent<{ conversationId?: string }>;
+      if (selectedConversationId && ce.detail?.conversationId === selectedConversationId) {
         fetchMessages(false);
       }
-    }, 3000);
+    };
+    window.addEventListener('new-message-received', handleNewMessage);
 
-    // Cleanup interval on unmount or conversation change
-    return () => clearInterval(pollInterval);
+    return () => window.removeEventListener('new-message-received', handleNewMessage);
   }, [selectedConversationId, currentUserId, transformMsg]);
 
   // Load older messages

--- a/frontend/src/components/messaging/MessagesContainer.tsx
+++ b/frontend/src/components/messaging/MessagesContainer.tsx
@@ -169,6 +169,9 @@ export const MessagesContainer: React.FC<MessagesContainerProps> = ({
 
         // Mark conversation as read
         await messagingApi.markConversationAsRead(selectedConversationId);
+        window.dispatchEvent(new CustomEvent('conversation-marked-read', {
+          detail: { conversationId: selectedConversationId }
+        }));
       } catch (err) {
         console.error("Error fetching messages:", err);
       } finally {

--- a/frontend/src/components/shop/bookings/BookingDetailsPanel.tsx
+++ b/frontend/src/components/shop/bookings/BookingDetailsPanel.tsx
@@ -70,6 +70,9 @@ export const BookingDetailsPanel: React.FC<BookingDetailsPanelProps> = ({
       setMessages(transformedMessages);
 
       await messagingApi.markConversationAsRead(conversation.conversationId);
+      window.dispatchEvent(new CustomEvent('conversation-marked-read', {
+        detail: { conversationId: conversation.conversationId }
+      }));
 
       // Auto-send booking_link message if first time for this booking
       const bookingKey = `${booking.orderId}-${conversation.conversationId}`;
@@ -150,6 +153,9 @@ export const BookingDetailsPanel: React.FC<BookingDetailsPanelProps> = ({
         }));
         setMessages(transformedMessages);
         await messagingApi.markConversationAsRead(conversationId);
+        window.dispatchEvent(new CustomEvent('conversation-marked-read', {
+          detail: { conversationId }
+        }));
       } catch (err) {
         // Silent fail on polling
       }

--- a/frontend/src/components/shop/bookings/BookingDetailsPanel.tsx
+++ b/frontend/src/components/shop/bookings/BookingDetailsPanel.tsx
@@ -10,6 +10,7 @@ import * as messagingApi from "@/services/api/messaging";
 import type { QuickReply } from "@/services/api/messaging";
 import { QuickReplyManager } from "@/components/messaging/QuickReplyManager";
 import { useAuthStore } from "@/stores/authStore";
+import { useConversationPresence } from "@/hooks/useConversationPresence";
 
 interface BookingDetailsPanelProps {
   booking: MockBooking | null;
@@ -41,6 +42,8 @@ export const BookingDetailsPanel: React.FC<BookingDetailsPanelProps> = ({
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const prevMessageCountRef = useRef<number>(0);
   const { userProfile } = useAuthStore();
+
+  useConversationPresence(activeTab === 'message' ? conversationId : null);
 
   // Load or create conversation when Message tab is selected
   const loadConversation = useCallback(async () => {

--- a/frontend/src/components/shop/tabs/AppointmentsTab.tsx
+++ b/frontend/src/components/shop/tabs/AppointmentsTab.tsx
@@ -102,9 +102,9 @@ export const AppointmentsTab: React.FC<AppointmentsTabProps> = ({ defaultSubTab 
     fetchCalendarStatus();
     fetchPendingCount();
 
-    // Refresh count every 30 seconds
-    const interval = setInterval(fetchPendingCount, 30000);
-    return () => clearInterval(interval);
+    const handler = () => fetchPendingCount();
+    window.addEventListener('reschedule-count-changed', handler);
+    return () => window.removeEventListener('reschedule-count-changed', handler);
   }, [fetchCalendarStatus, fetchPendingCount]);
 
   // Refresh count when switching away from reschedules tab (user may have approved/rejected)

--- a/frontend/src/components/ui/sidebar/ShopSidebar.tsx
+++ b/frontend/src/components/ui/sidebar/ShopSidebar.tsx
@@ -62,9 +62,9 @@ const ShopSidebar: React.FC<ShopSidebarProps> = ({
 
   useEffect(() => {
     fetchPendingCount();
-    // Refresh count every 30 seconds
-    const interval = setInterval(fetchPendingCount, 30000);
-    return () => clearInterval(interval);
+    const handler = () => fetchPendingCount();
+    window.addEventListener('reschedule-count-changed', handler);
+    return () => window.removeEventListener('reschedule-count-changed', handler);
   }, [fetchPendingCount]);
 
   const {

--- a/frontend/src/hooks/useConversationPresence.ts
+++ b/frontend/src/hooks/useConversationPresence.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react';
+import { sendWS } from '@/utils/wsClient';
+
+/**
+ * Tell the backend which conversation the current user is actively viewing,
+ * so MessageService can suppress email notifications while the recipient is
+ * already looking at the thread.
+ *
+ * - Sends `conversation:open` when `conversationId` becomes truthy/changes.
+ * - Sends `conversation:close` for the previous id on change / unmount.
+ * - On tab hide (visibilitychange), treats as closed; on show, reopens.
+ * - If the WS isn't open yet (e.g. reconnecting), the send is a no-op; the
+ *   backend will see the next successful open. Worst case: one extra email.
+ */
+export function useConversationPresence(conversationId: string | null | undefined): void {
+  const activeIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const id = conversationId || null;
+
+    if (activeIdRef.current && activeIdRef.current !== id) {
+      sendWS({ type: 'conversation:close', payload: { conversationId: activeIdRef.current } });
+    }
+
+    if (id) {
+      sendWS({ type: 'conversation:open', payload: { conversationId: id } });
+    }
+
+    activeIdRef.current = id;
+
+    const handleVisibility = () => {
+      const current = activeIdRef.current;
+      if (!current) return;
+      if (document.visibilityState === 'hidden') {
+        sendWS({ type: 'conversation:close', payload: { conversationId: current } });
+      } else if (document.visibilityState === 'visible') {
+        sendWS({ type: 'conversation:open', payload: { conversationId: current } });
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibility);
+      if (activeIdRef.current) {
+        sendWS({ type: 'conversation:close', payload: { conversationId: activeIdRef.current } });
+        activeIdRef.current = null;
+      }
+    };
+  }, [conversationId]);
+}

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -255,6 +255,14 @@ export const useNotifications = (options: UseNotificationsOptions = {}) => {
               }
               break;
 
+            case 'message:new':
+              if (typeof window !== 'undefined') {
+                window.dispatchEvent(new CustomEvent('new-message-received', {
+                  detail: message.payload
+                }));
+              }
+              break;
+
             default:
               console.warn('Unknown WebSocket message type:', message.type);
           }

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -4,6 +4,7 @@ import { useAuthStore } from '../stores/authStore';
 import apiClient from '@/services/api/client';
 import { usePushSubscription } from './usePushSubscription';
 import { WS_URL } from '@/utils/wsUrl';
+import { setActiveSocket } from '@/utils/wsClient';
 
 interface UseNotificationsOptions {
   enabled?: boolean;
@@ -162,6 +163,7 @@ export const useNotifications = (options: UseNotificationsOptions = {}) => {
       ws.onopen = () => {
         reconnectAttemptsRef.current = 0;
         manuallyClosedRef.current = false;
+        setActiveSocket(ws);
       };
 
       ws.onmessage = (event) => {
@@ -292,6 +294,7 @@ export const useNotifications = (options: UseNotificationsOptions = {}) => {
       ws.onclose = (event) => {
         console.log('🔌 WebSocket disconnected');
         setConnected(false);
+        setActiveSocket(null);
 
         // Don't show error or try to reconnect if we manually closed due to auth issues
         if (manuallyClosedRef.current) {
@@ -338,6 +341,7 @@ export const useNotifications = (options: UseNotificationsOptions = {}) => {
       wsRef.current = null;
     }
 
+    setActiveSocket(null);
     setConnected(false);
   }, [setConnected]);
 

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -187,6 +187,17 @@ export const useNotifications = (options: UseNotificationsOptions = {}) => {
                   icon: '/logo.png',
                 });
               }
+
+              // Companion DOM events for count-driven UI
+              if (typeof window !== 'undefined') {
+                const notificationType = message.payload?.notificationType;
+                if (
+                  notificationType === 'reschedule_request_created' ||
+                  notificationType === 'reschedule_request_expired'
+                ) {
+                  window.dispatchEvent(new CustomEvent('reschedule-count-changed'));
+                }
+              }
               break;
 
             case 'error':

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -3,11 +3,7 @@ import { useNotificationStore, Notification as NotificationType } from '../store
 import { useAuthStore } from '../stores/authStore';
 import apiClient from '@/services/api/client';
 import { usePushSubscription } from './usePushSubscription';
-
-// WebSocket URL - explicitly use api.repaircoin.ai subdomain in production
-const WS_URL = typeof window !== 'undefined' && window.location.hostname.includes('repaircoin.ai')
-  ? 'wss://api.repaircoin.ai'
-  : 'ws://localhost:4000';
+import { WS_URL } from '@/utils/wsUrl';
 
 interface UseNotificationsOptions {
   enabled?: boolean;

--- a/frontend/src/services/api/messaging.ts
+++ b/frontend/src/services/api/messaging.ts
@@ -40,6 +40,7 @@ export interface Message {
   deletedBy?: string;
   createdAt: string;
   updatedAt: string;
+  clientMessageId?: string;
   // Joined data
   senderName?: string;
 }
@@ -61,6 +62,7 @@ export interface SendMessageRequest {
   messageType?: 'text' | 'booking_link' | 'service_link' | 'system';
   metadata?: Record<string, any>;
   attachments?: MessageAttachment[];
+  clientMessageId?: string;
 }
 
 export interface PaginatedResponse<T> {

--- a/frontend/src/services/messageOutbox.ts
+++ b/frontend/src/services/messageOutbox.ts
@@ -1,0 +1,254 @@
+import * as messagingApi from './api/messaging';
+
+/**
+ * Background outbox for sending messages.
+ *
+ * - Optimistic: UI appends the message instantly and subscribes for updates.
+ * - Retries with exponential backoff (1s → 2s → 5s → 15s, max 4 attempts).
+ * - Per-conversation FIFO: next item dispatches only after the prior settles.
+ * - Idempotent on the server via clientMessageId — retries never double-insert.
+ * - Persisted to localStorage so a refresh mid-send doesn't drop the message.
+ * - Subscribers receive status updates; the UI replaces optimistic with
+ *   the canonical server message on success.
+ */
+
+export type OutboxStatus = 'sending' | 'sent' | 'failed';
+
+export interface OutboxPayload {
+  conversationId: string;
+  messageText: string;
+  messageType?: 'text' | 'booking_link' | 'service_link' | 'system';
+  metadata?: Record<string, unknown>;
+  attachments?: messagingApi.MessageAttachment[];
+}
+
+export interface OutboxItem {
+  clientMessageId: string;
+  payload: OutboxPayload;
+  status: OutboxStatus;
+  attempts: number;
+  lastError?: string;
+  createdAt: number;
+}
+
+export interface OutboxUpdate {
+  clientMessageId: string;
+  status: OutboxStatus;
+  conversationId: string;
+  attempts: number;
+  message?: messagingApi.Message;
+  error?: string;
+}
+
+type Listener = (update: OutboxUpdate) => void;
+
+const STORAGE_KEY = 'message_outbox_v1';
+const BACKOFF_MS = [1000, 2000, 5000, 15000];
+const MAX_ATTEMPTS = BACKOFF_MS.length;
+
+class MessageOutbox {
+  private items: Map<string, OutboxItem> = new Map();
+  private queueByConv: Map<string, string[]> = new Map();
+  private dispatching: Set<string> = new Set();
+  private listeners: Set<Listener> = new Set();
+  private hydrated = false;
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  getPending(conversationId: string): OutboxItem[] {
+    const ids = this.queueByConv.get(conversationId) || [];
+    return ids.map(id => this.items.get(id)!).filter(Boolean);
+  }
+
+  enqueue(payload: OutboxPayload): OutboxItem {
+    this.hydrateOnce();
+    const clientMessageId = generateId();
+    const item: OutboxItem = {
+      clientMessageId,
+      payload,
+      status: 'sending',
+      attempts: 0,
+      createdAt: Date.now(),
+    };
+    this.items.set(clientMessageId, item);
+
+    const ids = this.queueByConv.get(payload.conversationId) || [];
+    ids.push(clientMessageId);
+    this.queueByConv.set(payload.conversationId, ids);
+
+    this.persist();
+    this.kick(payload.conversationId);
+    return item;
+  }
+
+  retry(clientMessageId: string): void {
+    const item = this.items.get(clientMessageId);
+    if (!item || item.status === 'sent') return;
+    item.status = 'sending';
+    item.attempts = 0;
+    item.lastError = undefined;
+
+    const ids = this.queueByConv.get(item.payload.conversationId) || [];
+    if (!ids.includes(clientMessageId)) {
+      ids.unshift(clientMessageId);
+      this.queueByConv.set(item.payload.conversationId, ids);
+    }
+
+    this.emit({
+      clientMessageId,
+      status: 'sending',
+      conversationId: item.payload.conversationId,
+      attempts: 0,
+    });
+
+    this.persist();
+    this.kick(item.payload.conversationId);
+  }
+
+  discard(clientMessageId: string): void {
+    const item = this.items.get(clientMessageId);
+    if (!item) return;
+    this.items.delete(clientMessageId);
+    const ids = this.queueByConv.get(item.payload.conversationId) || [];
+    this.queueByConv.set(
+      item.payload.conversationId,
+      ids.filter(id => id !== clientMessageId),
+    );
+    this.persist();
+  }
+
+  private async kick(conversationId: string): Promise<void> {
+    if (this.dispatching.has(conversationId)) return;
+    const next = this.peekNext(conversationId);
+    if (!next) return;
+    this.dispatching.add(conversationId);
+    try {
+      await this.dispatch(next);
+    } finally {
+      this.dispatching.delete(conversationId);
+      if (this.peekNext(conversationId)) this.kick(conversationId);
+    }
+  }
+
+  private peekNext(conversationId: string): OutboxItem | null {
+    const ids = this.queueByConv.get(conversationId) || [];
+    for (const id of ids) {
+      const item = this.items.get(id);
+      if (item && item.status === 'sending') return item;
+    }
+    return null;
+  }
+
+  private async dispatch(item: OutboxItem): Promise<void> {
+    while (item.attempts < MAX_ATTEMPTS) {
+      item.attempts += 1;
+      try {
+        const message = await messagingApi.sendMessage({
+          conversationId: item.payload.conversationId,
+          messageText: item.payload.messageText,
+          messageType: item.payload.messageType,
+          metadata: item.payload.metadata,
+          attachments: item.payload.attachments,
+          clientMessageId: item.clientMessageId,
+        });
+
+        item.status = 'sent';
+        this.emit({
+          clientMessageId: item.clientMessageId,
+          status: 'sent',
+          conversationId: item.payload.conversationId,
+          attempts: item.attempts,
+          message,
+        });
+        this.removeFromQueue(item);
+        this.persist();
+        return;
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Send failed';
+        item.lastError = message;
+        if (item.attempts >= MAX_ATTEMPTS) {
+          item.status = 'failed';
+          this.emit({
+            clientMessageId: item.clientMessageId,
+            status: 'failed',
+            conversationId: item.payload.conversationId,
+            attempts: item.attempts,
+            error: message,
+          });
+          this.persist();
+          return;
+        }
+        await sleep(BACKOFF_MS[item.attempts - 1]);
+      }
+    }
+  }
+
+  private removeFromQueue(item: OutboxItem): void {
+    const ids = this.queueByConv.get(item.payload.conversationId) || [];
+    this.queueByConv.set(
+      item.payload.conversationId,
+      ids.filter(id => id !== item.clientMessageId),
+    );
+  }
+
+  private emit(update: OutboxUpdate): void {
+    this.listeners.forEach(listener => {
+      try {
+        listener(update);
+      } catch {
+        /* swallow listener errors */
+      }
+    });
+  }
+
+  private persist(): void {
+    if (typeof window === 'undefined') return;
+    const data = Array.from(this.items.values()).filter(item => item.status !== 'sent');
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch {
+      /* ignore quota errors */
+    }
+  }
+
+  hydrateOnce(): void {
+    if (this.hydrated || typeof window === 'undefined') return;
+    this.hydrated = true;
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const saved = JSON.parse(raw) as OutboxItem[];
+      saved.forEach(item => {
+        this.items.set(item.clientMessageId, item);
+        const ids = this.queueByConv.get(item.payload.conversationId) || [];
+        ids.push(item.clientMessageId);
+        this.queueByConv.set(item.payload.conversationId, ids);
+      });
+      const resumable = new Set(saved.map(s => s.payload.conversationId));
+      resumable.forEach(convId => {
+        const next = this.peekNext(convId);
+        if (next) this.kick(convId);
+      });
+    } catch {
+      /* ignore parse errors — just start fresh */
+    }
+  }
+}
+
+function generateId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `cm_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export const messageOutbox = new MessageOutbox();

--- a/frontend/src/utils/wsClient.ts
+++ b/frontend/src/utils/wsClient.ts
@@ -1,0 +1,15 @@
+let activeSocket: WebSocket | null = null;
+
+export function setActiveSocket(ws: WebSocket | null): void {
+  activeSocket = ws;
+}
+
+export function sendWS(message: { type: string; payload?: unknown }): boolean {
+  if (!activeSocket || activeSocket.readyState !== WebSocket.OPEN) return false;
+  try {
+    activeSocket.send(JSON.stringify(message));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/utils/wsUrl.ts
+++ b/frontend/src/utils/wsUrl.ts
@@ -1,0 +1,9 @@
+const apiUrl = new URL(
+  process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000/api",
+);
+apiUrl.protocol = apiUrl.protocol === "https:" ? "wss:" : "ws:";
+apiUrl.pathname = "";
+apiUrl.search = "";
+
+export const WS_URL =
+  process.env.NEXT_PUBLIC_WS_URL || apiUrl.toString().replace(/\/$/, "");


### PR DESCRIPTION
When a new message is sent, the recipient now gets a Web Push notification alongside the existing WebSocket unread badge and (for customer→shop) email. Covers the "tab is backgrounded or closed" gap.

- WebPushService.sendNewMessageNotification builds a MESSAGES-channel push keyed by a per-conversation tag, with a receiver-type-aware route in data.route so the service worker deep-links straight to
  the thread.
- MessageService.sendMessage fires the push between the email block and the WebSocket emit, reusing the existing receiverAddress and presence gate — if the recipient is actively viewing the thread we skip the push (same rule as email). Fire-and-forget, so the
  HTTP response doesn't wait on web push delivery.
- Sender avatar in the notification: MessageRepository joins customers.profile_image_url as customer_image_url on the queries used for sendMessage and shop inbox, so the push payload carries shop.logo_url for shop senders and customers.profile_image_url
  for customer senders.
- Service worker (sw.js) honours data.icon for the small icon, a new data.tag for per-conversation dedup, and also sets image: heroImage so Chromium/Edge/Firefox render the logo as a large hero banner under the text. Falls back to the favicon when no avatar exists.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>