### PR TITLE
fix(mobile): block FOREGROUND_SERVICE_MEDIA_PLAYBACK permission for Play Console compliance

### DIFF
--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -59,6 +59,9 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         "android.permission.INTERNET",
         "android.permission.VIBRATE",
       ],
+      blockedPermissions: [
+        "android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK",
+      ],
     },
     web: {
       bundler: "metro",


### PR DESCRIPTION
The permission was pulled in transitively by expo-video via androidx.media3:media3-session but the app does not perform foreground media playback. Google Play flagged it under the Foreground Services policy (compliance deadline Jan 31, 2024), blocking new releases.

Using Expo's android.blockedPermissions config to strip it from the merged AndroidManifest.xml at build time. Verified locally via npx expo prebuild + ./gradlew :app:processDebugMainManifest — merged manifest now contains only FOREGROUND_SERVICE.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>