### PR TITLE
fix: auto-generate referral code for new mobile accounts

### DIFF
--- a/mobile/feature/customer/profile/services/customer.services.ts
+++ b/mobile/feature/customer/profile/services/customer.services.ts
@@ -102,6 +102,20 @@ class CustomerApi {
     }
   }
 
+  async generateReferralCode(): Promise<string> {
+    try {
+      const response = await apiClient.post<any>("/referrals/generate");
+      return (
+        response?.data?.data?.referralCode ??
+        response?.data?.referralCode ??
+        response?.referralCode
+      );
+    } catch (error) {
+      console.error("Failed to generate referral code:", error);
+      throw error;
+    }
+  }
+
   async register(payload: CustomerFormData) {
     try {
       return await apiClient.post("/customers/register", payload);

--- a/mobile/feature/customer/referral/hooks/useReferral.ts
+++ b/mobile/feature/customer/referral/hooks/useReferral.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { Share, Linking } from "react-native";
 import { router } from "expo-router";
 import * as Clipboard from "expo-clipboard";
@@ -6,16 +6,43 @@ import { useAuthStore } from "@/feature/auth/store/auth.store";
 import { useAppToast } from "@/shared/hooks";
 import { REFERRER_REWARD, COPY_FEEDBACK_DURATION } from "@/shared/constants/referral";
 import { useCustomer } from "../../profile/hooks/useCustomer";
+import { customerApi } from "../../profile/services/customer.services";
 
 export function useReferral() {
   const { account } = useAuthStore();
   const { useGetCustomerByWalletAddress } = useCustomer();
-  const { data: customerData } = useGetCustomerByWalletAddress(account?.address);
+  const { data: customerData, refetch } = useGetCustomerByWalletAddress(account?.address);
   const { showWarning } = useAppToast();
 
   const [codeCopied, setCodeCopied] = useState(false);
+  const [generatingCode, setGeneratingCode] = useState(false);
+  const [generatedCode, setGeneratedCode] = useState<string | null>(null);
 
-  const referralCode = customerData?.customer?.referralCode || "LOADING...";
+  const profileCode = customerData?.customer?.referralCode;
+  const referralCode = profileCode || generatedCode || "Generating...";
+
+  // Auto-generate code for new accounts that don't have one yet
+  const generateCode = useCallback(async () => {
+    if (profileCode || generatingCode || !account?.address) return;
+    setGeneratingCode(true);
+    try {
+      const code = await customerApi.generateReferralCode();
+      if (code) {
+        setGeneratedCode(code);
+        refetch();
+      }
+    } catch (error) {
+      console.error("Failed to generate referral code:", error);
+    } finally {
+      setGeneratingCode(false);
+    }
+  }, [profileCode, generatingCode, account?.address, refetch]);
+
+  useEffect(() => {
+    if (customerData && !profileCode) {
+      generateCode();
+    }
+  }, [customerData, profileCode, generateCode]);
   const totalReferrals = customerData?.customer?.referralCount || 0;
   const totalEarned = totalReferrals * REFERRER_REWARD;
 


### PR DESCRIPTION
## What changed
- Fixed referral code showing "Generating..." forever on fresh new accounts in mobile
- Added `generateReferralCode()` API call to `customer.services.ts`
- Updated `useReferral.ts` to auto-call the generate endpoint when no referral code exists, then refresh the customer profile

## Root Cause
The mobile Referral screen only read `customerData.referralCode` from the customer profile query. For new accounts where `referral_code` is null in the database, it showed "Generating..." permanently because it never called `POST /referrals/generate` — unlike the web frontend which auto-generates on load.

## Files Changed
- `mobile/feature/customer/referral/hooks/useReferral.ts`
- `mobile/feature/customer/profile/services/customer.services.ts`

## How to Test
1. Register a brand new customer account
2. Go to the Referrals tab
3. Referral code should auto-generate and display within seconds

## Related
- Test Case CR-02 — referral code field present and functional ✓
- Note: RCN rewards are distributed after first repair completion (by design, not a bug)
