### PR TITLE
Tavie/dev

### DIFF
--- a/backend/docs/plans/auto-suspension-lift.md
+++ b/backend/docs/plans/auto-suspension-lift.md
@@ -1,0 +1,183 @@
+# Auto-Lift No-Show Suspensions
+
+## Context
+
+The customer no-show penalty system escalates a customer to `no_show_tier = 'suspended'` once their `no_show_count` crosses a shop's `suspension_threshold` (default 5), and sets `booking_suspended_until` to `NOW() + suspension_duration_days` (default 30 days). This tier escalation is handled by a DB trigger (`backend/migrations/065_recreate_no_show_tables.sql:192-238`) that fires on `INSERT INTO no_show_history`.
+
+**Problem:** there is currently no mechanism to *lift* suspension when `booking_suspended_until` elapses. The DB row stays frozen at `tier='suspended'` with a past-date `booking_suspended_until` forever. Consequences:
+
+- `frontend/src/components/customer/NoShowWarningBanner.tsx:54` switches purely on `tier === 'suspended'` and keeps rendering the gray "Account Temporarily Suspended" banner indefinitely, displaying a past date.
+- `backend/src/services/NoShowPolicyService.ts:270` computes `canBook = booking_suspended_until > NOW()` at read time, so the customer *can* technically book — creating a UX contradiction with the banner.
+- `EmailService.ts:1374` already tells customers "Suspension automatically lifts on ${suspensionEndDate}" and promises a `deposit_required` state with a refundable deposit and 48h advance booking — a promise the code doesn't keep.
+- Analytics queries counting `tier='suspended'` customers (`NoShowPolicyService.ts:490-493`) overstate the real number.
+
+**Outcome:** when `booking_suspended_until` passes, the customer should be automatically moved to the correct lower tier based on their remaining `no_show_count`, with `booking_suspended_until` cleared and a notification sent.
+
+## Approach
+
+Add a new scheduled service `SuspensionLiftService` that polls every 15 minutes for suspended customers whose timer has expired, downgrades them to the appropriate tier, and notifies them. Mirrors the existing `AutoNoShowDetectionService` pattern exactly.
+
+**Target tier after lift** (cascade based on current `no_show_count` using default thresholds — same approach as `NoShowPolicyService.getOverallCustomerStatus`):
+
+| `no_show_count` | New `no_show_tier` | `deposit_required` |
+|---|---|---|
+| `>= 3` (deposit threshold) | `deposit_required` | `TRUE` |
+| `= 2` (caution threshold)  | `caution` | `FALSE` |
+| `= 1` | `warning` | `FALSE` |
+| `0` | `normal` | `FALSE` |
+
+`no_show_count` is **not** reduced — the lift is time-served, not forgiveness. The customer must then complete successful appointments to drop further, handled by the existing `NoShowPolicyService.recordSuccessfulAppointment()` → `checkTierReset()` flow (lines 392-428). Realistic case after a fresh suspension: count is still ≥ 5, so the target is always `deposit_required`.
+
+Why a cron (not lazy-on-read): the existing code already lazy-computes `canBook` at read time, which proves lazy isn't sufficient — the banner, analytics, and reports all see the stale tier. A cron keeps DB state truthful for every reader with no per-call-site patching.
+
+## Files to Create
+
+### 1. `backend/src/services/SuspensionLiftService.ts`
+
+Class mirroring `AutoNoShowDetectionService` structure (`backend/src/services/AutoNoShowDetectionService.ts:58-77, 515-579`):
+
+- Constructor instantiates `NotificationService` and holds `getSharedPool()` for DB access.
+- `processSuspensionLifts()`: single UPDATE with RETURNING — atomic and idempotent:
+  ```sql
+  UPDATE customers
+  SET
+    no_show_tier = CASE
+      WHEN no_show_count >= 3 THEN 'deposit_required'
+      WHEN no_show_count >= 2 THEN 'caution'
+      WHEN no_show_count = 1 THEN 'warning'
+      ELSE 'normal'
+    END,
+    deposit_required = (no_show_count >= 3),
+    booking_suspended_until = NULL,
+    successful_appointments_since_tier3 = 0,
+    updated_at = NOW()
+  WHERE no_show_tier = 'suspended'
+    AND booking_suspended_until IS NOT NULL
+    AND booking_suspended_until <= NOW()
+  RETURNING address, no_show_count, no_show_tier;
+  ```
+  Thresholds 2/3 match `getDefaultPolicy()` (NoShowPolicyService.ts:141-170) and `DisputeController.reverseNoShowPenalty` defaults (DisputeController.ts:723-732). `successful_appointments_since_tier3 = 0` resets the counter so `checkTierReset()` starts fresh from `deposit_required`.
+- For each RETURNING row, call `NotificationService.createNotification` with `notificationType: 'suspension_lifted'`, following the pattern at `AutoNoShowDetectionService.ts:187-227`. Notification failures are caught and logged; they do not roll back the lift.
+- `start()` / `stop()` / `getStatus()` identical to `AutoNoShowDetectionService:515-579` but with `INTERVAL_MS = 15 * 60 * 1000` (15 minutes — finer than 30m because suspension deadlines aren't aligned to cron boundaries).
+- `start()` runs `processSuspensionLifts()` once immediately, then on interval.
+- Report object `{ timestamp, customersChecked, customersLifted, notificationsSent, errors[] }` — matches `AutoDetectionReport` shape.
+
+## Files to Modify
+
+### 2. `backend/src/app.ts` (around line 755)
+
+After the `getAutoNoShowDetectionService().start()` block, add:
+
+```ts
+const suspensionLiftEnabled = process.env.SUSPENSION_LIFT_ENABLED !== 'false';
+if (suspensionLiftEnabled) {
+  getSuspensionLiftService().start();
+  logger.info('Suspension lift service started (every 15 minutes)');
+} else {
+  logger.info('Suspension lift service DISABLED via SUSPENSION_LIFT_ENABLED=false');
+}
+```
+
+Feature-flag convention matches `AUTO_DETECTION_ENABLED` (app.ts:753). Import the service via a singleton accessor like `getSuspensionLiftService()` to mirror `getAutoNoShowDetectionService()`.
+
+### 3. `frontend/src/components/customer/NoShowWarningBanner.tsx:54` (safety net)
+
+Cron runs every 15 min, so there's a window where `booking_suspended_until < NOW()` but `tier` is still `'suspended'`. Add a client-side guard to suppress the suspended banner in that window:
+
+```tsx
+case 'suspended':
+  const suspendedUntil = status.bookingSuspendedUntil
+    ? new Date(status.bookingSuspendedUntil)
+    : null;
+  if (suspendedUntil && suspendedUntil <= new Date()) {
+    return null; // cron will reconcile tier on next run
+  }
+  // ...existing suspended config
+```
+
+This avoids showing a gray "suspended until [past date]" banner during the up-to-15-min reconciliation window.
+
+### 4. `deposit_required` banner copy alignment
+
+After the cron moves a customer from `suspended` → `deposit_required`, the banner is the user-facing result of this feature. Update banner copy and restriction text so the post-lift state reads cleanly:
+
+**Frontend (`frontend/src/components/customer/NoShowWarningBanner.tsx:49-50`):**
+- Title: `'Refundable Deposit Required'` → `'Deposit Required - Account Restricted'`
+- Message: `'Due to X missed appointments, you must now pay a refundable deposit for all bookings:'` → `'Due to X missed appointments, the following restrictions apply:'`
+
+**Backend (`backend/src/services/NoShowPolicyService.ts`):** align the shop-agnostic `getOverallCustomerStatus` (line 280-284) deposit-required restrictions with the (already-correct) shop-scoped `getCustomerStatus` (line 212-216), and format `depositAmount` with `.toFixed(2)` in both paths:
+
+```ts
+// getOverallCustomerStatus — replace existing three push() calls:
+restrictions.push(`Must book at least ${defaultPolicy.depositAdvanceBookingHours} hours in advance`);
+restrictions.push(`$${defaultPolicy.depositAmount.toFixed(2)} refundable deposit required`);
+restrictions.push(`Maximum ${defaultPolicy.maxRcnRedemptionPercent}% RCN redemption`);
+```
+
+```ts
+// getCustomerStatus — only the middle push() needs the format fix:
+restrictions.push(`$${policy.depositAmount.toFixed(2)} refundable deposit required`);
+```
+
+Rendered result for a customer with `no_show_count=5` after suspension lifts:
+- Title: `Deposit Required - Account Restricted`
+- Message: `Due to 5 missed appointments, the following restrictions apply:`
+- Bullets (in order):
+  - `Must book at least 48 hours in advance`
+  - `$25.00 refundable deposit required`
+  - `Maximum 80% RCN redemption`
+
+## Files to Reference (Reused, Not Modified)
+
+- `backend/src/services/AutoNoShowDetectionService.ts:510-579` — `start()` / `stop()` / `getStatus()` template to copy.
+- `backend/src/services/NoShowPolicyService.ts:141-170` — `getDefaultPolicy()` thresholds source (caution=2, deposit=3, suspension=5).
+- `backend/src/domains/notification/services/NotificationService.ts` — `createNotification()` for `'suspension_lifted'` notification.
+- `backend/src/utils/database-pool.ts` — `getSharedPool()` to avoid connection exhaustion.
+- `backend/src/utils/logger.ts` — `logger.info/error` for structured logs.
+
+## Out of Scope (deferred)
+
+- **Email notification** (`EmailService.sendSuspensionLifted`) — the in-app notification is sufficient for v1. Email can be added later using `EmailService.ts:1374+` as a template.
+- **Per-shop tier lookup** — current DB schema doesn't track which shop's policy caused the suspension, so we apply the global default thresholds. This matches the existing `getOverallCustomerStatus` precedent.
+- **Backfill of existing stale rows** — the first cron run will naturally catch any already-expired suspensions, so no separate migration needed.
+
+## Verification
+
+1. **Seed a test customer with expired suspension** (DB):
+   ```sql
+   UPDATE customers
+   SET no_show_count = 5,
+       no_show_tier = 'suspended',
+       booking_suspended_until = NOW() - INTERVAL '1 hour',
+       deposit_required = TRUE
+   WHERE LOWER(address) = LOWER('0xTEST_WALLET');
+   ```
+
+2. **Run the service manually** via a one-off script or by restarting the backend (the service runs immediately on `start()`). Check logs for `Suspension lift service started` and `Lifted N suspensions`.
+
+3. **Verify DB state** after the run:
+   ```sql
+   SELECT address, no_show_count, no_show_tier, booking_suspended_until, deposit_required
+   FROM customers WHERE LOWER(address) = LOWER('0xTEST_WALLET');
+   -- Expect: tier='deposit_required', booking_suspended_until=NULL, deposit_required=TRUE, count=5
+   ```
+
+4. **Verify notification** was created:
+   ```sql
+   SELECT * FROM notifications
+   WHERE LOWER(receiver_address) = LOWER('0xTEST_WALLET')
+     AND notification_type = 'suspension_lifted'
+   ORDER BY created_at DESC LIMIT 1;
+   ```
+
+5. **Verify frontend**: reload customer dashboard — banner should now show red "Refundable Deposit Required" (deposit_required tier) instead of gray "Suspended".
+
+6. **Edge-case tests** (mirror `backend/tests/shop/shop.dispute-tier-recalculation.test.ts` structure, create `backend/tests/services/suspension-lift.test.ts`):
+   - Customer with `booking_suspended_until` in the future → untouched.
+   - Customer with `booking_suspended_until = NULL` + `tier='suspended'` (anomalous state) → untouched.
+   - Customer with `tier='deposit_required'` + past `booking_suspended_until` → untouched (only `suspended` tier is lifted).
+   - Cascade matrix: count 5→deposit_required, count 2→caution, count 1→warning, count 0→normal.
+   - Notification is created per lifted customer.
+   - Notification failure does not prevent DB update (mock `createNotification` to throw).
+
+7. **Idempotency check**: run the service twice in a row — second run should report `customersLifted: 0`.

--- a/backend/docs/workflows/booking-flow.md
+++ b/backend/docs/workflows/booking-flow.md
@@ -1,0 +1,110 @@
+# Booking Flow — Customer Order Lifecycle
+
+## Overview
+
+A service booking moves through six stages: **payment intent created → pre-booking validation → Stripe payment confirmed → order row inserted → notifications dispatched → order completed**. The `service_orders` row is NOT written until Stripe confirms the payment, so there is no `pending` status in the DB — orders start life at `paid`. Shop manually marks the order `completed` after the appointment, which triggers event publication, RCN rewards, group tokens, and (for customers with no-show history) a tier cascade check.
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+  participant Customer
+  participant FE as Frontend (ServiceCheckoutModal)
+  participant OC as OrderController
+  participant PS as PaymentService
+  participant Stripe
+  participant OR as OrderRepository
+  participant NS as NotificationService
+
+  Customer->>FE: pick service, date, time, notes
+  FE->>OC: POST /api/services/orders/create-payment-intent
+  OC->>PS: createPaymentIntent(serviceId, bookingDate, bookingTime, rcnToRedeem)
+  PS->>PS: validate (blocked? tier allows booking? advance hours? slot free?)
+  PS->>Stripe: stripe.paymentIntents.create(metadata)
+  Stripe-->>PS: client_secret
+  PS-->>FE: client_secret
+  FE->>Stripe: confirmCardPayment(client_secret)
+  Stripe-->>FE: payment succeeded
+  Stripe->>PS: webhook payment_intent.succeeded
+  PS->>OR: createOrder(status='paid', shop_approved=true)
+  PS->>NS: createNotification 'service_booking_received' (shop)
+  PS->>NS: emails: new booking, payment received, new customer
+  Note over PS: later — shop presses "Mark Complete"
+  Customer->>OC: PUT /api/services/orders/:id/status { status: 'completed' }
+  OC->>OR: updateOrderStatus(id, 'completed')
+  OC->>OC: EventBus.publish 'service.order_completed' → RCN rewards, group tokens
+  OC->>NS: createNotification 'service_order_completed' (customer)
+  OC->>NoShowPolicyService: recordSuccessfulAppointment(customer)
+  Note right of OC: May cascade tier drop + tier_restored notification
+```
+
+## Stage-by-Stage
+
+### Stage 1 — Create payment intent
+
+- **Entry point:** `frontend/src/components/customer/ServiceCheckoutModal.tsx` posts to `createPaymentIntent()` in `frontend/src/services/api/services.ts:313`.
+- **Route:** `POST /api/services/orders/create-payment-intent`.
+- **Handler:** `backend/src/domains/ServiceDomain/controllers/OrderController.ts:39` (`createPaymentIntent`) — customer auth required, delegates to `PaymentService.createPaymentIntent` at line 61.
+
+### Stage 2 — Pre-booking validation
+
+All in `backend/src/domains/ServiceDomain/services/PaymentService.ts:125`:
+
+| Check | Lines | Failure |
+|---|---|---|
+| Service exists + active | 128–135 | 404 / service unavailable |
+| Customer blocked by shop | 137–142 | 403 |
+| Customer no-show tier allows booking | 144–154 | 403 with suspension message if `!customerStatus.canBook` |
+| Advance-hours requirement | 198 | `Math.max(config.minBookingHours, customerStatus.minimumAdvanceHours)` — tier floor applies |
+| Slot capacity | 180–187 | 409 / slot full |
+| Minimum notice | 189–195 | 400 |
+
+If any fail, no Stripe intent is created. No DB row exists yet — the intent lives only in Stripe's metadata.
+
+### Stage 3 — Payment confirmation (webhook)
+
+- **Route:** `POST /api/services/webhooks/stripe` — raw body, `STRIPE_WEBHOOK_SECRET` verification.
+- **Handler:** `PaymentService.handlePaymentSuccess()` at `backend/src/domains/ServiceDomain/services/PaymentService.ts:561`.
+- **Idempotency:** line 567–575 — if an order already exists for this `paymentIntentId`, returns it instead of inserting a duplicate.
+- **Insert:** line 607 — `OrderRepository.createOrder()` writes the `service_orders` row with `status='paid'`, `shop_approved=true`, `approvedAt=NOW()`, booking date/time, Stripe payment intent id, and amounts.
+
+### Stage 4 — RCN redemption (optional)
+
+If the customer opted to redeem RCN on the booking: `PaymentService.ts:636–658` calls `RcnRedemptionService.processRedemption()` which decrements their balance and writes a transaction row.
+
+### Stage 5 — Notifications dispatched
+
+- `service_booking_received` notification sent to the shop address (`PaymentService.ts:660–680`).
+- Shop email: `sendNewBookingNotification()` — gated on preferences (`PaymentService.ts:685–724`).
+- Shop email: `sendPaymentReceivedNotification()` — skipped when the order was 100% RCN-paid.
+- Shop email: `sendNewCustomerNotification()` — only if this is the customer's first order at this shop (line 726–757).
+- Customer email: `sendBookingConfirmation()` via `AppointmentReminderService` (line 759–767).
+- Google Calendar event created if the shop has Calendar connected (line 769–800).
+
+### Stage 6 — Completion
+
+- **Route:** `PUT /api/services/orders/:orderId/status` with `{ status: 'completed' }`.
+- **Handler:** `OrderController.updateOrderStatus()` at `backend/src/domains/ServiceDomain/controllers/OrderController.ts:300`.
+- **Auth:** shop owner only (line 302–305).
+- **Checks:** order belongs to this shop (line 321–328); order not already past the 24-hour completion window (line 331–348).
+- **Transition:** `OrderRepository.updateOrderStatus(id, 'completed')` sets `status='completed'` and `completed_at=NOW()`.
+- **Event:** `EventBus.publish('service.order_completed')` at line 355–367 — subscribers include the RCN rewards system and the group-token issuer (`issueGroupTokensForService()` at line 375).
+- **Notification:** `service_order_completed` to customer (line 389), after a 2-second delay to allow RCN minting to settle.
+- **Tier cascade check:** `NoShowPolicyService.recordSuccessfulAppointment(customerAddress)` at line 449–460. If the customer is on a penalized tier (`deposit_required`, `caution`, or `warning`) and the counter crosses `shop_no_show_policy.deposit_reset_after_successful` (default 3), they drop one tier and receive a `tier_restored` notification. See [no-show-flow.md](./no-show-flow.md#tier-de-escalation).
+- **Deposit refund:** if metadata marked `requiresDeposit=true`, partial Stripe refund is issued (`OrderController.ts:422–449`).
+
+## Key Design Decisions
+
+- **No `pending` status in DB.** Stripe failures leave nothing behind. This is by design — avoids garbage-collecting abandoned rows and simplifies `service_orders` queries. See `PaymentService.ts:123` comment.
+- **Idempotent webhook.** Stripe may redeliver. The dedupe on `stripe_payment_intent_id` prevents duplicate orders.
+- **Shop-manual completion.** There is no auto-completion; the shop must press "Mark Complete". Shops that forget will not issue RCN rewards. Auto-detection only covers no-shows, not completions.
+
+## Notifications Emitted
+
+| Type | Sender | Receiver | When | File:line |
+|---|---|---|---|---|
+| `service_booking_received` | SYSTEM | Shop | On payment success | `PaymentService.ts:667` |
+| `service_order_completed` | SYSTEM | Customer | On shop mark-complete | `OrderController.ts:389` |
+| `tier_restored` | SYSTEM | Customer | On cascade tier drop during completion | `NoShowPolicyService.ts` (`sendTierRestoredNotification`) |
+
+Emails (preference-gated, sent via `EmailService`): `sendNewBookingNotification`, `sendPaymentReceivedNotification`, `sendNewCustomerNotification`, `sendBookingConfirmation`.

--- a/backend/docs/workflows/dispute-flow.md
+++ b/backend/docs/workflows/dispute-flow.md
@@ -1,0 +1,121 @@
+# Dispute Flow — Contesting a No-Show
+
+## Overview
+
+A customer marked as no-show may contest the record. If the shop's policy has `auto_approve_first_offense=true` and this is the customer's first or second no-show at the shop, the dispute is approved and reversed immediately without shop review. Otherwise the dispute enters `pending` state and waits for the shop (or an admin) to approve or reject it. Approval marks the `no_show_history` row as reversed, recomputes the customer's `effective_count` excluding reversed rows, and re-tiers accordingly.
+
+## Dispute Window
+
+- **Column:** `shop_no_show_policy.dispute_window_days` (default 7).
+- **Enforcement:** `DisputeController.ts:145–156`. If `NOW() - marked_no_show_at > dispute_window_days`, submission is rejected with `403`.
+- **Rationale:** bounds the period during which shops must retain enough context to adjudicate.
+
+## Auto-Approve First Offense
+
+- **Policy flag:** `shop_no_show_policy.auto_approve_first_offense` (default `true`).
+- **Check:** `DisputeController.ts:158–188`. Counts the customer's total no-show records at this shop; if ≤ 1 (i.e., the record under dispute is their 1st or 2nd), the dispute is auto-approved.
+- **Effect:** `dispute_status='approved'`, `dispute_resolved_by='system_auto'`, `dispute_resolution_notes='Auto-approved: first offense policy'`. Immediately calls `reverseNoShowPenalty()` (line 194).
+
+## Sequence — Auto-Approve Path
+
+```mermaid
+sequenceDiagram
+  participant Customer
+  participant FE as Frontend (DisputeModal)
+  participant DC as DisputeController
+  participant DB
+  participant ES as EmailService
+
+  Customer->>FE: click "Dispute" on no-show entry, enter reason
+  FE->>DC: POST /api/services/orders/:orderId/dispute { reason }
+  DC->>DB: SELECT no_show_history row for order+customer
+  DC->>DB: SELECT shop_no_show_policy (allow_disputes? window? auto-approve?)
+  DC->>DC: window check, dedup check, reason min-length check
+  DC->>DB: COUNT no-shows for customer at this shop
+  Note over DC: totalNoShows ≤ 1 ⇒ first offense
+  DC->>DB: UPDATE no_show_history SET disputed=true, dispute_status='approved', dispute_resolved_at=NOW(), dispute_resolved_by='system_auto'
+  DC->>DC: reverseNoShowPenalty(pool, customerAddress, shopId, noShowHistoryId)
+  DC->>DB: UPDATE no_show_history SET notes = notes || ' [DISPUTE_REVERSED]'
+  DC->>DB: SELECT effective_count FROM no_show_history WHERE notes NOT LIKE '%[DISPUTE_REVERSED]%'
+  DC->>DB: UPDATE customers SET no_show_count=effective, no_show_tier=recomputed, booking_suspended_until, deposit_required
+  DC->>ES: sendDisputeResolved(resolution='approved', autoApproved=true)
+  DC-->>FE: { success: true, autoApproved: true }
+```
+
+## Sequence — Manual Review Path
+
+```mermaid
+sequenceDiagram
+  participant Customer
+  participant FE as Customer Frontend
+  participant SD as Shop Dispute Dashboard
+  participant DC as DisputeController
+  participant DB
+  participant ES as EmailService
+
+  Customer->>FE: submit dispute (reason)
+  FE->>DC: POST /api/services/orders/:orderId/dispute
+  DC->>DB: UPDATE no_show_history SET dispute_status='pending', dispute_submitted_at=NOW()
+  DC-->>FE: { success: true, autoApproved: false }
+
+  Note over SD: Shop reviews in dispute dashboard
+  alt approve
+    SD->>DC: PUT /api/services/shops/:shopId/disputes/:id/approve { resolutionNotes? }
+    DC->>DB: UPDATE no_show_history SET dispute_status='approved', dispute_resolved_by=shopAddress
+    DC->>DC: reverseNoShowPenalty(...)
+    DC->>ES: sendDisputeResolved(resolution='approved')
+  else reject
+    SD->>DC: PUT /api/services/shops/:shopId/disputes/:id/reject { resolutionNotes }
+    DC->>DB: UPDATE no_show_history SET dispute_status='rejected', dispute_resolved_by=shopAddress
+    Note right of DC: no penalty reversal; no-show stands
+    DC->>ES: sendDisputeResolved(resolution='rejected')
+  end
+```
+
+## `reverseNoShowPenalty` Mechanics
+
+Function at `backend/src/domains/ServiceDomain/controllers/DisputeController.ts:677–752`. Module-private. Called from:
+
+- `submitDispute` (line 194) — when auto-approved on first offense.
+- `approveDispute` (line 404) — on shop approval of a pending dispute.
+- `adminResolveDispute` (line 655) — on admin resolution of any dispute.
+
+Steps:
+
+1. **Mark, don't delete** (line 685–689): append `[DISPUTE_REVERSED]` to the record's `notes`. The row stays for audit.
+2. **Recompute effective count** (line 691–698): `SELECT COUNT(*) FROM no_show_history WHERE customer_address = ? AND (notes IS NULL OR notes NOT LIKE '%[DISPUTE_REVERSED]%')`.
+3. **Look up this shop's policy thresholds** (line 705–733). Fall back to defaults (caution=2, deposit=3, suspension=5, suspension_duration=30 days) if the shop has no policy row.
+4. **Re-tier** from `effective_count`. If the new tier is `suspended`, compute a fresh `booking_suspended_until`.
+5. **UPDATE** `customers` with the new `no_show_count` (= effective), new `no_show_tier`, new `booking_suspended_until`, and `deposit_required = (tier in ['deposit_required','suspended'])`.
+
+This is the **only** path that decrements `no_show_count`. Cascade reset and suspension auto-lift both preserve the count as lifetime history.
+
+## Admin Override
+
+`adminResolveDispute` at `DisputeController.ts:600` bypasses the shop-review requirement and lets an admin approve or reject on the shop's behalf. Same reversal mechanics.
+
+## Endpoints
+
+| Endpoint | Handler | Auth |
+|---|---|---|
+| `POST /api/services/orders/:orderId/dispute` | `submitDispute` | Customer |
+| `PUT /api/services/shops/:shopId/disputes/:id/approve` | `approveDispute` | Shop owner or admin |
+| `PUT /api/services/shops/:shopId/disputes/:id/reject` | `rejectDispute` | Shop owner or admin |
+| `GET /api/services/shops/:shopId/disputes` | `getShopDisputes` | Shop owner or admin |
+| `GET /api/admin/disputes` | `getAdminDisputes` | Admin only |
+
+## Notifications
+
+Currently **email-only** — no in-app notification is emitted for dispute submission, approval, or rejection. Customers receive:
+
+| Email | Trigger | File:line |
+|---|---|---|
+| `sendDisputeResolved` (approved, auto) | Auto-approved first offense | `DisputeController.ts:199–235` |
+| `sendDisputeResolved` (approved, manual) | Shop approves | `DisputeController.ts:408–425` |
+| `sendDisputeResolved` (rejected) | Shop rejects | `DisputeController.ts:500–517` |
+
+**Future work:** an in-app `dispute_resolved` notification type. Not emitted today; `notifications` table rows are not written from any dispute path.
+
+## Historical Bug
+
+`DisputeController.ts:696` previously read `nocctes NOT LIKE` instead of `notes NOT LIKE`. Any dispute approval would throw `column "nocctes" does not exist` at runtime. Fixed; a static regression test in `backend/tests/services/dispute-reversal.test.ts` guards against reintroduction.

--- a/backend/docs/workflows/no-show-flow.md
+++ b/backend/docs/workflows/no-show-flow.md
@@ -1,0 +1,132 @@
+# No-Show Flow — Penalty Tier System
+
+## Overview
+
+Customers who miss appointments accrue a `no_show_count` and escalate through a four-step penalty ladder. Each step applies progressively stricter booking rules. Three mechanisms can move a customer back down: cascade reset (earn-back via successful appointments), suspension auto-lift (time-served), and dispute reversal (audit correction).
+
+## Tier Ladder
+
+Defaults from `shop_no_show_policy` (migration `082_create_shop_no_show_policy_and_email_preferences.sql:21`). A shop can override thresholds per its policy row.
+
+| `no_show_count` | Tier | Restrictions |
+|---|---|---|
+| 0 | `normal` | None — full booking privileges |
+| 1 | `warning` | Informational banner only; no enforcement |
+| 2 | `caution` | Must book ≥ 24 h in advance; max 80% RCN redemption |
+| 3–4 | `deposit_required` | Must book ≥ 48 h in advance; $25 refundable deposit per booking; max 80% RCN redemption |
+| ≥ 5 | `suspended` | Booking blocked for 30 days; auto-lifts to `deposit_required` |
+
+Thresholds live in `shop_no_show_policy` columns `caution_threshold`, `deposit_threshold`, `suspension_threshold`. Default values set in `backend/src/services/NoShowPolicyService.ts:141–170` (`getDefaultPolicy`).
+
+## Manual No-Show — Sequence
+
+```mermaid
+sequenceDiagram
+  participant Shop
+  participant FE as Frontend (MarkNoShowModal)
+  participant OC as OrderController
+  participant OR as OrderRepository
+  participant NP as NoShowPolicyService
+  participant DB
+  participant NS as NotificationService
+
+  Shop->>FE: click "Mark No-Show" on paid order
+  FE->>OC: PUT /api/services/orders/:orderId/no-show { notes }
+  OC->>OR: markAsNoShow(orderId, notes)
+  OR->>DB: UPDATE service_orders SET no_show=true
+  OC->>NP: recordNoShowHistory(...)
+  NP->>DB: INSERT INTO no_show_history
+  DB-->>DB: trigger update_customer_no_show_tier AFTER INSERT
+  Note right of DB: increments no_show_count, recomputes tier, sets booking_suspended_until if tier=suspended
+  OC->>NS: createNotification 'service_no_show' (customer)
+  OC->>EmailService: tier-specific email (warning/caution/deposit/suspended)
+```
+
+## Auto-Detection — Sequence
+
+```mermaid
+sequenceDiagram
+  participant Cron as AutoNoShowDetectionService
+  participant DB
+  participant NP as NoShowPolicyService
+  participant NS as NotificationService
+
+  loop every 30 minutes
+    Cron->>DB: SELECT eligible orders (paid, past appointment + grace + delay, shop auto_detection_enabled)
+    DB-->>Cron: [orders]
+    loop per order
+      Cron->>DB: markAsNoShow(orderId, 'Automatically marked...')
+      Cron->>NP: recordNoShowHistory(markedBy='SYSTEM')
+      NP->>DB: INSERT INTO no_show_history
+      DB-->>DB: trigger update_customer_no_show_tier
+      Cron->>NS: createNotification 'service_no_show' (customer, autoDetected=true)
+      Cron->>NS: createNotification 'shop_no_show_auto_detected' (shop)
+      Cron->>EmailService: tier-specific email
+    end
+  end
+```
+
+- **Service:** `backend/src/services/AutoNoShowDetectionService.ts`.
+- **Schedule:** starts on server boot, runs once immediately, then every 30 min (`INTERVAL_MS = 30 * 60 * 1000` at line 536).
+- **Eligibility query** (line 90–137): `status IN ('paid', 'confirmed')`, `booking_date + booking_time + grace_period_minutes + auto_detection_delay_hours < NOW()`, shop has `auto_detection_enabled=true`.
+- **Defaults:** 15 min grace + 2 h delay = 2 h 15 min wait past appointment.
+
+## Tier Escalation
+
+The trigger at `backend/migrations/065_recreate_no_show_tables.sql:192–238` (`update_customer_no_show_tier`) fires **AFTER INSERT on `no_show_history`** only. It:
+
+1. Reads the shop's policy (or defaults if none).
+2. Recomputes `no_show_tier` from the current `customers.no_show_count` vs thresholds.
+3. If the new tier is `suspended`, sets `booking_suspended_until = NOW() + suspension_duration_days`.
+4. Writes `customers.last_no_show_at = NEW.marked_no_show_at`.
+
+The trigger does **not** increment `no_show_count` itself — that's done explicitly by `NoShowPolicyService.incrementCustomerNoShowCount()` (line 380–388), called at the end of `recordNoShowHistory()`. The trigger just re-derives the tier from whatever count is already on the row.
+
+The trigger does **not** fire on UPDATE to `customers`, so the three de-escalation paths below are safe to write directly to the tier field.
+
+## Tier De-escalation
+
+There are three mechanisms that move a customer back down. They are mutually independent and compose correctly.
+
+### 1. Cascade reset (earn-back via successful appointments)
+
+- **Trigger:** shop marks a paid order `completed` (see [booking-flow.md](./booking-flow.md#stage-6--completion)).
+- **Flow:** `NoShowPolicyService.recordSuccessfulAppointment()` → `checkTierReset()`.
+- **Logic:** increments `customers.successful_appointments_since_tier3`; when the counter crosses `shop_no_show_policy.deposit_reset_after_successful` (default 3), drops the customer one tier (`deposit_required → caution → warning → normal`), resets the counter to 0, and emits a `tier_restored` notification.
+- **Intermediate-step invariant:** `no_show_count` is preserved on `deposit_required → caution` and `caution → warning`. Only the active restriction tier moves at these steps.
+- **Final-step full reset:** on `warning → normal` the same UPDATE also wipes `no_show_count = 0` and `last_no_show_at = NULL`. This gives the customer a genuine clean slate — a future miss takes them to `warning` (count 1), not back to their pre-cascade tier. `no_show_history` rows are NOT deleted; the audit trail remains. The `tier_restored` notification for this step carries `metadata.fullReset = true` and a distinct "history has been cleared" message.
+- **Counter column:** `successful_appointments_since_tier3` was named for the original deposit-only reset. It now tracks successful appointments since the *last* tier drop across all penalized tiers. Rename deferred — migration `106_update_successful_appointments_counter_comment.sql` documents the new meaning via `COMMENT ON COLUMN`.
+
+### 2. Suspension auto-lift (time-served)
+
+- **Trigger:** `backend/src/services/SuspensionLiftService.ts` cron, every 15 min.
+- **Condition:** `no_show_tier = 'suspended'` AND `booking_suspended_until <= NOW()`.
+- **Action:** cascade to the appropriate tier based on current `no_show_count` (usually still `deposit_required` since count ≥ 5 right after suspension). Clears `booking_suspended_until`, resets `successful_appointments_since_tier3` to 0. Emits `suspension_lifted` notification.
+- **Does not** decrement `no_show_count`.
+
+### 3. Dispute reversal (audit correction)
+
+See [dispute-flow.md](./dispute-flow.md). The customer (or admin, or shop) may reverse a *specific* `no_show_history` row. `reverseNoShowPenalty` recomputes `effective_count` excluding reversed rows and re-tiers accordingly — this is the only path that can *partially* decrement `no_show_count` (by as many as were reversed, not all the way to zero).
+
+## Count vs. History — What's Mutable and When
+
+The source-of-truth audit log is `no_show_history`. Rows there are never deleted; the worst that happens is a note-field flag (`[DISPUTE_REVERSED]`) that excludes a row from effective-count calculations. `customers.no_show_count` is a derived, denormalized counter used for fast tier lookups — and it has three mutation paths:
+
+| Event | Effect on `no_show_count` |
+|---|---|
+| New no-show (`recordNoShowHistory`) | +1 (via `incrementCustomerNoShowCount`) |
+| Cascade final step (`warning → normal`) | Set to 0 |
+| Dispute approved (`reverseNoShowPenalty`) | Recomputed as `COUNT(no_show_history rows NOT marked reversed)` |
+
+The cascade and dispute paths do not touch `no_show_history`. A customer reset to `no_show_count = 0` via the cascade still has their historical rows on file; admins running audit queries can see the full chain of events including the reset moment.
+
+## Notifications Emitted
+
+| Type | Sender | Receiver | When | File:line |
+|---|---|---|---|---|
+| `service_no_show` | SYSTEM | Customer | On manual mark + on auto-detection | `OrderController.ts:928`, `AutoNoShowDetectionService.ts:190` |
+| `shop_no_show_auto_detected` | SYSTEM | Shop | On auto-detection only | `AutoNoShowDetectionService.ts:213` |
+| `suspension_lifted` | SYSTEM | Customer | On cron-driven suspension lift | `SuspensionLiftService.ts:81` |
+| `tier_restored` | SYSTEM | Customer | On cascade tier drop | `NoShowPolicyService.sendTierRestoredNotification` |
+
+Tier-specific emails via `EmailService`: `sendNoShowTier1Warning`, `sendNoShowTier2Caution`, `sendNoShowTier3DepositRequired`, `sendNoShowTier4Suspended` — preference-gated per shop policy.

--- a/backend/docs/workflows/service-booking-lifecycle.md
+++ b/backend/docs/workflows/service-booking-lifecycle.md
@@ -1,0 +1,342 @@
+# Service Booking Lifecycle
+
+*An end-to-end overview of what happens from the moment a customer books a service through completion, missed appointments, and disputes. Written for non-technical stakeholders.*
+
+---
+
+## What This Covers
+
+RepairCoin's service marketplace lets customers book repair appointments online, pay upfront (with cash or RCN tokens), show up, and earn rewards for completing their service. The system also protects shops from customers who repeatedly book and don't show up, while giving customers a fair way to contest a no-show that wasn't their fault.
+
+This document walks through the full journey: booking → appointment → outcome (completion or no-show) → any consequences → recovery.
+
+## Big Picture
+
+```mermaid
+flowchart TD
+  A([Customer books a service]) --> B{Payment succeeds?}
+  B -- No --> A1([Nothing saved, nothing charged])
+  B -- Yes --> C[Booking confirmed]
+  C --> D{Does the customer show up?}
+  D -- Yes --> E[Shop marks complete]
+  E --> F([Customer earns RCN rewards])
+  E --> G{Customer had past no-shows?}
+  G -- Yes --> H([Recovery counter ticks forward])
+  G -- No --> F
+  D -- No --> I[Marked as no-show<br/>manually or automatically]
+  I --> J([Penalty tier recalculated])
+  J --> K{Customer believes it's wrong?}
+  K -- Yes --> L[Submit dispute]
+  K -- No --> M([Restrictions apply<br/>for future bookings])
+  L --> N{Auto-approved first offense?}
+  N -- Yes --> O([No-show reversed<br/>tier recalculated down])
+  N -- No --> P{Shop reviews}
+  P -- Approve --> O
+  P -- Reject --> M
+
+  classDef start fill:#1e40af,color:#ffffff,stroke:#60a5fa,stroke-width:2px
+  classDef good fill:#166534,color:#ffffff,stroke:#4ade80,stroke-width:2px
+  classDef bad fill:#991b1b,color:#ffffff,stroke:#f87171,stroke-width:2px
+  classDef neutral fill:#374151,color:#e5e7eb,stroke:#9ca3af,stroke-width:2px
+
+  class A start
+  class F,O good
+  class M bad
+  class A1 neutral
+```
+
+---
+
+## 1. The Happy Path — A Successful Booking
+
+Here is what a customer experiences when everything goes well.
+
+**Step 1 — Browse and pick a service.** The customer opens the marketplace, chooses a shop, and selects a service (e.g., "Screen Replacement"). They see the price, estimated duration, and available time slots.
+
+**Step 2 — Pick a date and time.** The customer selects an available slot. The system enforces the shop's operating hours, break times, and capacity limits automatically — unavailable slots are greyed out.
+
+**Step 3 — Optionally redeem RCN tokens.** If the customer has earned RCN rewards at this shop (or any participating shop), they can apply some of them toward the bill. Up to 20% of their redemption can be used at any shop; up to 100% at the shop where they earned it.
+
+**Step 4 — Check out.** The customer enters payment details. At this moment, no booking is saved yet — the system first confirms the customer is in good standing, the slot is still free, and the payment clears.
+
+**Step 5 — Payment confirms.** Once the payment provider (Stripe) confirms funds, the booking is officially created. The customer gets a confirmation email and a calendar event. The shop gets a "new booking received" notification and — if the shop has Google Calendar connected — the appointment appears on the shop's calendar automatically.
+
+**Step 6 — The appointment happens.** The customer arrives, the shop performs the service.
+
+**Step 7 — Shop marks the booking complete.** The shop owner opens their dashboard and marks the service complete. This triggers:
+
+- **RCN rewards** are issued to the customer's wallet based on the transaction amount and the customer's loyalty tier.
+- **Group tokens** (for services linked to affiliate groups) are also issued automatically.
+- A **completion notification** is sent to the customer.
+- If the customer had any no-show history, their recovery counter ticks forward (see Section 5).
+
+The transaction is now permanently recorded, and the customer can rate and review the service.
+
+---
+
+## 2. When a Customer Doesn't Show Up
+
+Not every booking ends happily. A no-show is a booking where the customer paid (or reserved) but never arrived. Shops lose the slot, potentially turning away other customers.
+
+There are two ways a booking becomes a no-show:
+
+### Manual Marking
+The shop owner reviews their upcoming bookings and marks a specific one as "no-show" after the appointment time passes. They can add a note for their records.
+
+### Automatic Detection
+For shops that opt in, the system checks every 30 minutes for bookings that:
+- Were paid for,
+- Are past their appointment time (plus a grace period, typically 15 minutes),
+- Plus an additional delay window (typically 2 hours) to avoid flagging customers who are simply running late,
+- Have not been marked complete.
+
+These are automatically flagged as no-shows. The customer is notified, and the shop gets an "auto-detected no-show" alert so they can override if the customer actually did show up.
+
+In both cases, the missed appointment is logged in the customer's no-show history and counts toward their penalty tier.
+
+---
+
+## 3. The Penalty Ladder
+
+Every customer starts at **Normal**. As missed appointments accumulate, they climb a four-step penalty ladder. Each step adds restrictions to their ability to book future appointments, designed to compensate shops for the risk.
+
+| Missed Appointments | Tier | What the Customer Experiences |
+|---|---|---|
+| 0 | **Normal** | No restrictions. Full booking privileges. |
+| 1 | **Warning** | A banner appears reminding them to honor appointments. No booking restrictions yet. |
+| 2 | **Caution** | Must book at least 24 hours in advance. Maximum 80% of the bill can be paid with RCN tokens (some cash must be paid). |
+| 3–4 | **Deposit Required** | Must book at least 48 hours in advance. A $25 refundable deposit is required for each booking. 80% RCN redemption cap still applies. |
+| 5+ | **Suspended** | Booking is blocked entirely for 30 days. After that, the customer returns to the "Deposit Required" tier. |
+
+*Shops can adjust these thresholds and amounts for their individual business, but these are the platform defaults.*
+
+The customer sees a banner in their dashboard describing their current tier and the restrictions that apply. The banner colors and tone escalate with the tier — yellow for Warning, orange for Caution, red for Deposit Required, grey for Suspended.
+
+### The Tier Ladder, Visualized
+
+Arrows going **up** (red, thicker) are climbed by missing appointments. Arrows going **down** (green) represent recovery — each one a separate mechanism the customer can use to reduce their restrictions.
+
+```mermaid
+stateDiagram-v2
+  direction TB
+  [*] --> Normal
+
+  Normal --> Warning: 1st no-show
+  Warning --> Caution: 2nd no-show
+  Caution --> DepositRequired: 3rd no-show
+  DepositRequired --> Suspended: 5th no-show<br/>(30-day timer starts)
+
+  DepositRequired --> Caution: 3 successful appointments
+  Caution --> Warning: 3 successful appointments
+  Warning --> Normal: 3 successful appointments<br/>(full reset: count cleared)
+
+  Suspended --> DepositRequired: 30 days elapse<br/>(automatic)
+
+  DepositRequired --> Normal: Dispute approved<br/>(count drops)
+  Caution --> Normal: Dispute approved
+  Warning --> Normal: Dispute approved
+
+  note right of Normal
+    No restrictions
+  end note
+
+  note right of Warning
+    Reminder banner only
+  end note
+
+  note right of Caution
+    24h advance booking
+    Max 80% RCN
+  end note
+
+  note right of DepositRequired
+    48h advance booking
+    $25 refundable deposit
+    Max 80% RCN
+  end note
+
+  note right of Suspended
+    Booking blocked
+    for 30 days
+  end note
+```
+
+---
+
+## 4. How a Customer Reaches Each Tier
+
+The ladder goes up when a missed appointment is logged. The system automatically recalculates the customer's tier based on their total number of no-shows and the shop's thresholds.
+
+A customer who already has 4 missed appointments and misses a 5th one will jump from "Deposit Required" straight to "Suspended" — with a suspension end date 30 days out.
+
+The customer is always notified when their tier changes, with an explanation of the new restrictions and tips for avoiding further missed appointments (set reminders, cancel at least 4 hours ahead, contact the shop if running late).
+
+---
+
+## 5. Earning Your Way Back — Three Recovery Paths
+
+The system is strict but not unforgiving. There are three separate mechanisms that can reduce a customer's restrictions. They work independently and can combine.
+
+### Path A — Good Behavior (Cascade Reset)
+
+**How it works:** Every time the customer completes an appointment successfully, a counter increments. When the counter reaches **3 successful appointments**, the customer drops one step down the ladder.
+
+- Deposit Required → Caution (after 3 successful visits)
+- Caution → Warning (after 3 more)
+- Warning → Normal (after 3 more)
+
+The counter resets to zero at each step, so the customer has to earn another 3 successes to drop further.
+
+**What happens at each step:**
+
+- **Intermediate drops** (Deposit Required → Caution, Caution → Warning): the active restriction level moves down, but the customer's lifetime no-show count stays intact. Only disputes can reduce the count at these stages.
+- **Final step — Warning → Normal:** once the customer clears the full cascade, their no-show count is **wiped to zero**. This is a clean slate, not just a cosmetic tier change. A later miss takes them back to Warning (count 1), not straight into deeper penalties. The individual no-show records stay on file for audit purposes, but they no longer count against the customer.
+
+**When it happens:** Automatically, the moment the shop marks a booking complete. The customer gets a "Your restrictions have been reduced" notification at every step, and a special "Welcome back to good standing — history cleared" notification on the final step.
+
+### Path B — Time Served (Suspension Auto-Lift)
+
+**How it works:** Once a customer has been suspended for 30 days (the default — shops can configure this), the suspension automatically lifts. The customer is moved from "Suspended" back down to "Deposit Required" (or whichever tier their no-show count corresponds to).
+
+**What stays the same:** The customer still has to pay the refundable deposit and book 48 hours in advance on their next booking. The suspension was a time-out, not a reset.
+
+**When it happens:** Automatically, within 15 minutes of the suspension expiring. The customer gets a "You can book again" notification.
+
+### Path C — Dispute Reversal
+
+Sometimes a no-show record is wrong. The customer did show up, or there was a valid reason (a medical emergency, a shop error, a booking system glitch). In these cases, the customer can dispute the record. If the dispute is approved, the no-show is reversed — and the customer's count genuinely goes down, potentially moving them down one or more tiers instantly.
+
+Disputes are the only mechanism that decreases the lifetime count. They exist to correct factual errors, not to forgive legitimate misses. Disputes are covered in detail in the next section.
+
+---
+
+## 6. The Dispute Process
+
+A customer who believes a no-show was marked incorrectly has a fair, structured way to contest it.
+
+### Submitting a Dispute
+
+The customer opens the disputed no-show in their dashboard and clicks "Dispute." They write a reason (minimum 10 characters) explaining why the record is wrong. Common reasons:
+
+- "I was there on time but the shop was closed"
+- "I cancelled 6 hours ahead of the appointment via phone"
+- "I was in the ER — here's a photo of the discharge paper" (attachments are a future enhancement)
+
+### The Dispute Window
+
+Disputes must be submitted within **7 days** (default; shops can configure) of the missed appointment. After that window closes, the record becomes permanent. This bounds the period during which shops need to recall the details.
+
+### First-Offense Auto-Approval
+
+To avoid punishing new customers for a single bad day, the system can automatically approve the first dispute a customer files at a given shop (or their second, if they've only had one prior no-show at that shop). This requires the shop has "Auto-approve first offense" enabled in their policy — it's on by default.
+
+When auto-approved, the reversal happens immediately. The customer gets an "Your dispute was approved" email, their no-show count decreases, and their tier is recalculated.
+
+### Manual Shop Review
+
+For any dispute that isn't auto-approved, the dispute enters "Pending" status and appears in the shop's dispute dashboard. The shop reviews the customer's reason and decides:
+
+- **Approve** — the no-show is reversed. The customer's count goes down and their tier is recalculated. They receive an email with the shop's resolution notes (if any).
+- **Reject** — the no-show stands. The customer receives an email explaining the rejection reason (which the shop is required to provide).
+
+### Admin Override
+
+Platform admins can resolve any dispute on behalf of a shop — useful if the shop is non-responsive, if there's a pattern suggesting unfair rejections, or if the case involves multi-shop fraud.
+
+### What "Reversal" Means Technically
+
+When a dispute is approved, the no-show record is **not deleted** — it's marked with an internal reversal flag. This preserves the audit trail: a shop can always see that a record existed and was reversed, and admins investigating fraud or abuse have complete history. The customer's counts are recalculated from the non-reversed records.
+
+### Dispute Flow at a Glance
+
+```mermaid
+flowchart TD
+  A([Customer sees no-show<br/>in their dashboard]) --> B[Click 'Dispute' and write reason]
+  B --> C{Within 7-day<br/>dispute window?}
+  C -- No --> C1([Dispute rejected<br/>record becomes permanent])
+  C -- Yes --> D{Shop allows<br/>disputes?}
+  D -- No --> C1
+  D -- Yes --> E{1st or 2nd<br/>no-show at<br/>this shop?}
+  E -- Yes --> F{Shop has<br/>auto-approve<br/>enabled?}
+  F -- Yes --> G([Auto-approved<br/>no-show reversed<br/>tier recalculated])
+  F -- No --> H[Pending — waits<br/>for shop review]
+  E -- No --> H
+  H --> I{Shop's decision}
+  I -- Approve --> G
+  I -- Reject --> J([Rejected<br/>customer receives reason])
+  I -- No response --> K{Admin intervenes?}
+  K -- Approve --> G
+  K -- Reject --> J
+
+  classDef start fill:#1e40af,color:#ffffff,stroke:#60a5fa,stroke-width:2px
+  classDef good fill:#166534,color:#ffffff,stroke:#4ade80,stroke-width:2px
+  classDef bad fill:#991b1b,color:#ffffff,stroke:#f87171,stroke-width:2px
+
+  class A start
+  class G good
+  class J,C1 bad
+```
+
+---
+
+## 7. Design Principles
+
+A few ideas underpin the whole system:
+
+**1. No charge without a booking.** The customer's card is only charged after all validations pass and the slot is held. If anything fails, nothing is saved and nothing is charged.
+
+**2. Audit trail is permanent; the active count is earnable.** Every missed appointment is recorded in the audit log forever — shops and admins can always see what happened and when. But the *active* no-show count that drives restrictions gets wiped to zero once a customer completes the full cascade back to Normal. This rewards sustained good behavior without pretending the history didn't happen: the records remain, their consequences don't.
+
+**3. Disputes are for correction, not forgiveness.** Disputes exist to fix factual errors. If the customer genuinely missed the appointment, they should use the good-behavior path (cascade reset), not dispute it. Using disputes as forgiveness would pollute shop data and waste review time.
+
+**4. Shops have flexibility.** Most thresholds (how many no-shows trigger each tier, how much the deposit is, how long the suspension lasts, whether to auto-approve first offenses) are configurable per shop. Defaults exist so new shops don't have to make every decision upfront.
+
+**5. Customers always know where they stand.** The dashboard banner shows their current tier, the exact restrictions, progress toward the next recovery step, and tips for avoiding further issues. There are no hidden penalties or surprise charges.
+
+---
+
+## 8. What Customers Are Notified About
+
+Customers receive a mix of in-app notifications (a bell icon in the dashboard) and emails across the lifecycle:
+
+| Event | Notification | Email |
+|---|---|---|
+| Booking confirmed | ✓ | ✓ |
+| Appointment reminder (24h prior) | ✓ | ✓ |
+| Service completed (RCN issued) | ✓ | — |
+| No-show recorded | ✓ | ✓ (tier-specific copy) |
+| Suspension timer lifted | ✓ | — |
+| Restrictions reduced (cascade reset) | ✓ | — |
+| Dispute submitted | — | — |
+| Dispute approved | — | ✓ |
+| Dispute rejected | — | ✓ |
+
+*Email delivery is gated by each customer's preference settings — they can opt out of non-critical messages.*
+
+---
+
+## 9. What Shops Control
+
+Each shop has a no-show policy that they can tune in their dashboard:
+
+- **Grace period** — minutes past appointment time before a customer is considered no-show (default 15).
+- **Auto-detection** — opt in to let the system automatically mark no-shows, or keep manual-only.
+- **Thresholds** — how many no-shows trigger each tier (caution, deposit, suspension).
+- **Deposit amount** — dollar amount for the deposit-required tier (default $25).
+- **Advance-hours requirements** — how far ahead cautioned / deposit customers must book (defaults 24 / 48).
+- **RCN redemption cap** — the maximum percentage of a bill that can be paid with tokens for restricted customers (default 80%).
+- **Suspension duration** — how long the full booking block lasts (default 30 days).
+- **Disputes** — whether customers can dispute at all, the window (default 7 days), and whether first offenses auto-approve.
+- **Email alerts** — which tier transitions send the customer an email, and whether the shop gets a daily digest of their no-shows.
+
+---
+
+## Glossary
+
+- **RCN** — RepairCoin's utility token, earned from repairs and redeemed for discounts. 1 RCN = $0.10 USD.
+- **Tier** — a customer's current restriction level (Normal, Warning, Caution, Deposit Required, Suspended).
+- **No-show count** — the total lifetime number of missed appointments. Moves down only through dispute reversal.
+- **Recovery counter** — successful appointments since the customer's last tier drop. Moves the tier down when it hits the threshold.
+- **Auto-detection** — the system's 30-minute sweep that marks no-shows without shop intervention.
+- **Dispute window** — the time limit for submitting a dispute after a no-show is recorded (default 7 days).
+- **Suspension** — a full block on new bookings for a fixed duration; lifts automatically.

--- a/backend/docs/workflows/service-booking-lifecycle.md
+++ b/backend/docs/workflows/service-booking-lifecycle.md
@@ -206,7 +206,7 @@ The counter resets to zero at each step, so the customer has to earn another 3 s
 
 Sometimes a no-show record is wrong. The customer did show up, or there was a valid reason (a medical emergency, a shop error, a booking system glitch). In these cases, the customer can dispute the record. If the dispute is approved, the no-show is reversed — and the customer's count genuinely goes down, potentially moving them down one or more tiers instantly.
 
-Disputes are the only mechanism that decreases the lifetime count. They exist to correct factual errors, not to forgive legitimate misses. Disputes are covered in detail in the next section.
+Disputes are the primary mechanism for *partial* reductions tied to a specific contested record. (Completing the full cascade back to Normal also wipes the count, but that's a holistic earn-back rather than a correction of a specific incident.) Disputes exist to correct factual errors, not to forgive legitimate misses. They're covered in detail in the next section.
 
 ---
 

--- a/backend/migrations/106_update_successful_appointments_counter_comment.sql
+++ b/backend/migrations/106_update_successful_appointments_counter_comment.sql
@@ -1,0 +1,8 @@
+-- Migration 106: Update successful_appointments_since_tier3 column comment
+-- Description: The counter was originally only used for deposit_required -> caution resets.
+--              It now tracks successful appointments since the last tier drop across
+--              deposit_required, caution, and warning tiers (cascade reset feature).
+--              Column name kept for backwards compatibility with existing SELECT statements.
+-- Date: 2026-04-24
+
+COMMENT ON COLUMN customers.successful_appointments_since_tier3 IS 'Counter for successful appointments since last tier drop; cascades deposit_required -> caution -> warning -> normal';

--- a/backend/scripts/repair-stale-suspensions.sql
+++ b/backend/scripts/repair-stale-suspensions.sql
@@ -1,0 +1,38 @@
+-- Repair stale no-show suspensions
+--
+-- Finds customers stuck at no_show_tier='suspended' with no
+-- booking_suspended_until timer (NULL). The SuspensionLiftService cron
+-- ignores these rows because its WHERE clause requires the timer to be
+-- non-null and elapsed. Without repair, affected customers remain
+-- suspended forever.
+--
+-- This script is intentionally standalone — not a migration — because:
+--  1. It is environment-dependent: most DBs won't have stale rows, so
+--     running it on every migration pass would be wasted work.
+--  2. It is an operational repair rather than a schema change.
+--
+-- Usage:
+--   Step 1: Inspect candidates and decide if the repair is appropriate:
+--     SELECT address, no_show_count, last_no_show_at
+--     FROM customers
+--     WHERE no_show_tier = 'suspended'
+--       AND booking_suspended_until IS NULL;
+--
+--   Step 2: Run the repair UPDATE below. It applies the same cascade
+--   thresholds SuspensionLiftService uses (3/2/1) and resets the
+--   successful_appointments_since_tier3 counter.
+
+UPDATE customers
+SET
+  no_show_tier = CASE
+    WHEN no_show_count >= 3 THEN 'deposit_required'
+    WHEN no_show_count >= 2 THEN 'caution'
+    WHEN no_show_count = 1 THEN 'warning'
+    ELSE 'normal'
+  END,
+  deposit_required = (no_show_count >= 3),
+  successful_appointments_since_tier3 = 0,
+  updated_at = NOW()
+WHERE no_show_tier = 'suspended'
+  AND booking_suspended_until IS NULL
+RETURNING address, no_show_count, no_show_tier;

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -35,6 +35,7 @@ import { cleanupService } from './services/CleanupService';
 import { appointmentReminderService } from './services/AppointmentReminderService';
 import { subscriptionReminderService } from './services/SubscriptionReminderService';
 import { getAutoNoShowDetectionService } from './services/AutoNoShowDetectionService';
+import { getSuspensionLiftService } from './services/SuspensionLiftService';
 import { rescheduleExpirationService } from './services/RescheduleExpirationService';
 import { autoMessageSchedulerService } from './services/AutoMessageSchedulerService';
 import { ReportSchedulerService } from './services/ReportSchedulerService';
@@ -585,6 +586,7 @@ class RepairCoinApp {
       appointmentReminderService.stopScheduledReminders();
       subscriptionReminderService.stopScheduler();
       getAutoNoShowDetectionService().stop();
+      getSuspensionLiftService().stop();
       rescheduleExpirationService.stop();
       stopSubscriptionEnforcement();
       stopUnpaidBookingCleanup();
@@ -756,6 +758,16 @@ class RepairCoinApp {
           logger.info('🚫 Auto detection service started (no-show, expiry, pending cleanup - every 30 minutes)');
         } else {
           logger.info('⏸️ Auto detection service DISABLED via AUTO_DETECTION_ENABLED=false');
+        }
+
+        // Start suspension lift service - runs every 15 minutes
+        // Feature flag: set SUSPENSION_LIFT_ENABLED=false to disable
+        const suspensionLiftEnabled = process.env.SUSPENSION_LIFT_ENABLED !== 'false';
+        if (suspensionLiftEnabled) {
+          getSuspensionLiftService().start();
+          logger.info('🔓 Suspension lift service started (every 15 minutes)');
+        } else {
+          logger.info('⏸️ Suspension lift service DISABLED via SUSPENSION_LIFT_ENABLED=false');
         }
 
         // Start reschedule expiration service - runs every hour

--- a/backend/src/domains/ServiceDomain/controllers/DisputeController.ts
+++ b/backend/src/domains/ServiceDomain/controllers/DisputeController.ts
@@ -693,7 +693,7 @@ async function reverseNoShowPenalty(
       `SELECT COUNT(*) as effective_count
        FROM no_show_history
        WHERE LOWER(customer_address) = LOWER($1)
-         AND (notes IS NULL OR nocctes NOT LIKE '%[DISPUTE_REVERSED]%')`,
+         AND (notes IS NULL OR notes NOT LIKE '%[DISPUTE_REVERSED]%')`,
       [customerAddress]
     );
 

--- a/backend/src/domains/ServiceDomain/controllers/DisputeController.ts
+++ b/backend/src/domains/ServiceDomain/controllers/DisputeController.ts
@@ -732,13 +732,16 @@ export async function reverseNoShowPenalty(
       }
     }
 
-    // Update customer with correct effective count, recalculated tier, and suspension date
+    // Update customer with correct effective count, recalculated tier, and suspension date.
+    // When effectiveCount drops to 0 (all of this customer's no-shows were reversed),
+    // also null last_no_show_at so the row is internally consistent with tier=normal.
     await pool.query(
       `UPDATE customers
        SET no_show_count = $1,
            no_show_tier = $2,
            booking_suspended_until = $3,
            deposit_required = $4,
+           last_no_show_at = CASE WHEN $1::int = 0 THEN NULL ELSE last_no_show_at END,
            updated_at = NOW()
        WHERE LOWER(address) = LOWER($5)`,
       [effectiveCount, newTier, suspensionDate, newTier === 'deposit_required' || newTier === 'suspended', customerAddress]

--- a/backend/src/domains/ServiceDomain/controllers/DisputeController.ts
+++ b/backend/src/domains/ServiceDomain/controllers/DisputeController.ts
@@ -674,7 +674,7 @@ export async function adminResolveDispute(req: AuthenticatedRequest, res: Respon
  * Helper: Reverse a no-show penalty by decrementing the customer's no-show count
  * and recalculating their tier
  */
-async function reverseNoShowPenalty(
+export async function reverseNoShowPenalty(
   pool: ReturnType<typeof getSharedPool>,
   customerAddress: string,
   shopId: string,

--- a/backend/src/domains/notification/services/NotificationService.ts
+++ b/backend/src/domains/notification/services/NotificationService.ts
@@ -34,6 +34,8 @@ export interface NotificationMessageTemplates {
   support_message_received: (data: { ticketId: string; senderName: string; preview: string }) => string;
   support_ticket_resolved: (data: { ticketId: string; subject: string }) => string;
   support_ticket_assigned: (data: { ticketId: string; subject: string }) => string;
+  suspension_lifted: (data: { newTier: string }) => string;
+  tier_restored: (data: { previousTier: string; newTier: string; fullReset: boolean }) => string;
 }
 
 /**
@@ -172,8 +174,39 @@ export class NotificationService {
         `Your support ticket #${data.ticketId} (${data.subject}) has been resolved`,
 
       support_ticket_assigned: (data: { ticketId: string; subject: string }) =>
-        `Your support ticket #${data.ticketId} (${data.subject}) has been assigned to an admin`
+        `Your support ticket #${data.ticketId} (${data.subject}) has been assigned to an admin`,
+
+      suspension_lifted: (data) => {
+        if (data.newTier === 'deposit_required') {
+          return 'Your booking suspension has been lifted. You can now book appointments again with a refundable deposit.';
+        }
+        if (data.newTier === 'caution') {
+          return 'Your booking suspension has been lifted. Your account is now in good standing with minor booking restrictions.';
+        }
+        return 'Your booking suspension has been lifted. You can now book appointments again.';
+      },
+
+      tier_restored: (data) => {
+        if (data.fullReset) {
+          return 'Welcome back to good standing. Your no-show history has been cleared. Keep honoring appointments to stay here.';
+        }
+        return `Your booking restrictions have been reduced from ${data.previousTier.replace('_', ' ')} to ${data.newTier}. Keep honoring appointments to remove more restrictions.`;
+      }
     };
+  }
+
+  /**
+   * Public accessor so callers that bypass the type-specific helpers
+   * (e.g. SuspensionLiftService, NoShowPolicyService) can still use the
+   * centralized message copy rather than hardcoding strings at the
+   * call site.
+   */
+  buildMessage<K extends keyof NotificationMessageTemplates>(
+    type: K,
+    data: Parameters<NotificationMessageTemplates[K]>[0]
+  ): string {
+    const builder = this.messageTemplates[type] as (d: any) => string;
+    return builder(data);
   }
 
   async createNotification(params: CreateNotificationParams): Promise<Notification> {

--- a/backend/src/services/NoShowPolicyService.ts
+++ b/backend/src/services/NoShowPolicyService.ts
@@ -212,7 +212,7 @@ export class NoShowPolicyService {
     } else if (customer.tier === 'deposit_required') {
       minimumAdvanceHours = policy.depositAdvanceBookingHours;
       restrictions.push(`Must book at least ${policy.depositAdvanceBookingHours} hours in advance`);
-      restrictions.push(`$${policy.depositAmount} refundable deposit required`);
+      restrictions.push(`$${Number(policy.depositAmount).toFixed(2)} refundable deposit required`);
       restrictions.push(`Maximum ${policy.maxRcnRedemptionPercent}% RCN redemption`);
     } else if (customer.tier === 'suspended') {
       restrictions.push(`Booking suspended until ${customer.bookingSuspendedUntil ? new Date(customer.bookingSuspendedUntil).toLocaleDateString() : 'unknown'}`);
@@ -279,9 +279,9 @@ export class NoShowPolicyService {
       restrictions.push(`Limited to ${defaultPolicy.maxRcnRedemptionPercent}% RCN redemption per booking`);
     } else if (customer.tier === 'deposit_required') {
       minimumAdvanceHours = defaultPolicy.depositAdvanceBookingHours;
-      restrictions.push(`$${defaultPolicy.depositAmount} refundable deposit required for all bookings`);
       restrictions.push(`Must book at least ${defaultPolicy.depositAdvanceBookingHours} hours in advance`);
-      restrictions.push(`Limited to ${defaultPolicy.maxRcnRedemptionPercent}% RCN redemption per booking`);
+      restrictions.push(`$${Number(defaultPolicy.depositAmount).toFixed(2)} refundable deposit required`);
+      restrictions.push(`Maximum ${defaultPolicy.maxRcnRedemptionPercent}% RCN redemption`);
     } else if (customer.tier === 'suspended') {
       const suspensionDate = customer.bookingSuspendedUntil
         ? new Date(customer.bookingSuspendedUntil).toLocaleDateString('en-US', {

--- a/backend/src/services/NoShowPolicyService.ts
+++ b/backend/src/services/NoShowPolicyService.ts
@@ -415,11 +415,10 @@ export class NoShowPolicyService {
    * slate. no_show_history rows stay intact for audit.
    */
   private async checkTierReset(customerAddress: string): Promise<void> {
+    // Inline subquery with COALESCE so the cascade still fires in a DB
+    // with zero shop_no_show_policy rows (defaults to 3). A WITH + FROM JOIN
+    // would collapse to zero matched rows when the policy table is empty.
     const query = `
-      WITH threshold AS (
-        SELECT deposit_reset_after_successful AS n
-        FROM shop_no_show_policy LIMIT 1
-      )
       UPDATE customers c
       SET
         no_show_tier = CASE
@@ -439,10 +438,12 @@ export class NoShowPolicyService {
           ELSE c.last_no_show_at
         END,
         updated_at = NOW()
-      FROM threshold t
       WHERE c.address = $1
         AND c.no_show_tier IN ('deposit_required', 'caution', 'warning')
-        AND c.successful_appointments_since_tier3 >= COALESCE(t.n, 3)
+        AND c.successful_appointments_since_tier3 >= COALESCE(
+          (SELECT deposit_reset_after_successful FROM shop_no_show_policy LIMIT 1),
+          3
+        )
       RETURNING
         c.address,
         c.no_show_tier AS new_tier,

--- a/backend/src/services/NoShowPolicyService.ts
+++ b/backend/src/services/NoShowPolicyService.ts
@@ -471,9 +471,11 @@ export class NoShowPolicyService {
     try {
       const notificationService = new NotificationService();
       const fullReset = newTier === 'normal';
-      const message = fullReset
-        ? 'Welcome back to good standing. Your no-show history has been cleared. Keep honoring appointments to stay here.'
-        : `Your booking restrictions have been reduced from ${previousTier.replace('_', ' ')} to ${newTier}. Keep honoring appointments to remove more restrictions.`;
+      const message = notificationService.buildMessage('tier_restored', {
+        previousTier,
+        newTier,
+        fullReset
+      });
 
       await notificationService.createNotification({
         senderAddress: 'SYSTEM',

--- a/backend/src/services/NoShowPolicyService.ts
+++ b/backend/src/services/NoShowPolicyService.ts
@@ -2,6 +2,7 @@
 import { getSharedPool } from '../utils/database-pool';
 import { Pool } from 'pg';
 import { logger } from '../utils/logger';
+import { NotificationService } from '../domains/notification/services/NotificationService';
 
 export type NoShowTier = 'normal' | 'warning' | 'caution' | 'deposit_required' | 'suspended';
 
@@ -387,44 +388,108 @@ export class NoShowPolicyService {
   }
 
   /**
-   * Record successful appointment (for tier 3 reset tracking)
+   * Record a successful appointment. Increments the counter for any penalized
+   * tier so the customer can earn their way down the ladder:
+   * deposit_required → caution → warning → normal.
    */
   async recordSuccessfulAppointment(customerAddress: string): Promise<void> {
     const query = `
       UPDATE customers
       SET successful_appointments_since_tier3 = successful_appointments_since_tier3 + 1
       WHERE address = $1
-        AND no_show_tier = 'deposit_required'
+        AND no_show_tier IN ('deposit_required', 'caution', 'warning')
     `;
 
     const result = await this.pool.query(query, [customerAddress.toLowerCase()]);
 
-    // Check if customer should be restored to lower tier
     if (result.rowCount && result.rowCount > 0) {
       await this.checkTierReset(customerAddress);
     }
   }
 
   /**
-   * Check if customer should be reset to lower tier after successful appointments
+   * If the counter has met the threshold, drop the customer one tier.
+   * Intermediate drops (deposit_required -> caution -> warning) preserve
+   * no_show_count as in-progress history. The final step (warning -> normal)
+   * wipes no_show_count and last_no_show_at, giving the customer a clean
+   * slate. no_show_history rows stay intact for audit.
    */
   private async checkTierReset(customerAddress: string): Promise<void> {
     const query = `
-      UPDATE customers
+      WITH threshold AS (
+        SELECT deposit_reset_after_successful AS n
+        FROM shop_no_show_policy LIMIT 1
+      )
+      UPDATE customers c
       SET
-        no_show_tier = 'caution',
+        no_show_tier = CASE
+          WHEN c.no_show_tier = 'deposit_required' THEN 'caution'
+          WHEN c.no_show_tier = 'caution' THEN 'warning'
+          WHEN c.no_show_tier = 'warning' THEN 'normal'
+          ELSE c.no_show_tier
+        END,
         deposit_required = FALSE,
-        successful_appointments_since_tier3 = 0
-      WHERE address = $1
-        AND no_show_tier = 'deposit_required'
-        AND successful_appointments_since_tier3 >= (
-          SELECT deposit_reset_after_successful
-          FROM shop_no_show_policy
-          LIMIT 1  -- Using default policy for now
-        )
+        successful_appointments_since_tier3 = 0,
+        no_show_count = CASE
+          WHEN c.no_show_tier = 'warning' THEN 0
+          ELSE c.no_show_count
+        END,
+        last_no_show_at = CASE
+          WHEN c.no_show_tier = 'warning' THEN NULL
+          ELSE c.last_no_show_at
+        END,
+        updated_at = NOW()
+      FROM threshold t
+      WHERE c.address = $1
+        AND c.no_show_tier IN ('deposit_required', 'caution', 'warning')
+        AND c.successful_appointments_since_tier3 >= COALESCE(t.n, 3)
+      RETURNING
+        c.address,
+        c.no_show_tier AS new_tier,
+        CASE
+          WHEN c.no_show_tier = 'caution' THEN 'deposit_required'
+          WHEN c.no_show_tier = 'warning' THEN 'caution'
+          WHEN c.no_show_tier = 'normal' THEN 'warning'
+        END AS previous_tier
     `;
 
-    await this.pool.query(query, [customerAddress.toLowerCase()]);
+    const result = await this.pool.query(query, [customerAddress.toLowerCase()]);
+
+    if (result.rowCount && result.rowCount > 0) {
+      const { address, new_tier, previous_tier } = result.rows[0];
+      logger.info('No-show tier cascade reset', { address, previous_tier, new_tier });
+      await this.sendTierRestoredNotification(address, previous_tier, new_tier);
+    }
+  }
+
+  private async sendTierRestoredNotification(
+    customerAddress: string,
+    previousTier: string,
+    newTier: string
+  ): Promise<void> {
+    try {
+      const notificationService = new NotificationService();
+      const fullReset = newTier === 'normal';
+      const message = fullReset
+        ? 'Welcome back to good standing. Your no-show history has been cleared. Keep honoring appointments to stay here.'
+        : `Your booking restrictions have been reduced from ${previousTier.replace('_', ' ')} to ${newTier}. Keep honoring appointments to remove more restrictions.`;
+
+      await notificationService.createNotification({
+        senderAddress: 'SYSTEM',
+        receiverAddress: customerAddress.toLowerCase(),
+        notificationType: 'tier_restored',
+        message,
+        metadata: {
+          previousTier,
+          newTier,
+          reason: 'successful_appointments',
+          fullReset,
+          timestamp: new Date().toISOString()
+        }
+      });
+    } catch (err) {
+      logger.error('Failed to send tier_restored notification', { customerAddress, err });
+    }
   }
 
   /**

--- a/backend/src/services/SuspensionLiftService.ts
+++ b/backend/src/services/SuspensionLiftService.ts
@@ -74,7 +74,9 @@ export class SuspensionLiftService {
 
       for (const row of result.rows) {
         try {
-          const message = this.buildLiftMessage(row.no_show_tier);
+          const message = this.notificationService.buildMessage('suspension_lifted', {
+            newTier: row.no_show_tier
+          });
           await this.notificationService.createNotification({
             senderAddress: 'SYSTEM',
             receiverAddress: row.address,
@@ -101,16 +103,6 @@ export class SuspensionLiftService {
     }
 
     return report;
-  }
-
-  private buildLiftMessage(newTier: string): string {
-    if (newTier === 'deposit_required') {
-      return 'Your booking suspension has been lifted. You can now book appointments again with a refundable deposit.';
-    }
-    if (newTier === 'caution') {
-      return 'Your booking suspension has been lifted. Your account is now in good standing with minor booking restrictions.';
-    }
-    return 'Your booking suspension has been lifted. You can now book appointments again.';
   }
 
   /**

--- a/backend/src/services/SuspensionLiftService.ts
+++ b/backend/src/services/SuspensionLiftService.ts
@@ -20,6 +20,7 @@ export class SuspensionLiftService {
   private notificationService: NotificationService;
   private scheduledIntervalId: NodeJS.Timeout | null = null;
   private isRunning: boolean = false;
+  private lastRunAt: Date | null = null;
 
   constructor() {
     this.notificationService = new NotificationService();
@@ -102,6 +103,7 @@ export class SuspensionLiftService {
       report.errors.push(errMsg);
     }
 
+    this.lastRunAt = report.timestamp;
     return report;
   }
 
@@ -150,11 +152,16 @@ export class SuspensionLiftService {
     logger.info('Suspension lift service stopped');
   }
 
-  getStatus(): { isRunning: boolean; nextRunEstimate?: Date } {
+  getStatus(): { isRunning: boolean; lastRunAt?: Date; nextRunEstimate?: Date } {
+    const INTERVAL_MS = 15 * 60 * 1000;
+    if (!this.isRunning) {
+      return { isRunning: false };
+    }
     return {
-      isRunning: this.isRunning,
-      nextRunEstimate: this.isRunning
-        ? new Date(Date.now() + 15 * 60 * 1000)
+      isRunning: true,
+      lastRunAt: this.lastRunAt ?? undefined,
+      nextRunEstimate: this.lastRunAt
+        ? new Date(this.lastRunAt.getTime() + INTERVAL_MS)
         : undefined
     };
   }

--- a/backend/src/services/SuspensionLiftService.ts
+++ b/backend/src/services/SuspensionLiftService.ts
@@ -1,0 +1,178 @@
+// backend/src/services/SuspensionLiftService.ts
+import { logger } from '../utils/logger';
+import { NotificationService } from '../domains/notification/services/NotificationService';
+import { getSharedPool } from '../utils/database-pool';
+
+export interface SuspensionLiftReport {
+  timestamp: Date;
+  customersLifted: number;
+  notificationsSent: number;
+  errors: string[];
+}
+
+interface LiftedCustomerRow {
+  address: string;
+  no_show_count: number;
+  no_show_tier: string;
+}
+
+export class SuspensionLiftService {
+  private notificationService: NotificationService;
+  private scheduledIntervalId: NodeJS.Timeout | null = null;
+  private isRunning: boolean = false;
+
+  constructor() {
+    this.notificationService = new NotificationService();
+  }
+
+  /**
+   * Find customers whose suspension has expired, downgrade them to the
+   * appropriate tier, and notify them. The UPDATE is atomic and idempotent —
+   * running it twice in a row produces zero rows on the second run.
+   *
+   * Tier cascade after lift (default thresholds from NoShowPolicyService.getDefaultPolicy):
+   *   no_show_count >= 3 → deposit_required
+   *   no_show_count = 2  → caution
+   *   no_show_count = 1  → warning
+   *   no_show_count = 0  → normal
+   */
+  async processSuspensionLifts(): Promise<SuspensionLiftReport> {
+    const report: SuspensionLiftReport = {
+      timestamp: new Date(),
+      customersLifted: 0,
+      notificationsSent: 0,
+      errors: []
+    };
+
+    try {
+      const result = await getSharedPool().query<LiftedCustomerRow>(`
+        UPDATE customers
+        SET
+          no_show_tier = CASE
+            WHEN no_show_count >= 3 THEN 'deposit_required'
+            WHEN no_show_count >= 2 THEN 'caution'
+            WHEN no_show_count = 1 THEN 'warning'
+            ELSE 'normal'
+          END,
+          deposit_required = (no_show_count >= 3),
+          booking_suspended_until = NULL,
+          successful_appointments_since_tier3 = 0,
+          updated_at = NOW()
+        WHERE no_show_tier = 'suspended'
+          AND booking_suspended_until IS NOT NULL
+          AND booking_suspended_until <= NOW()
+        RETURNING address, no_show_count, no_show_tier
+      `);
+
+      report.customersLifted = result.rows.length;
+
+      if (report.customersLifted === 0) {
+        return report;
+      }
+
+      logger.info(`Lifted ${report.customersLifted} no-show suspension(s)`);
+
+      for (const row of result.rows) {
+        try {
+          const message = this.buildLiftMessage(row.no_show_tier);
+          await this.notificationService.createNotification({
+            senderAddress: 'SYSTEM',
+            receiverAddress: row.address,
+            notificationType: 'suspension_lifted',
+            message,
+            metadata: {
+              previousTier: 'suspended',
+              newTier: row.no_show_tier,
+              noShowCount: row.no_show_count,
+              depositRequired: row.no_show_tier === 'deposit_required'
+            }
+          });
+          report.notificationsSent += 1;
+        } catch (notifError: any) {
+          const errMsg = `Failed to notify ${row.address} of suspension lift: ${notifError?.message ?? notifError}`;
+          logger.error(errMsg, notifError);
+          report.errors.push(errMsg);
+        }
+      }
+    } catch (error: any) {
+      const errMsg = `Suspension lift query failed: ${error?.message ?? error}`;
+      logger.error(errMsg, error);
+      report.errors.push(errMsg);
+    }
+
+    return report;
+  }
+
+  private buildLiftMessage(newTier: string): string {
+    if (newTier === 'deposit_required') {
+      return 'Your booking suspension has been lifted. You can now book appointments again with a refundable deposit.';
+    }
+    if (newTier === 'caution') {
+      return 'Your booking suspension has been lifted. Your account is now in good standing with minor booking restrictions.';
+    }
+    return 'Your booking suspension has been lifted. You can now book appointments again.';
+  }
+
+  /**
+   * Start the scheduled suspension-lift service. Runs once immediately, then
+   * every 15 minutes. Suspension deadlines are not cron-aligned, so a
+   * sub-hour interval keeps the reconciliation lag small.
+   */
+  start(): void {
+    if (this.isRunning) {
+      logger.warn('Suspension lift service is already running');
+      return;
+    }
+
+    logger.info('Starting suspension lift service...');
+    this.isRunning = true;
+
+    this.processSuspensionLifts().catch(error => {
+      logger.error('Error in initial suspension lift run:', error);
+    });
+
+    const INTERVAL_MS = 15 * 60 * 1000;
+    this.scheduledIntervalId = setInterval(async () => {
+      try {
+        await this.processSuspensionLifts();
+      } catch (error) {
+        logger.error('Error in scheduled suspension lift run:', error);
+      }
+    }, INTERVAL_MS);
+
+    logger.info('Suspension lift service started. Running every 15 minutes.');
+  }
+
+  stop(): void {
+    if (!this.isRunning) {
+      logger.warn('Suspension lift service is not running');
+      return;
+    }
+
+    if (this.scheduledIntervalId) {
+      clearInterval(this.scheduledIntervalId);
+      this.scheduledIntervalId = null;
+    }
+
+    this.isRunning = false;
+    logger.info('Suspension lift service stopped');
+  }
+
+  getStatus(): { isRunning: boolean; nextRunEstimate?: Date } {
+    return {
+      isRunning: this.isRunning,
+      nextRunEstimate: this.isRunning
+        ? new Date(Date.now() + 15 * 60 * 1000)
+        : undefined
+    };
+  }
+}
+
+let suspensionLiftServiceInstance: SuspensionLiftService | null = null;
+
+export const getSuspensionLiftService = (): SuspensionLiftService => {
+  if (!suspensionLiftServiceInstance) {
+    suspensionLiftServiceInstance = new SuspensionLiftService();
+  }
+  return suspensionLiftServiceInstance;
+};

--- a/backend/tests/integration/README.md
+++ b/backend/tests/integration/README.md
@@ -1,0 +1,55 @@
+# Integration Tests
+
+These tests run against a real Postgres database. The no-show SQL integration
+suite (`no-show-sql.test.ts`) is the primary audience — it exercises the UPDATE
+statements that unit tests can't fully verify.
+
+## When the suite runs
+
+- **`TEST_DATABASE_URL` set** → all tests run against that database.
+- **`TEST_DATABASE_URL` unset** → the suite is marked `.skip` silently. CI stays green without a test DB.
+
+Never point `TEST_DATABASE_URL` at production. The tests write and delete rows matching the `0xtest_` wallet-address prefix plus a fixed `integration-test-shop` row in `shop_no_show_policy`. Collisions are unlikely but not impossible on a live DB.
+
+## Local setup
+
+```bash
+# Create a throwaway DB
+createdb repaircoin_test
+
+# Point the setup at it
+export TEST_DATABASE_URL=postgres://postgres@localhost:5432/repaircoin_test
+
+# Run the migrations
+npm run db:migrate
+
+# Run just the integration suite
+npx jest tests/integration/no-show-sql.test.ts
+```
+
+Or drop `TEST_DATABASE_URL=...` into `backend/.env.test` — `tests/setup.ts` loads that file before tests run.
+
+## What's covered
+
+- **Cascade reset (`NoShowPolicyService.recordSuccessfulAppointment`)**
+  - Warning → Normal with full count wipe.
+  - Caution → Warning (intermediate, count preserved).
+  - Counter below threshold — only increments.
+  - Normal / Suspended tiers untouched.
+- **Suspension auto-lift (`SuspensionLiftService.processSuspensionLifts`)**
+  - Past `booking_suspended_until` → cascades to `deposit_required`.
+  - Future `booking_suspended_until` → untouched.
+- **Dispute reversal (`reverseNoShowPenalty`)**
+  - Marks row with `[DISPUTE_REVERSED]`, recomputes customer count/tier.
+
+## What the suite does NOT cover
+
+- The DB trigger at `backend/migrations/065_recreate_no_show_tables.sql:192–238`. It references `wallet_address` while the service code uses `address` — possible pre-existing inconsistency. The tests verify the service-level SQL, not the trigger.
+- HTTP layer. Tests call services directly; auth, routing, and request validation are not exercised.
+
+## Cleanup contract
+
+After every test: delete any `customers`, `no_show_history`, and `notifications` rows whose address / receiver matches `LOWER(...) LIKE '0xtest_%'`.
+After the full suite: delete the `shop_no_show_policy` row for `integration-test-shop` and close the shared pool.
+
+If a test crashes mid-run, leftover rows with the `0xtest_` prefix may need manual cleanup. They are cosmetic; no foreign keys reference them.

--- a/backend/tests/integration/no-show-sql.test.ts
+++ b/backend/tests/integration/no-show-sql.test.ts
@@ -1,0 +1,291 @@
+/**
+ * No-Show SQL Integration Tests
+ *
+ * Exercises the actual SQL of the three no-show mutation paths against
+ * a real Postgres instance:
+ *   - NoShowPolicyService.recordSuccessfulAppointment / checkTierReset
+ *   - SuspensionLiftService.processSuspensionLifts
+ *   - DisputeController.reverseNoShowPenalty
+ *
+ * This suite catches the class of bug that the unit tests cannot:
+ * column typos, broken CASE mappings, malformed RETURNING, empty-policy
+ * edge cases, and so on.
+ *
+ * Enablement: set TEST_DATABASE_URL in backend/.env.test (picked up by
+ * tests/setup.ts) or in the shell. When unset, the whole suite skips.
+ * NEVER point it at a production DB — the suite writes rows and deletes
+ * them via a `0xtest_` address prefix.
+ */
+
+// IMPORTANT: set DATABASE_URL before any service import that transitively
+// pulls in getSharedPool(). The pool is lazy and reads process.env once.
+const testDbUrl = process.env.TEST_DATABASE_URL;
+if (testDbUrl) {
+  process.env.DATABASE_URL = testDbUrl;
+}
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from '@jest/globals';
+import { Pool } from 'pg';
+import { NoShowPolicyService } from '../../src/services/NoShowPolicyService';
+import { SuspensionLiftService } from '../../src/services/SuspensionLiftService';
+import { reverseNoShowPenalty } from '../../src/domains/ServiceDomain/controllers/DisputeController';
+import { getSharedPool, closeSharedPool } from '../../src/utils/database-pool';
+
+const d = testDbUrl ? describe : describe.skip;
+const TEST_SHOP_ID = 'integration-test-shop';
+const ADDRESS_PREFIX = '0xtest_'; // lowercase for consistent LIKE matching
+
+function uniqueAddress(): string {
+  const suffix = Math.random().toString(16).slice(2, 10);
+  return `${ADDRESS_PREFIX}${suffix}`.toLowerCase();
+}
+
+d('No-Show SQL Integration', () => {
+  let pool: Pool;
+  let schemaReady = false;
+
+  beforeAll(async () => {
+    pool = getSharedPool();
+
+    // Verify required tables exist before running destructive writes.
+    const { rows } = await pool.query(`
+      SELECT table_name FROM information_schema.tables
+      WHERE table_schema = 'public'
+        AND table_name IN ('customers', 'no_show_history', 'shop_no_show_policy', 'notifications')
+    `);
+    const tables = rows.map(r => r.table_name);
+    const required = ['customers', 'no_show_history', 'shop_no_show_policy', 'notifications'];
+    const missing = required.filter(t => !tables.includes(t));
+
+    if (missing.length > 0) {
+      console.warn(`Integration suite: missing tables ${missing.join(', ')} — tests will bail out`);
+      return;
+    }
+
+    // Seed a shop_no_show_policy row so the cascade SQL's threshold subquery
+    // returns a row. Idempotent via ON CONFLICT. No FK to shops was enforced
+    // at suite authoring time (see migration 065); if a FK landed later and
+    // blocks this insert, remove the ON CONFLICT or add a shops row first.
+    await pool.query(
+      `INSERT INTO shop_no_show_policy (shop_id, deposit_reset_after_successful)
+       VALUES ($1, 3)
+       ON CONFLICT (shop_id) DO NOTHING`,
+      [TEST_SHOP_ID]
+    );
+
+    schemaReady = true;
+  });
+
+  afterAll(async () => {
+    if (schemaReady) {
+      await pool.query(`DELETE FROM shop_no_show_policy WHERE shop_id = $1`, [TEST_SHOP_ID]);
+    }
+    await closeSharedPool();
+  });
+
+  afterEach(async () => {
+    if (!schemaReady) return;
+    await pool.query(`DELETE FROM notifications WHERE LOWER(receiver_address) LIKE $1`, [`${ADDRESS_PREFIX}%`]);
+    await pool.query(`DELETE FROM no_show_history WHERE LOWER(customer_address) LIKE $1`, [`${ADDRESS_PREFIX}%`]);
+    await pool.query(`DELETE FROM customers WHERE LOWER(address) LIKE $1`, [`${ADDRESS_PREFIX}%`]);
+  });
+
+  /** Seed a customer row with the specific tier/count state a test needs. */
+  async function seedCustomer(address: string, fields: {
+    no_show_count: number;
+    no_show_tier: string;
+    successful_appointments_since_tier3?: number;
+    deposit_required?: boolean;
+    booking_suspended_until?: Date | null;
+    last_no_show_at?: Date | null;
+  }): Promise<void> {
+    await pool.query(
+      `INSERT INTO customers (
+         address, no_show_count, no_show_tier,
+         successful_appointments_since_tier3, deposit_required,
+         booking_suspended_until, last_no_show_at
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      [
+        address,
+        fields.no_show_count,
+        fields.no_show_tier,
+        fields.successful_appointments_since_tier3 ?? 0,
+        fields.deposit_required ?? false,
+        fields.booking_suspended_until ?? null,
+        fields.last_no_show_at ?? null
+      ]
+    );
+  }
+
+  async function loadCustomer(address: string): Promise<any> {
+    const { rows } = await pool.query(`SELECT * FROM customers WHERE address = $1`, [address]);
+    return rows[0];
+  }
+
+  // ============================================================
+  // Cascade reset — NoShowPolicyService
+  // ============================================================
+  describe('NoShowPolicyService.recordSuccessfulAppointment', () => {
+    it('warning + counter=2 + successful appointment → normal with full reset', async () => {
+      if (!schemaReady) return;
+      const addr = uniqueAddress();
+      await seedCustomer(addr, {
+        no_show_count: 5,
+        no_show_tier: 'warning',
+        successful_appointments_since_tier3: 2,
+        last_no_show_at: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000)
+      });
+
+      const service = new NoShowPolicyService();
+      await service.recordSuccessfulAppointment(addr);
+
+      const row = await loadCustomer(addr);
+      expect(row.no_show_tier).toBe('normal');
+      expect(row.no_show_count).toBe(0);
+      expect(row.last_no_show_at).toBeNull();
+      expect(row.successful_appointments_since_tier3).toBe(0);
+      expect(row.deposit_required).toBe(false);
+    });
+
+    it('caution + counter=2 + successful appointment → warning (count preserved)', async () => {
+      if (!schemaReady) return;
+      const addr = uniqueAddress();
+      const originalLastNoShow = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
+      await seedCustomer(addr, {
+        no_show_count: 5,
+        no_show_tier: 'caution',
+        successful_appointments_since_tier3: 2,
+        last_no_show_at: originalLastNoShow
+      });
+
+      const service = new NoShowPolicyService();
+      await service.recordSuccessfulAppointment(addr);
+
+      const row = await loadCustomer(addr);
+      expect(row.no_show_tier).toBe('warning');
+      expect(row.no_show_count).toBe(5); // unchanged at intermediate steps
+      expect(row.successful_appointments_since_tier3).toBe(0);
+      expect(row.last_no_show_at).toEqual(originalLastNoShow);
+    });
+
+    it('counter not yet at threshold → only increments, no tier drop', async () => {
+      if (!schemaReady) return;
+      const addr = uniqueAddress();
+      await seedCustomer(addr, {
+        no_show_count: 5,
+        no_show_tier: 'caution',
+        successful_appointments_since_tier3: 0
+      });
+
+      const service = new NoShowPolicyService();
+      await service.recordSuccessfulAppointment(addr);
+
+      const row = await loadCustomer(addr);
+      expect(row.no_show_tier).toBe('caution');
+      expect(row.successful_appointments_since_tier3).toBe(1);
+    });
+
+    it('tier=normal is untouched', async () => {
+      if (!schemaReady) return;
+      const addr = uniqueAddress();
+      await seedCustomer(addr, {
+        no_show_count: 0,
+        no_show_tier: 'normal',
+        successful_appointments_since_tier3: 0
+      });
+
+      const service = new NoShowPolicyService();
+      await service.recordSuccessfulAppointment(addr);
+
+      const row = await loadCustomer(addr);
+      expect(row.no_show_tier).toBe('normal');
+      expect(row.successful_appointments_since_tier3).toBe(0);
+    });
+  });
+
+  // ============================================================
+  // Suspension lift — SuspensionLiftService
+  // ============================================================
+  describe('SuspensionLiftService.processSuspensionLifts', () => {
+    it('suspended + booking_suspended_until in the past → cascades to deposit_required', async () => {
+      if (!schemaReady) return;
+      const addr = uniqueAddress();
+      await seedCustomer(addr, {
+        no_show_count: 5,
+        no_show_tier: 'suspended',
+        booking_suspended_until: new Date(Date.now() - 60 * 60 * 1000),
+        deposit_required: true
+      });
+
+      const service = new SuspensionLiftService();
+      const report = await service.processSuspensionLifts();
+
+      expect(report.customersLifted).toBeGreaterThanOrEqual(1);
+
+      const row = await loadCustomer(addr);
+      expect(row.no_show_tier).toBe('deposit_required');
+      expect(row.booking_suspended_until).toBeNull();
+      expect(row.successful_appointments_since_tier3).toBe(0);
+      expect(row.deposit_required).toBe(true);
+    });
+
+    it('suspended + booking_suspended_until still in the future → untouched', async () => {
+      if (!schemaReady) return;
+      const addr = uniqueAddress();
+      const futureDate = new Date(Date.now() + 60 * 60 * 1000);
+      await seedCustomer(addr, {
+        no_show_count: 5,
+        no_show_tier: 'suspended',
+        booking_suspended_until: futureDate,
+        deposit_required: true
+      });
+
+      const service = new SuspensionLiftService();
+      await service.processSuspensionLifts();
+
+      const row = await loadCustomer(addr);
+      expect(row.no_show_tier).toBe('suspended');
+      expect(row.booking_suspended_until).toEqual(futureDate);
+    });
+  });
+
+  // ============================================================
+  // Dispute reversal — DisputeController.reverseNoShowPenalty
+  // ============================================================
+  describe('reverseNoShowPenalty', () => {
+    it('marks the history row reversed and recomputes customer count/tier', async () => {
+      if (!schemaReady) return;
+      const addr = uniqueAddress();
+      await seedCustomer(addr, {
+        no_show_count: 2,
+        no_show_tier: 'caution'
+      });
+
+      // Seed two history rows; we'll reverse only the first.
+      const { rows: insertedRows } = await pool.query(
+        `INSERT INTO no_show_history (
+           customer_address, order_id, service_id, shop_id,
+           scheduled_time, marked_by
+         )
+         VALUES
+           ($1, gen_random_uuid(), gen_random_uuid(), $2, NOW() - INTERVAL '3 days', 'SYSTEM'),
+           ($1, gen_random_uuid(), gen_random_uuid(), $2, NOW() - INTERVAL '1 day',  'SYSTEM')
+         RETURNING id`,
+        [addr, TEST_SHOP_ID]
+      );
+      const firstHistoryId = insertedRows[0].id;
+
+      await reverseNoShowPenalty(pool, addr, TEST_SHOP_ID, firstHistoryId);
+
+      const reversedRow = await pool.query(
+        `SELECT notes FROM no_show_history WHERE id = $1`, [firstHistoryId]
+      );
+      expect(reversedRow.rows[0].notes).toMatch(/\[DISPUTE_REVERSED\]/);
+
+      const customer = await loadCustomer(addr);
+      expect(customer.no_show_count).toBe(1);
+      expect(customer.no_show_tier).toBe('warning');
+    });
+  });
+});

--- a/backend/tests/services/dispute-reversal.test.ts
+++ b/backend/tests/services/dispute-reversal.test.ts
@@ -1,0 +1,33 @@
+/**
+ * DisputeController.reverseNoShowPenalty — regression guard
+ *
+ * Context: a typo (`nocctes` instead of `notes`) was shipped in the
+ * reversal SQL at DisputeController.ts:696. It caused every dispute
+ * approval to throw `column "nocctes" does not exist` at runtime.
+ * The function is module-private, so we guard with a static check on
+ * the source file rather than a direct unit call.
+ */
+import { describe, it, expect } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const CONTROLLER_PATH = join(
+  __dirname,
+  '../../src/domains/ServiceDomain/controllers/DisputeController.ts'
+);
+
+describe('DisputeController.reverseNoShowPenalty SQL', () => {
+  const source = readFileSync(CONTROLLER_PATH, 'utf8');
+
+  it('does not reference the historical `nocctes` typo', () => {
+    expect(source).not.toMatch(/nocctes/);
+  });
+
+  it('references `notes NOT LIKE` in the effective-count query', () => {
+    expect(source).toMatch(/notes\s+NOT\s+LIKE\s+'%\[DISPUTE_REVERSED\]%'/);
+  });
+
+  it('marks reversed records with [DISPUTE_REVERSED] in notes (not deletion)', () => {
+    expect(source).toMatch(/\[DISPUTE_REVERSED\]/);
+  });
+});

--- a/backend/tests/services/dispute-reversal.test.ts
+++ b/backend/tests/services/dispute-reversal.test.ts
@@ -1,11 +1,12 @@
 /**
- * DisputeController.reverseNoShowPenalty — regression guard
+ * DisputeController.reverseNoShowPenalty — static sanity guard.
  *
- * Context: a typo (`nocctes` instead of `notes`) was shipped in the
- * reversal SQL at DisputeController.ts:696. It caused every dispute
- * approval to throw `column "nocctes" does not exist` at runtime.
- * The function is module-private, so we guard with a static check on
- * the source file rather than a direct unit call.
+ * The real coverage for this function lives in
+ * `backend/tests/integration/no-show-sql.test.ts`, which runs the actual
+ * SQL against Postgres. This file stays as a one-line cheap guard
+ * against the specific `nocctes` typo that caused the original incident
+ * — any future reintroduction fails fast without needing the integration
+ * DB set up.
  */
 import { describe, it, expect } from '@jest/globals';
 import { readFileSync } from 'fs';
@@ -16,18 +17,12 @@ const CONTROLLER_PATH = join(
   '../../src/domains/ServiceDomain/controllers/DisputeController.ts'
 );
 
-describe('DisputeController.reverseNoShowPenalty SQL', () => {
-  const source = readFileSync(CONTROLLER_PATH, 'utf8');
-
-  it('does not reference the historical `nocctes` typo', () => {
-    expect(source).not.toMatch(/nocctes/);
-  });
-
-  it('references `notes NOT LIKE` in the effective-count query', () => {
-    expect(source).toMatch(/notes\s+NOT\s+LIKE\s+'%\[DISPUTE_REVERSED\]%'/);
-  });
-
-  it('marks reversed records with [DISPUTE_REVERSED] in notes (not deletion)', () => {
-    expect(source).toMatch(/\[DISPUTE_REVERSED\]/);
+describe('DisputeController — historical typo guard', () => {
+  it('does not reference the `nocctes` column typo', () => {
+    const source = readFileSync(CONTROLLER_PATH, 'utf8');
+    // Match only as a standalone identifier to avoid false-positives on
+    // comments like "historical typo: nocctes" — require a non-word
+    // boundary immediately adjacent to column-position characters.
+    expect(source).not.toMatch(/[\s."(]nocctes[\s."(]/);
   });
 });

--- a/backend/tests/services/no-show-tier-cascade.test.ts
+++ b/backend/tests/services/no-show-tier-cascade.test.ts
@@ -44,9 +44,11 @@ jest.mock('../../src/utils/database-pool', () => ({
 }));
 
 const mockCreateNotification = jest.fn<(...args: any[]) => Promise<any>>();
+const mockBuildMessage = jest.fn<(...args: any[]) => string>();
 jest.mock('../../src/domains/notification/services/NotificationService', () => ({
   NotificationService: jest.fn().mockImplementation(() => ({
-    createNotification: mockCreateNotification
+    createNotification: mockCreateNotification,
+    buildMessage: mockBuildMessage
   }))
 }));
 
@@ -63,6 +65,10 @@ describe('NoShowPolicyService — tier cascade reset', () => {
     mockQueryShouldReject = null;
     mockCreateNotification.mockReset();
     mockCreateNotification.mockResolvedValue({ id: 'notif-1' });
+    mockBuildMessage.mockReset();
+    mockBuildMessage.mockImplementation((_type, data: any) =>
+      data?.fullReset ? 'history has been cleared' : `reduced to ${data?.newTier}`
+    );
     service = new NoShowPolicyService();
   });
 

--- a/backend/tests/services/no-show-tier-cascade.test.ts
+++ b/backend/tests/services/no-show-tier-cascade.test.ts
@@ -107,8 +107,8 @@ describe('NoShowPolicyService — tier cascade reset', () => {
       const cascade = mockQueryCalls.find(c => /RETURNING/i.test(c.text));
       expect(cascade).toBeDefined();
       const sql = cascade!.text.replace(/\s+/g, ' ');
-      expect(sql).toContain('deposit_reset_after_successful AS n');
-      expect(sql).toContain('COALESCE(t.n, 3)');
+      expect(sql).toContain('SELECT deposit_reset_after_successful FROM shop_no_show_policy LIMIT 1');
+      expect(sql).toMatch(/COALESCE\(\s*\(SELECT deposit_reset_after_successful FROM shop_no_show_policy LIMIT 1\),\s*3\s*\)/);
     });
 
     it('filters to penalized tiers only (never touches normal or suspended)', async () => {

--- a/backend/tests/services/no-show-tier-cascade.test.ts
+++ b/backend/tests/services/no-show-tier-cascade.test.ts
@@ -1,0 +1,228 @@
+/**
+ * NoShowPolicyService — tier cascade reset tests
+ *
+ * Verifies the earn-back flow:
+ *   recordSuccessfulAppointment() increments the counter for any penalized
+ *   tier (deposit_required, caution, warning), and checkTierReset() drops
+ *   one tier when the counter crosses the threshold, cascading through
+ *   deposit_required -> caution -> warning -> normal.
+ *
+ * File under test: backend/src/services/NoShowPolicyService.ts
+ */
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+const mockQueryCalls: Array<{ text: string; params: any[] }> = [];
+let nextUpdateRowCount = 0;
+let nextReturningRows: Array<{ address: string; new_tier: string; previous_tier: string }> = [];
+let mockQueryShouldReject: Error | null = null;
+
+const stableMockQuery = jest.fn().mockImplementation(async (...args: any[]) => {
+  const text: string = typeof args[0] === 'string' ? args[0] : args[0]?.text ?? '';
+  const params: any[] = args[1] ?? [];
+  mockQueryCalls.push({ text, params });
+
+  if (mockQueryShouldReject) {
+    const err = mockQueryShouldReject;
+    mockQueryShouldReject = null;
+    throw err;
+  }
+
+  if (/UPDATE\s+customers/i.test(text) && /RETURNING/i.test(text)) {
+    return { rows: nextReturningRows, rowCount: nextReturningRows.length };
+  }
+  if (/UPDATE\s+customers/i.test(text)) {
+    return { rows: [], rowCount: nextUpdateRowCount };
+  }
+  return { rows: [], rowCount: 0 };
+});
+
+const stablePool = { query: stableMockQuery };
+
+jest.mock('../../src/utils/database-pool', () => ({
+  __esModule: true,
+  getSharedPool: () => stablePool
+}));
+
+const mockCreateNotification = jest.fn<(...args: any[]) => Promise<any>>();
+jest.mock('../../src/domains/notification/services/NotificationService', () => ({
+  NotificationService: jest.fn().mockImplementation(() => ({
+    createNotification: mockCreateNotification
+  }))
+}));
+
+// Import AFTER mocks so the service picks up the mocked pool & NotificationService
+import { NoShowPolicyService } from '../../src/services/NoShowPolicyService';
+
+describe('NoShowPolicyService — tier cascade reset', () => {
+  let service: NoShowPolicyService;
+
+  beforeEach(() => {
+    mockQueryCalls.length = 0;
+    nextUpdateRowCount = 0;
+    nextReturningRows = [];
+    mockQueryShouldReject = null;
+    mockCreateNotification.mockReset();
+    mockCreateNotification.mockResolvedValue({ id: 'notif-1' });
+    service = new NoShowPolicyService();
+  });
+
+  describe('recordSuccessfulAppointment — counter increment SQL', () => {
+    it('increments the counter for deposit_required, caution, or warning tiers', async () => {
+      nextUpdateRowCount = 0; // prevent cascade from running in this test
+      await service.recordSuccessfulAppointment('0xABC');
+
+      const incrementCall = mockQueryCalls[0];
+      const sql = incrementCall.text.replace(/\s+/g, ' ');
+      expect(sql).toContain("no_show_tier IN ('deposit_required', 'caution', 'warning')");
+      expect(sql).toContain('successful_appointments_since_tier3 = successful_appointments_since_tier3 + 1');
+      expect(incrementCall.params[0]).toBe('0xabc');
+    });
+
+    it('does not run the cascade UPDATE when no row was incremented (normal/suspended)', async () => {
+      nextUpdateRowCount = 0;
+      await service.recordSuccessfulAppointment('0xABC');
+
+      // Only the increment ran — no second UPDATE (the cascade one with RETURNING)
+      const cascadeCalls = mockQueryCalls.filter(c => /RETURNING/i.test(c.text));
+      expect(cascadeCalls).toHaveLength(0);
+      expect(mockCreateNotification).not.toHaveBeenCalled();
+    });
+
+    it('runs the cascade UPDATE when the increment affected a row', async () => {
+      nextUpdateRowCount = 1;
+      nextReturningRows = []; // counter not yet at threshold
+      await service.recordSuccessfulAppointment('0xABC');
+
+      const cascadeCalls = mockQueryCalls.filter(c => /RETURNING/i.test(c.text));
+      expect(cascadeCalls).toHaveLength(1);
+    });
+  });
+
+  describe('checkTierReset — cascade SQL shape', () => {
+    it('uses the shop policy threshold with a fallback of 3', async () => {
+      nextUpdateRowCount = 1;
+      nextReturningRows = [];
+      await service.recordSuccessfulAppointment('0xABC');
+
+      const cascade = mockQueryCalls.find(c => /RETURNING/i.test(c.text));
+      expect(cascade).toBeDefined();
+      const sql = cascade!.text.replace(/\s+/g, ' ');
+      expect(sql).toContain('deposit_reset_after_successful AS n');
+      expect(sql).toContain('COALESCE(t.n, 3)');
+    });
+
+    it('filters to penalized tiers only (never touches normal or suspended)', async () => {
+      nextUpdateRowCount = 1;
+      nextReturningRows = [];
+      await service.recordSuccessfulAppointment('0xABC');
+
+      const cascade = mockQueryCalls.find(c => /RETURNING/i.test(c.text));
+      const sql = cascade!.text.replace(/\s+/g, ' ');
+      expect(sql).toContain("c.no_show_tier IN ('deposit_required', 'caution', 'warning')");
+      expect(sql).not.toMatch(/c\.no_show_tier\s*=\s*'suspended'/);
+    });
+
+    it('maps each tier down exactly one step', async () => {
+      nextUpdateRowCount = 1;
+      nextReturningRows = [];
+      await service.recordSuccessfulAppointment('0xABC');
+
+      const cascade = mockQueryCalls.find(c => /RETURNING/i.test(c.text));
+      const sql = cascade!.text.replace(/\s+/g, ' ');
+      expect(sql).toContain("WHEN c.no_show_tier = 'deposit_required' THEN 'caution'");
+      expect(sql).toContain("WHEN c.no_show_tier = 'caution' THEN 'warning'");
+      expect(sql).toContain("WHEN c.no_show_tier = 'warning' THEN 'normal'");
+    });
+
+    it('clears deposit_required and resets the counter on a successful drop', async () => {
+      nextUpdateRowCount = 1;
+      nextReturningRows = [];
+      await service.recordSuccessfulAppointment('0xABC');
+
+      const cascade = mockQueryCalls.find(c => /RETURNING/i.test(c.text));
+      const sql = cascade!.text.replace(/\s+/g, ' ');
+      expect(sql).toContain('deposit_required = FALSE');
+      expect(sql).toContain('successful_appointments_since_tier3 = 0');
+    });
+
+    it('wipes no_show_count and last_no_show_at only on the final warning -> normal step', async () => {
+      nextUpdateRowCount = 1;
+      nextReturningRows = [];
+      await service.recordSuccessfulAppointment('0xABC');
+
+      const cascade = mockQueryCalls.find(c => /RETURNING/i.test(c.text));
+      const sql = cascade!.text.replace(/\s+/g, ' ');
+      expect(sql).toContain("no_show_count = CASE WHEN c.no_show_tier = 'warning' THEN 0");
+      expect(sql).toContain("last_no_show_at = CASE WHEN c.no_show_tier = 'warning' THEN NULL");
+    });
+  });
+
+  describe('notifications on tier drop', () => {
+    it('sends a tier_restored notification when the customer drops a tier', async () => {
+      nextUpdateRowCount = 1;
+      nextReturningRows = [
+        { address: '0xabc', new_tier: 'caution', previous_tier: 'deposit_required' }
+      ];
+
+      await service.recordSuccessfulAppointment('0xABC');
+
+      expect(mockCreateNotification).toHaveBeenCalledTimes(1);
+      const call = mockCreateNotification.mock.calls[0][0] as any;
+      expect(call.receiverAddress).toBe('0xabc');
+      expect(call.notificationType).toBe('tier_restored');
+      expect(call.metadata).toMatchObject({
+        previousTier: 'deposit_required',
+        newTier: 'caution',
+        reason: 'successful_appointments'
+      });
+    });
+
+    it('uses a "history cleared" message and flags fullReset when newTier is normal', async () => {
+      nextUpdateRowCount = 1;
+      nextReturningRows = [
+        { address: '0xabc', new_tier: 'normal', previous_tier: 'warning' }
+      ];
+
+      await service.recordSuccessfulAppointment('0xABC');
+
+      const call = mockCreateNotification.mock.calls[0][0] as any;
+      expect(call.message).toMatch(/history has been cleared|back to good standing/i);
+      expect(call.metadata.fullReset).toBe(true);
+    });
+
+    it('does not flag fullReset for intermediate cascade steps', async () => {
+      nextUpdateRowCount = 1;
+      nextReturningRows = [
+        { address: '0xabc', new_tier: 'warning', previous_tier: 'caution' }
+      ];
+
+      await service.recordSuccessfulAppointment('0xABC');
+
+      const call = mockCreateNotification.mock.calls[0][0] as any;
+      expect(call.metadata.fullReset).toBe(false);
+    });
+
+    it('does not send a notification when no tier dropped', async () => {
+      nextUpdateRowCount = 1;
+      nextReturningRows = []; // counter incremented but threshold not crossed
+
+      await service.recordSuccessfulAppointment('0xABC');
+
+      expect(mockCreateNotification).not.toHaveBeenCalled();
+    });
+
+    it('swallows notification failures without rolling back the DB update', async () => {
+      nextUpdateRowCount = 1;
+      nextReturningRows = [
+        { address: '0xabc', new_tier: 'warning', previous_tier: 'caution' }
+      ];
+      mockCreateNotification.mockRejectedValueOnce(new Error('notify-down'));
+
+      await expect(service.recordSuccessfulAppointment('0xABC')).resolves.toBeUndefined();
+
+      // The cascade UPDATE still ran; the error was caught internally.
+      const cascade = mockQueryCalls.find(c => /RETURNING/i.test(c.text));
+      expect(cascade).toBeDefined();
+    });
+  });
+});

--- a/backend/tests/services/suspension-lift.test.ts
+++ b/backend/tests/services/suspension-lift.test.ts
@@ -36,9 +36,11 @@ jest.mock('../../src/utils/database-pool', () => ({
 }));
 
 const mockCreateNotification = jest.fn<(...args: any[]) => Promise<any>>();
+const mockBuildMessage = jest.fn<(...args: any[]) => string>();
 jest.mock('../../src/domains/notification/services/NotificationService', () => ({
   NotificationService: jest.fn().mockImplementation(() => ({
-    createNotification: mockCreateNotification
+    createNotification: mockCreateNotification,
+    buildMessage: mockBuildMessage
   }))
 }));
 
@@ -54,6 +56,10 @@ describe('SuspensionLiftService', () => {
     mockQueryRejection = null;
     mockCreateNotification.mockReset();
     mockCreateNotification.mockResolvedValue({ id: 'notif-1' });
+    mockBuildMessage.mockReset();
+    mockBuildMessage.mockImplementation((_type, data: any) =>
+      `suspension lifted to ${data?.newTier}`
+    );
     service = new SuspensionLiftService();
   });
 

--- a/backend/tests/services/suspension-lift.test.ts
+++ b/backend/tests/services/suspension-lift.test.ts
@@ -1,0 +1,194 @@
+/**
+ * SuspensionLiftService — unit tests
+ *
+ * Verifies that the scheduled service correctly:
+ *  - Downgrades tier based on remaining no_show_count
+ *  - Clears booking_suspended_until
+ *  - Resets successful_appointments_since_tier3
+ *  - Sends a 'suspension_lifted' notification per lifted customer
+ *  - Keeps the lift atomic even when notification fails
+ *
+ * File under test: backend/src/services/SuspensionLiftService.ts
+ */
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+const mockQueryCalls: Array<{ text: string; params: any[] }> = [];
+let mockReturningRows: Array<{ address: string; no_show_count: number; no_show_tier: string }> = [];
+let mockQueryRejection: Error | null = null;
+
+const stableMockQuery = jest.fn().mockImplementation(async (...args: any[]) => {
+  const text: string = typeof args[0] === 'string' ? args[0] : args[0]?.text ?? '';
+  const params: any[] = args[1] ?? [];
+  mockQueryCalls.push({ text, params });
+  if (mockQueryRejection) {
+    const err = mockQueryRejection;
+    mockQueryRejection = null;
+    throw err;
+  }
+  return { rows: mockReturningRows };
+});
+
+const stablePool = { query: stableMockQuery };
+
+jest.mock('../../src/utils/database-pool', () => ({
+  __esModule: true,
+  getSharedPool: () => stablePool
+}));
+
+const mockCreateNotification = jest.fn<(...args: any[]) => Promise<any>>();
+jest.mock('../../src/domains/notification/services/NotificationService', () => ({
+  NotificationService: jest.fn().mockImplementation(() => ({
+    createNotification: mockCreateNotification
+  }))
+}));
+
+// Import AFTER mocks so the service picks up the mocked pool & NotificationService
+import { SuspensionLiftService } from '../../src/services/SuspensionLiftService';
+
+describe('SuspensionLiftService', () => {
+  let service: SuspensionLiftService;
+
+  beforeEach(() => {
+    mockQueryCalls.length = 0;
+    mockReturningRows = [];
+    mockQueryRejection = null;
+    mockCreateNotification.mockReset();
+    mockCreateNotification.mockResolvedValue({ id: 'notif-1' });
+    service = new SuspensionLiftService();
+  });
+
+  describe('SQL query structure', () => {
+    it('filters only suspended customers whose suspension has elapsed', async () => {
+      await service.processSuspensionLifts();
+
+      expect(mockQueryCalls).toHaveLength(1);
+      const sql = mockQueryCalls[0].text.replace(/\s+/g, ' ');
+      expect(sql).toContain("no_show_tier = 'suspended'");
+      expect(sql).toContain('booking_suspended_until IS NOT NULL');
+      expect(sql).toContain('booking_suspended_until <= NOW()');
+    });
+
+    it('clears booking_suspended_until and resets successful_appointments_since_tier3', async () => {
+      await service.processSuspensionLifts();
+      const sql = mockQueryCalls[0].text.replace(/\s+/g, ' ');
+      expect(sql).toContain('booking_suspended_until = NULL');
+      expect(sql).toContain('successful_appointments_since_tier3 = 0');
+    });
+
+    it('uses default thresholds (3/2/1) for the tier cascade', async () => {
+      await service.processSuspensionLifts();
+      const sql = mockQueryCalls[0].text.replace(/\s+/g, ' ');
+      expect(sql).toContain("WHEN no_show_count >= 3 THEN 'deposit_required'");
+      expect(sql).toContain("WHEN no_show_count >= 2 THEN 'caution'");
+      expect(sql).toContain("WHEN no_show_count = 1 THEN 'warning'");
+      expect(sql).toContain("ELSE 'normal'");
+    });
+  });
+
+  describe('notifications', () => {
+    it('sends one notification per lifted customer', async () => {
+      mockReturningRows = [
+        { address: '0xaaa', no_show_count: 5, no_show_tier: 'deposit_required' },
+        { address: '0xbbb', no_show_count: 2, no_show_tier: 'caution' }
+      ];
+
+      const report = await service.processSuspensionLifts();
+
+      expect(report.customersLifted).toBe(2);
+      expect(report.notificationsSent).toBe(2);
+      expect(mockCreateNotification).toHaveBeenCalledTimes(2);
+
+      const firstCall = mockCreateNotification.mock.calls[0][0] as any;
+      expect(firstCall.receiverAddress).toBe('0xaaa');
+      expect(firstCall.notificationType).toBe('suspension_lifted');
+      expect(firstCall.metadata).toMatchObject({
+        previousTier: 'suspended',
+        newTier: 'deposit_required',
+        noShowCount: 5,
+        depositRequired: true
+      });
+    });
+
+    it('does not send notifications when nothing was lifted', async () => {
+      mockReturningRows = [];
+
+      const report = await service.processSuspensionLifts();
+
+      expect(report.customersLifted).toBe(0);
+      expect(report.notificationsSent).toBe(0);
+      expect(mockCreateNotification).not.toHaveBeenCalled();
+      expect(report.errors).toHaveLength(0);
+    });
+
+    it('continues when one notification fails and records the error', async () => {
+      mockReturningRows = [
+        { address: '0xaaa', no_show_count: 5, no_show_tier: 'deposit_required' },
+        { address: '0xbbb', no_show_count: 5, no_show_tier: 'deposit_required' }
+      ];
+      mockCreateNotification
+        .mockRejectedValueOnce(new Error('notify-down'))
+        .mockResolvedValueOnce({ id: 'notif-2' });
+
+      const report = await service.processSuspensionLifts();
+
+      expect(report.customersLifted).toBe(2);
+      expect(report.notificationsSent).toBe(1);
+      expect(report.errors).toHaveLength(1);
+      expect(report.errors[0]).toContain('0xaaa');
+      expect(report.errors[0]).toContain('notify-down');
+    });
+
+    it('flags depositRequired=false for caution / warning / normal tiers', async () => {
+      mockReturningRows = [
+        { address: '0xccc', no_show_count: 2, no_show_tier: 'caution' }
+      ];
+
+      await service.processSuspensionLifts();
+
+      const call = mockCreateNotification.mock.calls[0][0] as any;
+      expect(call.metadata.depositRequired).toBe(false);
+      expect(call.metadata.newTier).toBe('caution');
+    });
+  });
+
+  describe('error handling', () => {
+    it('captures UPDATE query errors without throwing', async () => {
+      mockQueryRejection = new Error('connection lost');
+
+      const report = await service.processSuspensionLifts();
+
+      expect(report.customersLifted).toBe(0);
+      expect(report.notificationsSent).toBe(0);
+      expect(report.errors).toHaveLength(1);
+      expect(report.errors[0]).toContain('connection lost');
+    });
+  });
+
+  describe('scheduler lifecycle', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      service.stop();
+      jest.useRealTimers();
+    });
+
+    it('start() sets isRunning and schedules an interval', () => {
+      service.start();
+      expect(service.getStatus().isRunning).toBe(true);
+    });
+
+    it('start() is idempotent — second call does not schedule twice', () => {
+      service.start();
+      service.start();
+      expect(service.getStatus().isRunning).toBe(true);
+    });
+
+    it('stop() clears isRunning', () => {
+      service.start();
+      service.stop();
+      expect(service.getStatus().isRunning).toBe(false);
+    });
+  });
+});

--- a/frontend/src/app/(authenticated)/customer/CustomerDashboardClient.tsx
+++ b/frontend/src/app/(authenticated)/customer/CustomerDashboardClient.tsx
@@ -106,13 +106,17 @@ export default function CustomerDashboardClient() {
   }, [searchParams]);
 
   // Fetch no-show status (shop-agnostic)
+  // thirdweb's useActiveAccount() can lag behind auth rehydration on page refresh,
+  // leaving account?.address undefined while isAuthenticated is already true.
+  // Fall back to userProfile.address; switchingAccount still guards the wallet-switch window.
+  const walletAddress = userProfile?.address || account?.address;
   useEffect(() => {
     const fetchNoShowStatus = async () => {
-      if (!account?.address || !isAuthenticated || switchingAccount) return;
+      if (!walletAddress || !isAuthenticated || switchingAccount) return;
 
       setLoadingNoShowStatus(true);
       try {
-        const status = await getOverallCustomerNoShowStatus(account.address);
+        const status = await getOverallCustomerNoShowStatus(walletAddress);
         setNoShowStatus(status);
       } catch (error) {
         console.error('Error fetching no-show status:', error);
@@ -123,7 +127,7 @@ export default function CustomerDashboardClient() {
     };
 
     fetchNoShowStatus();
-  }, [account?.address, isAuthenticated, switchingAccount]);
+  }, [walletAddress, isAuthenticated, switchingAccount]);
 
   // Get login function to refresh profile when page becomes visible
   const { login } = useAuthStore();

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -68,7 +68,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" className={`${inriaSans.variable} ${poppinsExtended.variable}`}>
+    <html lang="en" className={`${inriaSans.variable} ${poppinsExtended.variable}`} suppressHydrationWarning>
       {/* Google Analytics */}
       <Script
         src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}

--- a/frontend/src/components/customer/NoShowWarningBanner.tsx
+++ b/frontend/src/components/customer/NoShowWarningBanner.tsx
@@ -46,14 +46,23 @@ export default function NoShowWarningBanner({ status, onDismiss }: NoShowWarning
           textColor: 'text-red-900',
           iconBgColor: 'bg-red-100',
           icon: '🚨',
-          title: 'Refundable Deposit Required',
-          message: `Due to ${status.noShowCount} missed appointments, you must now pay a refundable deposit for all bookings:`,
+          title: 'Deposit Required - Account Restricted',
+          message: `Due to ${status.noShowCount} missed appointments, the following restrictions apply:`,
           showDetails: true
         };
 
       case 'suspended':
-        const suspensionEndDate = status.bookingSuspendedUntil
-          ? new Date(status.bookingSuspendedUntil).toLocaleDateString('en-US', {
+        // Safety net: backend cron reconciles expired suspensions every ~15 min.
+        // Hide the banner if the suspension has already elapsed but the tier hasn't caught up yet.
+        const suspendedUntilDate = status.bookingSuspendedUntil
+          ? new Date(status.bookingSuspendedUntil)
+          : null;
+        if (suspendedUntilDate && suspendedUntilDate <= new Date()) {
+          return null;
+        }
+
+        const suspensionEndDate = suspendedUntilDate
+          ? suspendedUntilDate.toLocaleDateString('en-US', {
               weekday: 'long',
               year: 'numeric',
               month: 'long',

--- a/frontend/src/components/customer/NoShowWarningBanner.tsx
+++ b/frontend/src/components/customer/NoShowWarningBanner.tsx
@@ -120,10 +120,10 @@ export default function NoShowWarningBanner({ status, onDismiss }: NoShowWarning
           )}
 
           {/* Help Text */}
-          {status.tier === 'deposit_required' && (
+          {(status.tier === 'deposit_required' || status.tier === 'caution' || status.tier === 'warning') && (
             <div className="bg-white/50 rounded p-3 mt-3">
               <p className="text-sm text-gray-700">
-                <strong>Good News:</strong> Complete 3 successful appointments and these restrictions will be removed automatically.
+                <strong>Good News:</strong> Complete 3 successful appointments and you'll move to a lower restriction level.
               </p>
               <p className="text-xs text-gray-600 mt-1">
                 Progress: {status.successfulAppointmentsSinceTier3} / 3 successful appointments

--- a/frontend/src/components/customer/ServiceOrdersTab.tsx
+++ b/frontend/src/components/customer/ServiceOrdersTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useRef, useMemo } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import { toast } from "react-hot-toast";
 import { useRouter } from "next/navigation";
 import {
@@ -10,19 +10,15 @@ import {
   XCircle,
   DollarSign,
   Calendar,
-  MapPin,
   Loader2,
   Star,
   Eye,
   HelpCircle,
   ChevronDown,
   ChevronUp,
-  ChevronLeft,
-  ChevronRight,
-  Store,
   RotateCcw,
 } from "lucide-react";
-import { getCustomerOrders, ServiceOrderWithDetails, servicesApi } from "@/services/api/services";
+import { getCustomerOrders, ServiceOrderWithDetails, servicesApi, OrderStatus } from "@/services/api/services";
 import { WriteReviewModal } from "./WriteReviewModal";
 import { BookingDetailsModal } from "./BookingDetailsModal";
 import { BookingCard } from "./BookingCard";
@@ -32,6 +28,7 @@ import DisputeModal from "./DisputeModal";
 import { getDisputeStatus } from "@/services/api/noShow";
 import type { NoShowHistoryEntry } from "@/services/api/noShow";
 import { AlertTriangle } from "lucide-react";
+import Pagination from "@/components/shop/groups/shared/Pagination";
 
 // No-Show banner with dispute status awareness
 const NoShowBanner: React.FC<{
@@ -187,43 +184,36 @@ export const ServiceOrdersTab: React.FC = () => {
   const [viewingOrder, setViewingOrder] = useState<ServiceOrderWithDetails | null>(null);
   const [cancellingOrder, setCancellingOrder] = useState<ServiceOrderWithDetails | null>(null);
   const [disputeOrder, setDisputeOrder] = useState<ServiceOrderWithDetails | null>(null);
-  const filterScrollRef = useRef<HTMLDivElement>(null);
-  const [showLeftArrow, setShowLeftArrow] = useState(false);
-  const [showRightArrow, setShowRightArrow] = useState(true);
-
-  const handleFilterScroll = () => {
-    if (filterScrollRef.current) {
-      const { scrollLeft, scrollWidth, clientWidth } = filterScrollRef.current;
-      setShowLeftArrow(scrollLeft > 0);
-      setShowRightArrow(scrollLeft < scrollWidth - clientWidth - 10);
-    }
-  };
-
-  const scrollFilters = (direction: 'left' | 'right') => {
-    if (filterScrollRef.current) {
-      const scrollAmount = 150;
-      filterScrollRef.current.scrollBy({
-        left: direction === 'left' ? -scrollAmount : scrollAmount,
-        behavior: 'smooth'
-      });
-    }
-  };
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [statusCounts, setStatusCounts] = useState<Record<string, number>>({});
+  const ITEMS_PER_PAGE = 5;
 
   useEffect(() => {
-    loadOrders();
+    setCurrentPage(1);
+    loadOrders(1, filter);
   }, [filter]);
 
-  const loadOrders = async () => {
+  useEffect(() => {
+    loadCounts();
+  }, []);
+
+  const loadOrders = async (page: number = currentPage, currentFilter: string = filter) => {
     setLoading(true);
     try {
-      const statusFilter = filter === "all" ? undefined : filter;
+      const statusFilter = currentFilter === "all" ? undefined : (currentFilter as OrderStatus);
       const response = await getCustomerOrders({
         status: statusFilter,
-        limit: 50,
+        page,
+        limit: ITEMS_PER_PAGE,
       });
 
       if (response) {
         setOrders(response.data);
+        if (response.pagination) {
+          setTotalPages(response.pagination.totalPages);
+          setCurrentPage(response.pagination.page);
+        }
         // Check review eligibility for completed orders
         checkReviewEligibility(response.data);
       }
@@ -233,6 +223,29 @@ export const ServiceOrdersTab: React.FC = () => {
     } finally {
       setLoading(false);
     }
+  };
+
+  const loadCounts = async () => {
+    try {
+      const statuses: OrderStatus[] = ["pending", "paid", "completed", "cancelled", "refunded"];
+      const results = await Promise.all(
+        statuses.map((s) =>
+          getCustomerOrders({ status: s, page: 1, limit: 1 }).then(
+            (r) => [s, r?.pagination?.totalItems ?? 0] as const
+          )
+        )
+      );
+      const counts: Record<string, number> = {};
+      results.forEach(([s, n]) => { counts[s] = n; });
+      setStatusCounts(counts);
+    } catch (error) {
+      console.error("Error loading order counts:", error);
+    }
+  };
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+    loadOrders(page);
   };
 
   const checkReviewEligibility = async (ordersList: ServiceOrderWithDetails[]) => {
@@ -384,13 +397,13 @@ export const ServiceOrdersTab: React.FC = () => {
     });
   };
 
-  // Calculate summary counts
+  // Calculate summary counts from backend status totals (not the current page)
   const getSummary = () => {
     return {
-      pending: orders.filter(o => o.status === "pending").length,
-      paid: orders.filter(o => o.status === "paid" || o.status === "approved" || o.status === "scheduled").length,
-      completed: orders.filter(o => o.status === "completed").length,
-      cancelled: orders.filter(o => o.status === "cancelled").length,
+      pending: statusCounts["pending"] || 0,
+      paid: statusCounts["paid"] || 0,
+      completed: statusCounts["completed"] || 0,
+      cancelled: (statusCounts["cancelled"] || 0) + (statusCounts["refunded"] || 0),
     };
   };
 
@@ -415,106 +428,42 @@ export const ServiceOrdersTab: React.FC = () => {
     );
   }
 
+  const filterPills = [
+    { key: "all", label: "All", count: summary.pending + summary.paid + summary.completed + summary.cancelled },
+    { key: "pending", label: "Pending", count: summary.pending },
+    { key: "paid", label: "Paid", count: summary.paid },
+    { key: "completed", label: "Completed", count: summary.completed },
+    { key: "cancelled", label: "Cancelled", count: summary.cancelled },
+  ];
+
   return (
     <div className="space-y-4">
-      {/* Filter Tabs & Sort */}
+      {/* Filter Pills + Sort */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-        {/* Filter Buttons - Horizontal scroll on mobile with arrows */}
-        <div className="relative flex items-center">
-          {/* Left Arrow */}
-          {showLeftArrow && (
+        <div className="flex flex-wrap gap-2">
+          {filterPills.map((pill) => (
             <button
-              onClick={() => scrollFilters('left')}
-              className="sm:hidden absolute -left-1 top-1/2 -translate-y-1/2 z-10 w-7 h-7 flex items-center justify-center bg-[#1A1A1A] border border-gray-700 rounded-full shadow-lg active:scale-95 transition-transform"
+              key={pill.key}
+              onClick={() => setFilter(pill.key)}
+              className={`px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${
+                filter === pill.key
+                  ? "bg-white text-black"
+                  : "bg-[#1A1A1A] text-gray-400 border border-gray-800 hover:border-gray-600"
+              }`}
             >
-              <ChevronLeft className="w-4 h-4 text-[#FFCC00]" />
+              {pill.label} ({pill.count})
             </button>
-          )}
-
-          {/* Scrollable Filter Container */}
-          <div
-            ref={filterScrollRef}
-            onScroll={handleFilterScroll}
-            className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0"
-            style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
-          >
-            <style jsx>{`div::-webkit-scrollbar { display: none; }`}</style>
-            <div className="flex gap-2 sm:gap-3 flex-nowrap min-w-max pt-2">
-              <button
-                onClick={() => setFilter("all")}
-                className={`px-4 sm:px-6 py-2 sm:py-2.5 rounded-lg text-sm font-semibold transition-all duration-200 whitespace-nowrap ${
-                  filter === "all"
-                    ? "bg-[#FFCC00] text-black"
-                    : "bg-gray-200 text-black hover:bg-gray-300"
-                }`}
-              >
-                All
-              </button>
-              <button
-                onClick={() => setFilter("pending")}
-                className={`relative px-4 sm:px-6 py-2 sm:py-2.5 rounded-lg text-sm font-semibold transition-all duration-200 whitespace-nowrap ${
-                  filter === "pending"
-                    ? "bg-[#FFCC00] text-black"
-                    : "bg-gray-200 text-black hover:bg-gray-300"
-                }`}
-              >
-                Pending
-                {summary.pending > 0 && (
-                  <span className="absolute -top-1 -right-1 w-3 h-3 bg-red-500 rounded-full" />
-                )}
-              </button>
-              <button
-                onClick={() => setFilter("paid")}
-                className={`px-4 sm:px-6 py-2 sm:py-2.5 rounded-lg text-sm font-semibold transition-all duration-200 whitespace-nowrap ${
-                  filter === "paid"
-                    ? "bg-[#FFCC00] text-black"
-                    : "bg-gray-200 text-black hover:bg-gray-300"
-                }`}
-              >
-                Paid
-              </button>
-              <button
-                onClick={() => setFilter("completed")}
-                className={`px-4 sm:px-6 py-2 sm:py-2.5 rounded-lg text-sm font-semibold transition-all duration-200 whitespace-nowrap ${
-                  filter === "completed"
-                    ? "bg-[#FFCC00] text-black"
-                    : "bg-gray-200 text-black hover:bg-gray-300"
-                }`}
-              >
-                Completed
-              </button>
-              <button
-                onClick={() => setFilter("cancelled")}
-                className={`px-4 sm:px-6 py-2 sm:py-2.5 rounded-lg text-sm font-semibold transition-all duration-200 whitespace-nowrap ${
-                  filter === "cancelled"
-                    ? "bg-[#FFCC00] text-black"
-                    : "bg-gray-200 text-black hover:bg-gray-300"
-                }`}
-              >
-                Cancelled
-              </button>
-            </div>
-          </div>
-
-          {/* Right Arrow */}
-          {showRightArrow && (
-            <button
-              onClick={() => scrollFilters('right')}
-              className="sm:hidden absolute -right-1 top-1/2 -translate-y-1/2 z-10 w-7 h-7 flex items-center justify-center bg-[#1A1A1A] border border-gray-700 rounded-full shadow-lg active:scale-95 transition-transform"
-            >
-              <ChevronRight className="w-4 h-4 text-[#FFCC00]" />
-            </button>
-          )}
+          ))}
         </div>
 
-        {/* Sort Dropdown - Hidden on mobile */}
-        <div className="hidden sm:flex items-center gap-2 flex-shrink-0">
+        {/* Sort Dropdown */}
+        <div className="flex items-center gap-2 flex-shrink-0">
           <span className="text-sm text-gray-500">Sort by:</span>
           <Select
             value={sortOrder}
             onValueChange={(value) => setSortOrder(value as "asc" | "desc")}
           >
-            <SelectTrigger className="w-[100px] bg-transparent border border-gray-700 text-white h-9 rounded-lg hover:border-gray-500 transition-colors">
+            <SelectTrigger className="w-[110px] bg-[#1A1A1A] border border-gray-800 text-white h-9 rounded-lg hover:border-gray-600 transition-colors">
               <SelectValue placeholder="Date" />
             </SelectTrigger>
             <SelectContent className="bg-[#1A1A1A] border-gray-800">
@@ -693,12 +642,20 @@ export const ServiceOrdersTab: React.FC = () => {
                 />
               );
             })}
+
+            <Pagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              onPageChange={handlePageChange}
+              disabled={loading}
+            />
           </div>
 
           {/* Quick Summary Sidebar - Hidden on mobile */}
-          <div className="hidden lg:block space-y-4">
+          <div className="hidden lg:block">
+           <div className="sticky top-0 space-y-4">
             {/* Summary Card */}
-            <div className="bg-gradient-to-br from-[#1A1A1A] to-[#0D0D0D] border border-gray-800 rounded-xl p-5 sticky top-4">
+            <div className="bg-gradient-to-br from-[#1A1A1A] to-[#0D0D0D] border border-gray-800 rounded-xl p-5">
               <div className="flex items-center gap-2 mb-4">
                 <div className="w-8 h-8 bg-[#FFCC00] rounded-lg flex items-center justify-center">
                   <ShoppingBag className="w-5 h-5 text-black" />
@@ -786,6 +743,7 @@ export const ServiceOrdersTab: React.FC = () => {
                 </div>
               )}
             </div>
+           </div>
           </div>
         </div>
       )}
@@ -799,6 +757,7 @@ export const ServiceOrdersTab: React.FC = () => {
           onSuccess={() => {
             setReviewingOrder(null);
             loadOrders();
+            loadCounts();
           }}
         />
       )}
@@ -820,6 +779,7 @@ export const ServiceOrdersTab: React.FC = () => {
         onSuccess={() => {
           setCancellingOrder(null);
           loadOrders();
+          loadCounts();
         }}
       />
 
@@ -846,6 +806,7 @@ export const ServiceOrdersTab: React.FC = () => {
           onDisputeSubmitted={() => {
             setDisputeOrder(null);
             loadOrders();
+            loadCounts();
             toast.success("Dispute submitted successfully");
           }}
         />


### PR DESCRIPTION
- reverseNoShowPenalty: null out last_no_show_at when the recalculated count drops to 0, so a fully-cleared customer is internally consistent
  with the cascade final-step state.
- SuspensionLiftService.getStatus: track lastRunAt and compute nextRunEstimate = lastRunAt + INTERVAL, instead of claiming the next
  run is always 15 min from now regardless of when the cron last fired.
- New backend/scripts/repair-stale-suspensions.sql: one-off recovery for legacy rows where no_show_tier='suspended' but booking_suspended_until is NULL — these are invisible to the cron and get stuck forever.

Priority 3b from the review (removing "dead" sortOrder state) was wrong — the state is in use by the Sort dropdown UI. No change.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>