### PR TITLE
fix(ui): prevent layout shift / white bar when dropdowns open

### DIFF
--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -19,6 +19,13 @@
 .thin-scrollbar::-webkit-scrollbar-thumb:hover { background: #555; }
 .thin-scrollbar { scrollbar-width: thin; scrollbar-color: #333 transparent; }
 
+/* Keep the scrollbar when Radix overlays open so the page doesn't shift or show
+   a white strip. `html body` specificity overrides react-remove-scroll. */
+html body[data-scroll-locked] {
+  overflow: auto !important;
+  margin-right: 0 !important;
+}
+
 @layer base {
   * {
     box-sizing: border-box;


### PR DESCRIPTION
Opening a Radix dropdown/select/dialog locks body scroll via `react-remove-scroll`,
  which hides the scrollbar and adds a compensating `margin-right` to `<body>`. On tall
  pages this shifted content and exposed a white strip on the right.

  Reported on: Customer → My Appointments; Admin → Overview, Customer Management,
  Promo Codes, Sessions, Waitlist.

  ## Fix (`frontend/src/styles/globals.css`)
  Keep the scrollbar in place and drop the compensation so opening an overlay causes no
  layout change — and no permanent gutter on scrollbar-less pages:
  ```css
  html body[data-scroll-locked] {
    overflow: auto !important;
    margin-right: 0 !important;
  }
```

  Trade-off

  Background scroll is no longer locked while any Radix overlay is open — including
  Dialog-based modals (~19 components: ConfirmationModal, OnboardingModal,
  SubscriptionManagement, RCGPurchaseModal, campaign modals, etc.). Acceptable for this
  dark, scroll-heavy dashboard; if a specific modal must freeze the background, we can
  lock scroll just for that one.

  Test plan

  - [ ] Admin → Promo Codes: open status filter → no shift, no white bar
  - [ ] Customer → My Appointments: open a dropdown → no shift, no white bar