### PR TITLE
fix(customer): display no_show status as "No-Show" badge

### DIFF
--- a/frontend/src/components/customer/ServiceOrdersTab.tsx
+++ b/frontend/src/components/customer/ServiceOrdersTab.tsx
@@ -342,15 +342,29 @@ export const ServiceOrdersTab: React.FC = () => {
           description: "This booking was cancelled.",
           color: "text-gray-300"
         };
-      default:
+      case "no_show":
+        return {
+          icon: <AlertTriangle className="w-5 h-5" />,
+          text: "No-Show",
+          badge: "⚠️ No-Show",
+          badgeColor: "bg-orange-500/20 text-orange-300 border-orange-500/30",
+          description: "This booking was marked as a no-show by the shop.",
+          color: "text-orange-300"
+        };
+      default: {
+        const formatted = status
+          .split("_")
+          .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+          .join("-");
         return {
           icon: <Clock className="w-5 h-5" />,
-          text: status,
-          badge: status,
+          text: formatted,
+          badge: formatted,
           badgeColor: "bg-gray-500/20 text-gray-300 border-gray-500/30",
           description: "",
           color: "text-gray-300"
         };
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- Adds a dedicated `no_show` case to `getStatusInfo` in `ServiceOrdersTab.tsx` so the customer-facing status badge renders a styled **"⚠️ No-Show"** label instead of the raw `no_show` snake_case string.
- Improves the `default` case to format any other unknown status into Title-Case (e.g. `some_status` → `Some-Status`), so no raw snake_case can leak into the UI.

## Changes
- `frontend/src/components/customer/ServiceOrdersTab.tsx` — new `no_show` status case (orange styling + `AlertTriangle` icon, consistent with the existing "Marked as No-Show" banner) and a Title-Case fallback for unknown statuses.

## Test plan
- [ ] View a service order with status `no_show` in the customer Service Orders tab — badge shows "⚠️ No-Show".
- [ ] Confirm existing statuses (pending/paid/approved/scheduled/completed/cancelled) render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)