### PR TITLE
fix(purchase-orders): per-shop PO numbering + create/list UI fixes

### DIFF
--- a/backend/migrations/132_fix_purchase_order_number_uniqueness.sql
+++ b/backend/migrations/132_fix_purchase_order_number_uniqueness.sql
@@ -1,0 +1,32 @@
+-- Migration 132: Fix purchase order number uniqueness (per-shop, not global)
+-- Description: PO numbers are generated per-shop (PO-YYYY-#### scoped to each shop),
+--              but the column was declared globally UNIQUE. This caused a 500 when a
+--              second shop generated a PO number already used by another shop
+--              (e.g. every shop's first PO of the year is PO-YYYY-0001).
+--
+--              Fix: replace the global UNIQUE(po_number) with a composite
+--              UNIQUE(shop_id, po_number) so each shop has its own PO sequence.
+
+-- Drop the global unique constraint (auto-named when po_number was declared UNIQUE).
+ALTER TABLE purchase_orders
+  DROP CONSTRAINT IF EXISTS purchase_orders_po_number_key;
+
+-- Add per-shop uniqueness so each shop can independently use PO-YYYY-0001, 0002, ...
+-- Guarded so the migration is idempotent (safe to re-run via single-file runner + db:migrate).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'unique_shop_po_number'
+  ) THEN
+    ALTER TABLE purchase_orders
+      ADD CONSTRAINT unique_shop_po_number UNIQUE (shop_id, po_number);
+  END IF;
+END $$;
+
+COMMENT ON CONSTRAINT unique_shop_po_number ON purchase_orders
+  IS 'PO numbers are unique per shop, not globally (each shop has its own PO-YYYY-#### sequence)';
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Migration 132: purchase_orders po_number uniqueness is now per-shop (shop_id, po_number)';
+END $$;

--- a/backend/scripts/record-and-verify-migration-132.ts
+++ b/backend/scripts/record-and-verify-migration-132.ts
@@ -1,0 +1,98 @@
+// Apply + record + verify migration 132 (per-shop PO number uniqueness) on DO.
+// Same pattern as scripts/record-and-verify-migration-126.ts.
+
+import { Client } from "pg";
+import * as dotenv from "dotenv";
+import * as path from "path";
+import * as fs from "fs";
+
+dotenv.config({ path: path.resolve(__dirname, "../.env") });
+
+const MIGRATION_FILE = path.resolve(
+  __dirname,
+  "../migrations/132_fix_purchase_order_number_uniqueness.sql"
+);
+
+async function main() {
+  const client = new Client({
+    host: process.env.DB_HOST,
+    port: parseInt(process.env.DB_PORT || "25060", 10),
+    database: process.env.DB_NAME,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    ssl: { rejectUnauthorized: false },
+    connectionTimeoutMillis: 15000,
+  });
+  await client.connect();
+
+  let allGood = true;
+  const log = (label: string, ok: boolean, detail = "") => {
+    console.log(`  ${ok ? "✓" : "✗"} ${label.padEnd(60)} ${detail}`);
+    if (!ok) allGood = false;
+  };
+
+  try {
+    const sql = fs.readFileSync(MIGRATION_FILE, "utf-8");
+    await client.query(sql);
+    await client.query(
+      `INSERT INTO schema_migrations (version, name)
+       VALUES (132, 'fix_purchase_order_number_uniqueness')
+       ON CONFLICT (version) DO NOTHING`
+    );
+
+    console.log("=== schema_migrations row 132 ===");
+    const rec = await client.query(
+      `SELECT version, name, applied_at FROM schema_migrations WHERE version = 132`
+    );
+    log(
+      "row exists",
+      rec.rows.length === 1 && rec.rows[0].name === "fix_purchase_order_number_uniqueness"
+    );
+
+    console.log("\n=== Old global constraint removed ===");
+    const oldC = await client.query(
+      `SELECT 1 FROM pg_constraint WHERE conname = 'purchase_orders_po_number_key'`
+    );
+    log("purchase_orders_po_number_key dropped", oldC.rows.length === 0);
+
+    console.log("\n=== New per-shop constraint present ===");
+    const newC = await client.query<{ contype: string }>(
+      `SELECT contype FROM pg_constraint WHERE conname = 'unique_shop_po_number'`
+    );
+    log(
+      "unique_shop_po_number is a UNIQUE constraint",
+      newC.rows.length === 1 && newC.rows[0].contype === "u"
+    );
+
+    console.log("\n=== Constraint covers (shop_id, po_number) ===");
+    const cols = await client.query<{ attname: string }>(
+      `SELECT a.attname
+       FROM pg_constraint c
+       JOIN unnest(c.conkey) WITH ORDINALITY AS k(attnum, ord) ON true
+       JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum
+       WHERE c.conname = 'unique_shop_po_number'
+       ORDER BY k.ord`
+    );
+    const colNames = cols.rows.map((r) => r.attname);
+    log(
+      "columns = shop_id, po_number",
+      colNames.length === 2 && colNames[0] === "shop_id" && colNames[1] === "po_number",
+      colNames.join(", ")
+    );
+
+    console.log("\n=== Verdict ===");
+    console.log(
+      allGood
+        ? "  ✓ Migration 132 applied + recorded + verified."
+        : "  ✗ Issues detected."
+    );
+    process.exit(allGood ? 0 : 1);
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/backend/src/repositories/PurchaseOrderRepository.ts
+++ b/backend/src/repositories/PurchaseOrderRepository.ts
@@ -1,4 +1,5 @@
 // backend/src/repositories/PurchaseOrderRepository.ts
+import { PoolClient } from 'pg';
 import { BaseRepository } from './BaseRepository';
 import { logger } from '../utils/logger';
 
@@ -70,31 +71,56 @@ export class PurchaseOrderRepository extends BaseRepository {
   }
 
   /**
-   * Generate a unique PO number
+   * Generate a per-shop PO number (format: PO-YYYY-####).
+   *
+   * Scoped per shop (unique on shop_id + po_number, see migration 132), so two
+   * shops can both hold PO-2026-0001. Uses MAX(seq)+1 not COUNT(*)+1 so gaps from
+   * deletions never reuse a number; createPurchaseOrder retries on collision.
+   * Runs on the transaction client so the read shares the insert's transaction.
    */
-  private async generatePONumber(shopId: string): Promise<string> {
+  private async generatePONumber(client: PoolClient, shopId: string): Promise<string> {
     const year = new Date().getFullYear();
+    const prefix = `PO-${year}-`;
+
+    // SPLIT_PART(po_number, '-', 3) extracts #### from PO-YYYY-####; LIKE limits to valid rows.
     const query = `
-      SELECT COUNT(*) as count
+      SELECT COALESCE(MAX(CAST(SPLIT_PART(po_number, '-', 3) AS INTEGER)), 0) AS max_seq
       FROM purchase_orders
       WHERE shop_id = $1
-        AND EXTRACT(YEAR FROM order_date) = $2
+        AND po_number LIKE $2
     `;
 
-    const result = await this.pool.query(query, [shopId, year]);
-    const count = parseInt(result.rows[0].count) + 1;
-    const paddedCount = count.toString().padStart(4, '0');
+    const result = await client.query(query, [shopId, `${prefix}%`]);
+    const nextSeq = parseInt(result.rows[0].max_seq, 10) + 1;
 
-    return `PO-${year}-${paddedCount}`;
+    return `${prefix}${nextSeq.toString().padStart(4, '0')}`;
   }
 
   /**
    * Create a new purchase order with items
    */
   async createPurchaseOrder(data: CreatePurchaseOrderData): Promise<PurchaseOrder> {
+    // Retry on the (rare) race where two concurrent inserts generate the same PO number.
+    const maxAttempts = 5;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        return await this.createPurchaseOrderOnce(data);
+      } catch (error: any) {
+        // 23505 = unique_violation; only the po_number collision is retryable.
+        if (error?.code === '23505' && attempt < maxAttempts) {
+          logger.warn(`PO number collision, retrying (${attempt}/${maxAttempts})`, { shopId: data.shopId });
+          continue;
+        }
+        throw error;
+      }
+    }
+    throw new Error('Failed to generate a unique purchase order number after multiple attempts');
+  }
+
+  private async createPurchaseOrderOnce(data: CreatePurchaseOrderData): Promise<PurchaseOrder> {
     return await this.withTransaction(async (client) => {
       // Generate PO number
-      const poNumber = await this.generatePONumber(data.shopId);
+      const poNumber = await this.generatePONumber(client, data.shopId);
 
       // Calculate totals
       const subtotal = data.items.reduce((sum, item) => sum + (item.quantity * item.unitCost), 0);

--- a/frontend/src/components/shop/tabs/PurchaseOrdersTab.tsx
+++ b/frontend/src/components/shop/tabs/PurchaseOrdersTab.tsx
@@ -29,6 +29,13 @@ import {
 import { CreatePurchaseOrderModal } from "./modals/CreatePurchaseOrderModal";
 import { PurchaseOrderDetailModal } from "./modals/PurchaseOrderDetailModal";
 import { ReceiveItemsModal } from "./modals/ReceiveItemsModal";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
 
 interface PurchaseOrdersTabProps {
   shopId: string;
@@ -47,7 +54,6 @@ export function PurchaseOrdersTab({ shopId }: PurchaseOrdersTabProps) {
   const [showDetailModal, setShowDetailModal] = useState(false);
   const [showReceiveModal, setShowReceiveModal] = useState(false);
   const [selectedPO, setSelectedPO] = useState<PurchaseOrder | null>(null);
-  const [dropdownOpen, setDropdownOpen] = useState<string | null>(null);
 
   useEffect(() => {
     loadData();
@@ -81,13 +87,11 @@ export function PurchaseOrdersTab({ shopId }: PurchaseOrdersTabProps) {
   const handleViewDetails = (po: PurchaseOrder) => {
     setSelectedPO(po);
     setShowDetailModal(true);
-    setDropdownOpen(null);
   };
 
   const handleReceiveItems = (po: PurchaseOrder) => {
     setSelectedPO(po);
     setShowReceiveModal(true);
-    setDropdownOpen(null);
   };
 
   const handleReceiveSuccess = () => {
@@ -108,7 +112,6 @@ export function PurchaseOrdersTab({ shopId }: PurchaseOrdersTabProps) {
       console.error("Error cancelling PO:", error);
       toast.error("Failed to cancel purchase order");
     }
-    setDropdownOpen(null);
   };
 
   const handleDeletePO = async (po: PurchaseOrder) => {
@@ -127,7 +130,6 @@ export function PurchaseOrdersTab({ shopId }: PurchaseOrdersTabProps) {
       console.error("Error deleting PO:", error);
       toast.error("Failed to delete purchase order");
     }
-    setDropdownOpen(null);
   };
 
   const getStatusBadge = (status: PurchaseOrderStatus) => {
@@ -186,7 +188,7 @@ export function PurchaseOrdersTab({ shopId }: PurchaseOrdersTabProps) {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm text-gray-400">Total Spending</p>
-                <p className="text-2xl font-bold text-white">${parseFloat(stats.totalSpending || '0').toFixed(2)}</p>
+                <p className="text-2xl font-bold text-white">${parseFloat(String(stats.totalSpending || 0)).toFixed(2)}</p>
               </div>
               <TrendingUp className="w-8 h-8 text-green-500" />
             </div>
@@ -216,7 +218,7 @@ export function PurchaseOrdersTab({ shopId }: PurchaseOrdersTabProps) {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm text-gray-400">Avg Order Value</p>
-                <p className="text-2xl font-bold text-white">${parseFloat(stats.averageOrderValue || '0').toFixed(2)}</p>
+                <p className="text-2xl font-bold text-white">${parseFloat(String(stats.averageOrderValue || 0)).toFixed(2)}</p>
               </div>
               <TrendingUp className="w-8 h-8 text-blue-500" />
             </div>
@@ -349,56 +351,57 @@ export function PurchaseOrdersTab({ shopId }: PurchaseOrdersTabProps) {
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-right">
-                      <div className="relative inline-block">
-                        <button
-                          onClick={() => setDropdownOpen(dropdownOpen === po.id ? null : po.id)}
-                          className="p-2 hover:bg-[#252525] rounded-lg transition-colors"
-                        >
+                      <DropdownMenu>
+                        <DropdownMenuTrigger className="p-2 hover:bg-[#252525] rounded-lg transition-colors outline-none">
                           <MoreVertical className="w-5 h-5 text-gray-400" />
-                        </button>
+                        </DropdownMenuTrigger>
 
-                        {dropdownOpen === po.id && (
-                          <div className="absolute right-0 mt-2 w-48 bg-[#1a1a1a] rounded-lg shadow-lg border border-gray-700 z-10">
-                            <button
-                              onClick={() => handleViewDetails(po)}
-                              className="w-full flex items-center gap-2 px-4 py-2 text-sm text-gray-300 hover:bg-[#252525]"
+                        <DropdownMenuContent
+                          align="end"
+                          className="w-48 bg-[#1a1a1a] border border-gray-700 text-gray-300 p-0"
+                        >
+                          <DropdownMenuItem
+                            onClick={() => handleViewDetails(po)}
+                            className="gap-2 px-4 py-2 text-sm text-gray-300 rounded-none cursor-pointer focus:bg-[#252525] focus:text-gray-300"
+                          >
+                            <Eye className="w-4 h-4" />
+                            View Details
+                          </DropdownMenuItem>
+
+                          {(po.status === "confirmed" || po.status === "partially_received") && (
+                            <DropdownMenuItem
+                              onClick={() => handleReceiveItems(po)}
+                              className="gap-2 px-4 py-2 text-sm text-green-400 rounded-none cursor-pointer focus:bg-[#252525] focus:text-green-400"
                             >
-                              <Eye className="w-4 h-4" />
-                              View Details
-                            </button>
+                              <PackageCheck className="w-4 h-4" />
+                              Receive Items
+                            </DropdownMenuItem>
+                          )}
 
-                            {(po.status === "confirmed" || po.status === "partially_received") && (
-                              <button
-                                onClick={() => handleReceiveItems(po)}
-                                className="w-full flex items-center gap-2 px-4 py-2 text-sm text-green-400 hover:bg-[#252525]"
-                              >
-                                <PackageCheck className="w-4 h-4" />
-                                Receive Items
-                              </button>
-                            )}
+                          {po.status !== "received" && po.status !== "cancelled" && (
+                            <DropdownMenuItem
+                              onClick={() => handleCancelPO(po)}
+                              className="gap-2 px-4 py-2 text-sm text-orange-400 rounded-none cursor-pointer focus:bg-[#252525] focus:text-orange-400"
+                            >
+                              <Ban className="w-4 h-4" />
+                              Cancel Order
+                            </DropdownMenuItem>
+                          )}
 
-                            {po.status !== "received" && po.status !== "cancelled" && (
-                              <button
-                                onClick={() => handleCancelPO(po)}
-                                className="w-full flex items-center gap-2 px-4 py-2 text-sm text-orange-400 hover:bg-[#252525]"
-                              >
-                                <Ban className="w-4 h-4" />
-                                Cancel Order
-                              </button>
-                            )}
-
-                            {po.status === "draft" && (
-                              <button
+                          {po.status === "draft" && (
+                            <>
+                              <DropdownMenuSeparator className="bg-gray-700 my-0" />
+                              <DropdownMenuItem
                                 onClick={() => handleDeletePO(po)}
-                                className="w-full flex items-center gap-2 px-4 py-2 text-sm text-red-400 hover:bg-[#252525] border-t border-gray-700"
+                                className="gap-2 px-4 py-2 text-sm text-red-400 rounded-none cursor-pointer focus:bg-[#252525] focus:text-red-400"
                               >
                                 <Trash2 className="w-4 h-4" />
                                 Delete
-                              </button>
-                            )}
-                          </div>
-                        )}
-                      </div>
+                              </DropdownMenuItem>
+                            </>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
                     </td>
                   </tr>
                 ))}

--- a/frontend/src/components/shop/tabs/modals/CreatePurchaseOrderModal.tsx
+++ b/frontend/src/components/shop/tabs/modals/CreatePurchaseOrderModal.tsx
@@ -103,7 +103,7 @@ export function CreatePurchaseOrderModal({
   };
 
   const calculateTotal = () => {
-    return poItems.reduce((sum, item) => sum + item.quantity * item.unitCost, 0);
+    return poItems.reduce((sum, item) => sum + (item.quantity || 0) * (item.unitCost || 0), 0);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -119,7 +119,7 @@ export function CreatePurchaseOrderModal({
       return;
     }
 
-    if (poItems.some((item) => !item.inventoryItemId || item.quantity <= 0 || item.unitCost < 0)) {
+    if (poItems.some((item) => !item.inventoryItemId || !(item.quantity > 0) || !(item.unitCost >= 0))) {
       toast.error("Please fill in all item details correctly");
       return;
     }
@@ -257,13 +257,14 @@ export function CreatePurchaseOrderModal({
                 {poItems.map((item, index) => (
                   <div
                     key={index}
-                    className="flex flex-col sm:flex-row gap-3 p-4 border border-gray-200 rounded-lg"
+                    className="flex flex-col sm:flex-row sm:items-end gap-3 p-4 border border-gray-200 rounded-lg"
                   >
                     <div className="flex-1">
+                      <label aria-hidden className="block text-xs font-medium text-gray-600 mb-1">&nbsp;</label>
                       <select
                         value={item.inventoryItemId}
                         onChange={(e) => updateItem(index, "inventoryItemId", e.target.value)}
-                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#FFCC00] focus:border-transparent text-sm"
+                        className="w-full h-10 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#FFCC00] focus:border-transparent text-sm"
                         required
                       >
                         <option value="">Select item</option>
@@ -276,33 +277,35 @@ export function CreatePurchaseOrderModal({
                     </div>
 
                     <div className="w-24">
+                      <label className="block text-xs font-medium text-gray-600 mb-1">Qty</label>
                       <input
                         type="number"
                         min="1"
                         value={item.quantity}
                         onChange={(e) => updateItem(index, "quantity", parseInt(e.target.value))}
                         placeholder="Qty"
-                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#FFCC00] focus:border-transparent text-sm"
+                        className="w-full h-10 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#FFCC00] focus:border-transparent text-sm"
                         required
                       />
                     </div>
 
                     <div className="w-32">
+                      <label className="block text-xs font-medium text-gray-600 mb-1">Cost</label>
                       <input
                         type="number"
                         min="0"
                         step="0.01"
                         value={item.unitCost}
                         onChange={(e) => updateItem(index, "unitCost", parseFloat(e.target.value))}
-                        placeholder="Unit cost"
-                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#FFCC00] focus:border-transparent text-sm"
+                        placeholder="0.00"
+                        className="w-full h-10 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#FFCC00] focus:border-transparent text-sm"
                         required
                       />
                     </div>
 
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 pb-0.5">
                       <div className="text-sm font-medium text-gray-700 min-w-[80px]">
-                        ${(item.quantity * item.unitCost).toFixed(2)}
+                        ${((item.quantity || 0) * (item.unitCost || 0)).toFixed(2)}
                       </div>
                       <button
                         type="button"


### PR DESCRIPTION
## Summary

  Fixes a purchase-order creation 500 plus several UI issues in the PO create/list flow.

  ### Backend
  - **Per-shop PO numbering.** PO numbers were generated per shop (`PO-YYYY-####` scoped to each shop) but the column was globally `UNIQUE`, so the
  second shop to generate a given number (e.g. every shop's first PO of the year, `PO-2026-0001`) hit `duplicate key ...
  purchase_orders_po_number_key` and 500'd. Migration **132** replaces `UNIQUE(po_number)` with `UNIQUE(shop_id, po_number)`.
  - **Hardened generation.** `generatePONumber` now derives the next number from `MAX(seq)+1` (not `COUNT(*)+1`) inside the transaction, so
  deletions/gaps never reuse a number. `createPurchaseOrder` retries on a unique-violation to cover concurrent inserts.
  - Adds `record-and-verify-migration-132.ts` (applies + records + verifies). **Already applied + recorded on the DO database.**

  ### Frontend
  - **Actions menu clipping (`PurchaseOrdersTab`).** The absolute-positioned actions dropdown was clipped / scrolled inside the table's `overflow`
  wrapper. Replaced with the shadcn (Radix portal) `DropdownMenu` so it floats above the table.
  - **`$NaN` order total (`CreatePurchaseOrderModal`).** Clearing a quantity/unit-cost field produced `$NaN`; totals are now NaN-safe and `NaN`
  rows are rejected on submit.
  - **Unclear item fields.** Added `Qty` / `Cost` labels and aligned the item-row controls.