### PR TITLE
fix(customer): derive display name so social-login customers aren't "Anonymous"

### DIFF
--- a/backend/src/domains/customer/services/CustomerService.ts
+++ b/backend/src/domains/customer/services/CustomerService.ts
@@ -165,10 +165,19 @@ export class CustomerService {
 
       // Role conflict validation is handled by middleware
 
+      // Derive a display name when one isn't supplied directly. The
+      // registration form and social logins (Google/Apple) only provide
+      // first/last name or email, so without this the `name` column stays
+      // null and the customer shows up as "Anonymous"/"Guest" everywhere.
+      const derivedName =
+        data.name?.trim() ||
+        [data.first_name, data.last_name].filter(Boolean).join(' ').trim() ||
+        undefined;
+
       // Create new customer
       const newCustomer = TierManager.createNewCustomer(
         data.walletAddress,
-        data.name,
+        derivedName,
         data.email,
         data.phone,
         data.fixflowCustomerId,
@@ -261,6 +270,20 @@ export class CustomerService {
       if (updates.email !== undefined) profileUpdates.email = updates.email;
       if (updates.phone !== undefined) profileUpdates.phone = updates.phone;
       if (updates.profile_image_url !== undefined) profileUpdates.profileImageUrl = updates.profile_image_url;
+
+      // Keep the derived display name in sync when first/last change but no
+      // explicit name is provided, so the stored `name` doesn't go stale.
+      if (
+        updates.name === undefined &&
+        (updates.first_name !== undefined || updates.last_name !== undefined)
+      ) {
+        const firstName =
+          updates.first_name !== undefined ? updates.first_name : customer.first_name;
+        const lastName =
+          updates.last_name !== undefined ? updates.last_name : customer.last_name;
+        const derived = [firstName, lastName].filter(Boolean).join(' ').trim();
+        if (derived) profileUpdates.name = derived;
+      }
 
       await customerRepository.updateCustomerProfile(address, profileUpdates);
 

--- a/frontend/src/app/(auth)/register/customer/CustomerRegisterClient.tsx
+++ b/frontend/src/app/(auth)/register/customer/CustomerRegisterClient.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useAuthMethod } from "@/contexts/AuthMethodContext";
 import { useCustomer } from "@/hooks/useCustomer";
 import { getUserEmail } from "thirdweb/wallets";
+import { getProfiles } from "thirdweb/wallets/in-app";
 import { useRecaptcha } from "@/hooks/useRecaptcha";
 
 const client = createThirdwebClient({
@@ -33,18 +34,41 @@ export default function CustomerRegisterClient() {
     clearMessages,
   } = useCustomer();
 
-  // Fetch user email if available
+  // Pre-fill email and name from the social/email login profile if available
   useEffect(() => {
-    const fetchEmail = async () => {
-      if (account?.address) {
-        const email = await getUserEmail({ client });
+    const fetchProfile = async () => {
+      if (!account?.address) return;
 
-        if (email) {
-          updateRegistrationFormField("email", email);
+      const email = await getUserEmail({ client });
+      if (email) {
+        updateRegistrationFormField("email", email);
+      }
+
+      // Pre-fill name from the social (Google/Apple) profile so customers
+      // aren't stored as "Anonymous". External wallets have no profile here,
+      // which is fine — the user can still type their name manually.
+      try {
+        const profiles = await getProfiles({ client });
+        const social = profiles.find(
+          (p) => p.type === "google" || p.type === "apple"
+        );
+        const details = social?.details as
+          | { name?: string; givenName?: string; familyName?: string }
+          | undefined;
+
+        if (details) {
+          const nameParts = details.name?.trim().split(/\s+/) ?? [];
+          const firstName = details.givenName || nameParts[0];
+          const lastName = details.familyName || nameParts.slice(1).join(" ");
+
+          if (firstName) updateRegistrationFormField("first_name", firstName);
+          if (lastName) updateRegistrationFormField("last_name", lastName);
         }
+      } catch {
+        // No social profile available (e.g. external wallet) — ignore
       }
     };
-    fetchEmail();
+    fetchProfile();
   }, [account?.address, updateRegistrationFormField]);
 
   // Handle form submission


### PR DESCRIPTION
 ## Summary
  Customers registered via the form or social login (Google/Apple) only supplied
  `first_name`/`last_name` or email, and the `name` column was never derived from
  them — so it stayed null. They showed up as **"Anonymous"** in shop/admin views
  and **"Hello There, Guest!"** on their own overview.

  ## Changes
  - **`CustomerService.registerCustomer`** — derive `name` from
    `name → "first last" → undefined` before creating the customer.
  - **`CustomerService.updateCustomer`** — keep the derived name in sync when
    first/last change but no explicit name is provided (so it doesn't go stale).
  - **`CustomerRegisterClient`** — pre-fill first/last name from the social profile
    via thirdweb `getProfiles`, mirroring the existing email pre-fill, so
    Google/Apple users get a real name captured at registration.

  ## Test plan
  - [ ] Register a new customer via Google → name is captured, not "Anonymous"
  - [ ] Register via the form with first/last only → `name` is stored as "First Last"
  - [ ] Edit first/last in Settings → display name updates
  - [ ] Shop customers list + customer Overview show the real name