### PR TITLE
fix: referral code not saving to customer table and revoked login infinite loop

### DIFF
--- a/backend/src/repositories/CustomerRepository.ts
+++ b/backend/src/repositories/CustomerRepository.ts
@@ -232,7 +232,8 @@ export class CustomerRepository extends BaseRepository {
         suspendedAt: 'suspended_at',
         suspensionReason: 'suspension_reason',
         referredBy: 'referred_by',
-        profile_image_url: 'profile_image_url'
+        profile_image_url: 'profile_image_url',
+        referralCode: 'referral_code'
       };
 
       for (const [key, value] of Object.entries(updates)) {

--- a/backend/src/services/ReferralService.ts
+++ b/backend/src/services/ReferralService.ts
@@ -31,11 +31,22 @@ export class ReferralService {
       // Check if customer already has a referral code
       const existingReferral = await this.referralRepository.getReferralByReferrer(customerAddress);
       if (existingReferral) {
+        // Sync to customers table in case it was never written there
+        if (!customer.referralCode) {
+          await this.customerRepository.updateCustomer(customerAddress, {
+            referralCode: existingReferral.referralCode
+          });
+        }
         return existingReferral.referralCode;
       }
 
       // Create new referral
       const referral = await this.referralRepository.createReferral(customerAddress);
+
+      // Sync the generated code to the customers table so GET /customers/:address returns it
+      await this.customerRepository.updateCustomer(customerAddress, {
+        referralCode: referral.referralCode
+      });
 
       logger.info('Referral code generated', {
         customerAddress,

--- a/frontend/src/components/customer/ReferralDashboard.tsx
+++ b/frontend/src/components/customer/ReferralDashboard.tsx
@@ -115,7 +115,7 @@ export function ReferralDashboard() {
         ]);
 
         const generatedCode: string | undefined =
-          resp?.data?.referralCode ?? resp?.referralCode;
+          resp?.data?.data?.referralCode ?? resp?.data?.referralCode ?? resp?.referralCode;
 
         if (cancelled) return;
 

--- a/frontend/src/providers/AuthProvider.tsx
+++ b/frontend/src/providers/AuthProvider.tsx
@@ -122,6 +122,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             fontSize: '15px'
           }
         });
+        // Disconnect wallet so Thirdweb doesn't auto-reconnect on reload,
+        // which would create an infinite revoked → reload → revoked loop.
+        setTimeout(async () => {
+          console.log('[AuthProvider] Disconnecting wallet after revoked error');
+          try { await disconnect(wallet!); } catch { /* ignore */ }
+          window.location.reload();
+        }, 3000);
+        return;
       } else if (type === 'unverified' || type === 'inactive') {
         // Don't show error for unverified/inactive - handled by dashboard UI
         console.log('[AuthProvider] Skipping toast for unverified/inactive shop - handled in UI');


### PR DESCRIPTION
## What changed
- Fixed referral code not saving to `customers` table after generation
- Added `referralCode` field mapping in `CustomerRepository.updateCustomer`
- Fixed infinite reload loop when a suspended/revoked account tries to login
- Wallet now disconnects before page reload on revoked error

## Root Causes
- `ReferralService.generateReferralCode` only inserted into `referrals` table, never updated `customers.referral_code` — so the UI stayed on "Generating..." forever
- `AuthProvider` was reloading the page on revoked error but NOT disconnecting the wallet, causing Thirdweb to auto-reconnect and loop endlessly

## How to Test
1. Login as a customer → go to Referrals tab → referral code should appear
2. Suspend a customer account → try to login → should show revoked error, disconnect wallet, and stop looping
