### PR TITLE
fix(promo-codes): correct admin column mapping and refresh button overflow

### DIFF
--- a/backend/src/services/PromoCodeService.ts
+++ b/backend/src/services/PromoCodeService.ts
@@ -293,13 +293,13 @@ export class PromoCodeService {
         pc.code as name,
         pc.shop_id,
         s.name as shop_name,
-        pc.discount_type as bonus_type,
-        pc.discount_value as bonus_value,
-        pc.status = 'active' as is_active,
-        pc.used_count as times_used,
-        (pc.discount_value * pc.used_count) as total_bonus_issued,
-        pc.valid_from as start_date,
-        pc.valid_until as end_date,
+        pc.bonus_type as bonus_type,
+        pc.bonus_value as bonus_value,
+        pc.is_active as is_active,
+        pc.times_used as times_used,
+        (pc.bonus_value * pc.times_used) as total_bonus_issued,
+        pc.start_date as start_date,
+        pc.end_date as end_date,
         pc.created_at
       FROM promo_codes pc
       JOIN shops s ON pc.shop_id = s.shop_id
@@ -315,11 +315,11 @@ export class PromoCodeService {
     const query = `
       SELECT 
         COUNT(DISTINCT pc.id) as total_codes,
-        COUNT(DISTINCT CASE WHEN pc.status = 'active' THEN pc.id END) as active_codes,
+        COUNT(DISTINCT CASE WHEN pc.is_active THEN pc.id END) as active_codes,
         COUNT(DISTINCT pc.shop_id) as shops_with_codes,
-        SUM(pc.used_count) as total_uses,
-        COALESCE(SUM(pc.discount_value * pc.used_count), 0) as total_bonus_issued,
-        AVG(pc.used_count) as avg_uses_per_code
+        SUM(pc.times_used) as total_uses,
+        COALESCE(SUM(pc.bonus_value * pc.times_used), 0) as total_bonus_issued,
+        AVG(pc.times_used) as avg_uses_per_code
       FROM promo_codes pc
     `;
 
@@ -329,11 +329,11 @@ export class PromoCodeService {
         pc.code as name,
         pc.shop_id,
         s.name as shop_name,
-        pc.used_count as times_used,
-        (pc.discount_value * pc.used_count) as total_bonus_issued
+        pc.times_used as times_used,
+        (pc.bonus_value * pc.times_used) as total_bonus_issued
       FROM promo_codes pc
       JOIN shops s ON pc.shop_id = s.shop_id
-      ORDER BY pc.used_count DESC
+      ORDER BY pc.times_used DESC
       LIMIT 10
     `;
 

--- a/frontend/src/components/admin/tabs/PromoCodesAnalyticsTab.tsx
+++ b/frontend/src/components/admin/tabs/PromoCodesAnalyticsTab.tsx
@@ -409,7 +409,7 @@ export default function PromoCodesAnalyticsTab() {
             {/* Filter and Refresh */}
             <div className="flex gap-2 sm:gap-3">
               <Select value={filterStatus} onValueChange={(value) => setFilterStatus(value)}>
-                <SelectTrigger variant="dark" className="flex-1 sm:flex-none text-sm">
+                <SelectTrigger variant="dark" className="flex-1 sm:flex-none sm:w-auto text-sm">
                   <SelectValue placeholder="All Codes" />
                 </SelectTrigger>
                 <SelectContent variant="dark">


### PR DESCRIPTION
## Summary
  Two fixes for the admin **All Promo Codes** page (`/admin?tab=promo-codes`).

  ### 1. Null dates & wrong values in the admin promo views
  `getAllPromoCodes` and `getPromoCodeAnalytics` read the migration-083 duplicate
  columns (`valid_from`/`valid_until`, `discount_type`/`discount_value`, `status`,
  `used_count`) that the write path never populates, so start/end dates and bonus
  values came back null. Repointed both queries at the columns the repository
  actually writes: `start_date`/`end_date`, `bonus_type`/`bonus_value`,
  `is_active`, `times_used`. Output aliases unchanged — no client contract change.

  ### 2. Refresh button overflowing the card
  The shared `SelectTrigger`'s base `w-full` overrode the tab's `sm:flex-none`, so
  the filter dropdown consumed the row and pushed the Refresh button outside the
  card. Added `sm:w-auto` to keep both inside.

  ## Test plan
  - [ ] All Promo Codes table shows correct Valid Period and Bonus for recent codes
  - [ ] Summary cards reflect real usage counts
  - [ ] Desktop width: filter dropdown + Refresh button sit inside the card

  ## Notes
  Read-query-only; no migration/schema change.