### PR TITLE
fix(bookings): group no-show/refunded/expired under cancelled and refresh on no-show

### DIFF
--- a/backend/src/domains/ServiceDomain/controllers/OrderController.ts
+++ b/backend/src/domains/ServiceDomain/controllers/OrderController.ts
@@ -1,7 +1,7 @@
 // backend/src/domains/ServiceDomain/controllers/OrderController.ts
 import { Request, Response } from 'express';
 import { PaymentService } from '../services/PaymentService';
-import { OrderRepository } from '../../../repositories/OrderRepository';
+import { OrderRepository, OrderStatus } from '../../../repositories/OrderRepository';
 import { NotificationService } from '../../notification/services/NotificationService';
 import { ServiceRepository } from '../../../repositories/ServiceRepository';
 import { shopRepository } from '../../../repositories';
@@ -160,8 +160,15 @@ export class OrderController {
         return res.status(401).json({ success: false, error: 'Customer authentication required' });
       }
 
+      // status may be a single value or a comma-separated group (e.g. the
+      // "cancelled" filter aggregates cancelled, refunded, no_show and expired)
+      const statusParam = req.query.status as string | undefined;
+      const statusValues = statusParam
+        ? (statusParam.split(',').filter(Boolean) as OrderStatus[])
+        : undefined;
+
       const filters = {
-        status: req.query.status as 'pending' | 'paid' | 'completed' | 'cancelled' | 'refunded' | undefined,
+        status: statusValues && statusValues.length === 1 ? statusValues[0] : statusValues,
         startDate: req.query.startDate ? new Date(req.query.startDate as string) : undefined,
         endDate: req.query.endDate ? new Date(req.query.endDate as string) : undefined
       };
@@ -198,8 +205,15 @@ export class OrderController {
         return res.status(401).json({ success: false, error: 'Shop authentication required' });
       }
 
+      // status may be a single value or a comma-separated group (e.g. the
+      // "cancelled" tab aggregates cancelled, refunded, no_show and expired)
+      const statusParam = req.query.status as string | undefined;
+      const statusValues = statusParam
+        ? (statusParam.split(',').filter(Boolean) as OrderStatus[])
+        : undefined;
+
       const filters = {
-        status: req.query.status as 'pending' | 'paid' | 'completed' | 'cancelled' | 'refunded' | undefined,
+        status: statusValues && statusValues.length === 1 ? statusValues[0] : statusValues,
         startDate: req.query.startDate ? new Date(req.query.startDate as string) : undefined,
         endDate: req.query.endDate ? new Date(req.query.endDate as string) : undefined,
         customerAddress: req.query.customerAddress as string | undefined

--- a/backend/src/repositories/OrderRepository.ts
+++ b/backend/src/repositories/OrderRepository.ts
@@ -95,7 +95,7 @@ export interface CreateOrderParams {
 }
 
 export interface OrderFilters {
-  status?: OrderStatus;
+  status?: OrderStatus | OrderStatus[];
   startDate?: Date;
   endDate?: Date;
   customerAddress?: string;
@@ -256,8 +256,13 @@ export class OrderRepository extends BaseRepository {
 
       if (filters.status) {
         paramCount++;
-        whereClauses.push(`o.status = $${paramCount}`);
-        params.push(filters.status);
+        if (Array.isArray(filters.status)) {
+          whereClauses.push(`o.status = ANY($${paramCount})`);
+          params.push(filters.status);
+        } else {
+          whereClauses.push(`o.status = $${paramCount}`);
+          params.push(filters.status);
+        }
       }
 
       if (filters.startDate) {
@@ -349,8 +354,13 @@ export class OrderRepository extends BaseRepository {
 
       if (filters.status) {
         paramCount++;
-        whereClauses.push(`o.status = $${paramCount}`);
-        params.push(filters.status);
+        if (Array.isArray(filters.status)) {
+          whereClauses.push(`o.status = ANY($${paramCount})`);
+          params.push(filters.status);
+        } else {
+          whereClauses.push(`o.status = $${paramCount}`);
+          params.push(filters.status);
+        }
       }
 
       if (filters.startDate) {

--- a/frontend/src/components/customer/AppointmentCard.tsx
+++ b/frontend/src/components/customer/AppointmentCard.tsx
@@ -47,12 +47,15 @@ export const AppointmentCard: React.FC<AppointmentCardProps> = ({
     paid: { bg: 'bg-green-500/20', text: 'text-green-400', label: 'Paid' },
     'in-progress': { bg: 'bg-purple-500/20', text: 'text-purple-400', label: 'In Progress' },
     completed: { bg: 'bg-green-500/20', text: 'text-green-400', label: 'Completed' },
-    cancelled: { bg: 'bg-red-500/20', text: 'text-red-400', label: 'Cancelled' }
+    cancelled: { bg: 'bg-red-500/20', text: 'text-red-400', label: 'Cancelled' },
+    no_show: { bg: 'bg-orange-500/20', text: 'text-orange-400', label: 'No-Show' },
+    expired: { bg: 'bg-gray-500/20', text: 'text-gray-400', label: 'Expired' },
+    refunded: { bg: 'bg-red-500/20', text: 'text-red-400', label: 'Refunded' }
   };
 
   const status = appointment.status.toLowerCase();
   const statusStyle = STATUS_COLORS[status] || STATUS_COLORS.pending;
-  const isUpcoming = !['completed', 'cancelled'].includes(status);
+  const isUpcoming = !['completed', 'cancelled', 'no_show', 'expired', 'refunded'].includes(status);
 
   // Check if appointment date is in the future
   // Parse YYYY-MM-DD as local date (new Date("YYYY-MM-DD") is UTC, causing off-by-one in western timezones)

--- a/frontend/src/components/customer/AppointmentsTab.tsx
+++ b/frontend/src/components/customer/AppointmentsTab.tsx
@@ -21,6 +21,10 @@ import {
 type FilterTab = 'upcoming' | 'completed' | 'cancelled';
 type SortOrder = 'asc' | 'desc';
 
+// Terminal statuses that should be grouped under "Cancelled" (matching the
+// shop account behavior), never shown as upcoming.
+const CANCELLED_STATUSES = ['cancelled', 'no_show', 'expired', 'refunded'];
+
 export const AppointmentsTab: React.FC = () => {
   const router = useRouter();
   const [loading, setLoading] = useState(true);
@@ -101,7 +105,7 @@ export const AppointmentsTab: React.FC = () => {
       const [year, month, day] = apt.bookingDate.split('-').map(Number);
       const aptDate = new Date(year, month - 1, day);
 
-      if (status === 'cancelled') {
+      if (CANCELLED_STATUSES.includes(status)) {
         cancelled.push(apt);
       } else if (status === 'completed') {
         completed.push(apt);
@@ -165,7 +169,7 @@ export const AppointmentsTab: React.FC = () => {
     const now = new Date();
     const hoursUntil = (appointmentDate.getTime() - now.getTime()) / (1000 * 60 * 60);
     const status = appointment.status.toLowerCase();
-    return hoursUntil >= 24 && status !== 'completed' && status !== 'cancelled';
+    return hoursUntil >= 24 && status !== 'completed' && !CANCELLED_STATUSES.includes(status);
   };
 
   const canRescheduleAppointment = (appointment: CalendarBooking): boolean => {

--- a/frontend/src/components/customer/ServiceOrdersTab.tsx
+++ b/frontend/src/components/customer/ServiceOrdersTab.tsx
@@ -201,7 +201,15 @@ export const ServiceOrdersTab: React.FC = () => {
   const loadOrders = async (page: number = currentPage, currentFilter: string = filter) => {
     setLoading(true);
     try {
-      const statusFilter = currentFilter === "all" ? undefined : (currentFilter as OrderStatus);
+      // The "cancelled" filter aggregates all terminal statuses (matching its
+      // pill count below), so request them as a comma-separated group.
+      const cancelledGroup: string = "cancelled,refunded,no_show,expired";
+      const statusFilter =
+        currentFilter === "all"
+          ? undefined
+          : currentFilter === "cancelled"
+          ? (cancelledGroup as OrderStatus)
+          : (currentFilter as OrderStatus);
       const response = await getCustomerOrders({
         status: statusFilter,
         page,
@@ -227,7 +235,7 @@ export const ServiceOrdersTab: React.FC = () => {
 
   const loadCounts = async () => {
     try {
-      const statuses: OrderStatus[] = ["pending", "paid", "completed", "cancelled", "refunded"];
+      const statuses: OrderStatus[] = ["pending", "paid", "completed", "cancelled", "refunded", "no_show", "expired"];
       const results = await Promise.all(
         statuses.map((s) =>
           getCustomerOrders({ status: s, page: 1, limit: 1 }).then(
@@ -417,7 +425,7 @@ export const ServiceOrdersTab: React.FC = () => {
       pending: statusCounts["pending"] || 0,
       paid: statusCounts["paid"] || 0,
       completed: statusCounts["completed"] || 0,
-      cancelled: (statusCounts["cancelled"] || 0) + (statusCounts["refunded"] || 0),
+      cancelled: (statusCounts["cancelled"] || 0) + (statusCounts["refunded"] || 0) + (statusCounts["no_show"] || 0) + (statusCounts["expired"] || 0),
     };
   };
 

--- a/frontend/src/components/shop/bookings/BookingsTabV2.tsx
+++ b/frontend/src/components/shop/bookings/BookingsTabV2.tsx
@@ -23,6 +23,7 @@ import {
   updateOrderStatus,
   approveBooking,
   ServiceOrderWithDetails,
+  OrderStatus,
 } from "@/services/api/services";
 import { appointmentsApi } from "@/services/api/appointments";
 import { RescheduleModal } from "../modals/RescheduleModal";
@@ -126,7 +127,10 @@ export const BookingsTabV2: React.FC<BookingsTabV2Props> = ({
   // Map frontend filter key to backend status value
   const getApiStatus = (filter: string): string | undefined => {
     if (filter === "all") return undefined;
-    return filter; // "pending", "paid", "completed", "cancelled" map directly
+    // The "cancelled" tab aggregates all terminal statuses (matching its count
+    // in filterCounts below), so request them as a comma-separated group.
+    if (filter === "cancelled") return "cancelled,refunded,no_show,expired";
+    return filter; // "pending", "paid", "completed" map directly
   };
 
   // Load status counts from API
@@ -150,7 +154,7 @@ export const BookingsTabV2: React.FC<BookingsTabV2Props> = ({
       const response = await getShopOrders({
         limit: ITEMS_PER_PAGE,
         page,
-        ...(apiStatus ? { status: apiStatus as 'pending' | 'paid' | 'completed' | 'cancelled' } : {}),
+        ...(apiStatus ? { status: apiStatus as OrderStatus } : {}),
       });
       if (response && response.data) {
         // Transform API data to UI format
@@ -483,6 +487,36 @@ export const BookingsTabV2: React.FC<BookingsTabV2Props> = ({
     setCancelModalBooking(null);
   };
 
+  const handleNoShowComplete = () => {
+    if (noShowModalBooking) {
+      // no_show maps to the "cancelled" display status (see mapApiStatus).
+      // Update locally so the badge changes immediately without a page refresh.
+      setBookings((prev) =>
+        prev.map((b) => {
+          if (b.bookingId === noShowModalBooking.bookingId) {
+            const newTimeline = [
+              ...b.timeline,
+              {
+                id: `tl-${Date.now()}`,
+                type: "cancelled" as const,
+                timestamp: new Date().toISOString(),
+                description: "Booking marked as no-show",
+              },
+            ];
+            return {
+              ...b,
+              status: "cancelled" as const,
+              timeline: newTimeline,
+            };
+          }
+          return b;
+        }),
+      );
+      loadCounts();
+    }
+    setNoShowModalBooking(null);
+  };
+
   return (
     <div className="space-y-6">
       {/* Page Header */}
@@ -648,10 +682,7 @@ export const BookingsTabV2: React.FC<BookingsTabV2Props> = ({
         } as ServiceOrderWithDetails : null}
         isOpen={!!noShowModalBooking}
         onClose={() => setNoShowModalBooking(null)}
-        onSuccess={() => {
-          setNoShowModalBooking(null);
-          loadBookings();
-        }}
+        onSuccess={handleNoShowComplete}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

  Booking statuses `no_show`, `refunded`, and `expired` are all terminal/cancelled-type outcomes, but they weren't surfaced consistently with
  `cancelled` bookings. This caused several mismatches across the shop and customer views:

  - Shop **Cancelled** tab counted no-shows in its badge but didn't list them
  - Marking a booking as **no-show** required a page refresh before the status updated
  - Customer **Cancelled** filter didn't include no-shows
  - Customer **Appointments** showed no-show bookings as *Upcoming* instead of *Cancelled*

  This PR groups all terminal statuses under "Cancelled" everywhere and fixes the no-show refresh.

  ## Changes

  ### Backend
  - `getShopOrders` and `getCustomerOrders` now parse a comma-separated `status` query param into an array
  - `OrderFilters.status` accepts `OrderStatus | OrderStatus[]`; `getOrdersByShop` and `getOrdersByCustomer` use `status = ANY($n)` for array
  filters (single-value path unchanged)

  ### Shop bookings (`BookingsTabV2`)
  - **Cancelled** tab now requests the full group (`cancelled, refunded, no_show, expired`), so the list matches the tab count
  - Marking a booking as **no-show** updates local state optimistically (mirroring the existing cancel/complete flows) — status changes instantly,
  no refresh needed

  ### Customer bookings (`ServiceOrdersTab`)
  - **Cancelled** filter requests the same group, and its pill count now includes `no_show` and `expired`

  ### Customer appointments (`AppointmentsTab` / `AppointmentCard`)
  - `no_show`/`refunded`/`expired` appointments are grouped under **Cancelled** instead of **Upcoming**
  - `AppointmentCard` renders proper badges for these statuses (e.g. orange "No-Show") and no longer shows a countdown for terminal bookings

  ## Testing
  - [ ] Shop: mark a paid booking as no-show → status updates immediately and it appears under the Cancelled tab
  - [ ] Shop: Cancelled tab list count matches the number of listed bookings
  - [ ] Customer: Cancelled filter lists no-show bookings (with No-Show badge) and the count matches
  - [ ] Customer: a no-show appointment moves from Upcoming → Cancelled
  - [ ] Existing single-status filters (pending/paid/completed) still work unchanged