### PR TITLE
fix(manual-booking): correct payment status, add mark-as-paid, fix dropdown & approve state

### DIFF
--- a/backend/src/domains/ServiceDomain/controllers/ManualBookingController.ts
+++ b/backend/src/domains/ServiceDomain/controllers/ManualBookingController.ts
@@ -222,7 +222,7 @@ export const createManualBooking = async (req: Request, res: Response): Promise<
     // 'send_link' and 'qr_code' create order in 'pending' status until customer pays
     // Note: Valid statuses are: pending, paid, completed, cancelled, refunded, no_show, expired
     const requiresPayment = paymentStatus === 'send_link' || paymentStatus === 'qr_code';
-    const orderStatus = requiresPayment ? 'pending' : 'paid';
+    const orderStatus = paymentStatus === 'paid' ? 'paid' : 'pending';
     const dbPaymentStatus = requiresPayment ? 'pending' : paymentStatus;
     console.log('Step 10: Order status will be:', orderStatus, ', dbPaymentStatus:', dbPaymentStatus);
 

--- a/backend/src/domains/ServiceDomain/controllers/OrderController.ts
+++ b/backend/src/domains/ServiceDomain/controllers/OrderController.ts
@@ -1098,6 +1098,44 @@ export class OrderController {
   };
 
   /**
+   * Mark a pending order as paid (e.g. cash collected for a manual booking)
+   * POST /api/services/orders/:id/mark-paid
+   */
+  markOrderPaid = async (req: Request, res: Response) => {
+    try {
+      const shopId = req.user?.shopId;
+      if (!shopId) {
+        return res.status(401).json({ success: false, error: 'Shop authentication required' });
+      }
+
+      const { id } = req.params;
+
+      const order = await this.orderRepository.getOrderById(id);
+      if (!order) {
+        return res.status(404).json({ success: false, error: 'Order not found' });
+      }
+
+      if (order.shopId !== shopId) {
+        return res.status(403).json({ success: false, error: 'Unauthorized to update this order' });
+      }
+
+      if (order.status !== 'pending') {
+        return res.status(400).json({ success: false, error: 'Only pending orders can be marked as paid' });
+      }
+
+      const updated = await this.orderRepository.markAsPaid(id);
+
+      res.json({ success: true, data: updated });
+    } catch (error: unknown) {
+      logger.error('Error in markOrderPaid controller:', error);
+      res.status(400).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to mark order as paid'
+      });
+    }
+  };
+
+  /**
    * Helper method to issue group tokens when a service is completed
    */
   private async issueGroupTokensForService(order: { orderId: string; serviceId: string; customerAddress: string; totalAmount: number; shopId: string }): Promise<void> {

--- a/backend/src/domains/ServiceDomain/routes.ts
+++ b/backend/src/domains/ServiceDomain/routes.ts
@@ -1073,6 +1073,13 @@ export function initializeRoutes(stripe: StripeService): Router {
     orderController.markNoShow
   );
 
+  router.post(
+    '/orders/:id/mark-paid',
+    authMiddleware,
+    requireRole(['shop']),
+    orderController.markOrderPaid
+  );
+
   /**
    * @swagger
    * /api/services/orders/{id}/approve:

--- a/backend/src/repositories/OrderRepository.ts
+++ b/backend/src/repositories/OrderRepository.ts
@@ -606,6 +606,29 @@ export class OrderRepository extends BaseRepository {
     }
   }
 
+  async markAsPaid(orderId: string): Promise<ServiceOrder> {
+    try {
+      const query = `
+        UPDATE service_orders
+        SET status = 'paid', payment_status = 'paid', updated_at = NOW()
+        WHERE order_id = $1
+        RETURNING *
+      `;
+
+      const result = await this.pool.query(query, [orderId]);
+
+      if (result.rows.length === 0) {
+        throw new Error('Order not found');
+      }
+
+      logger.info('Order marked as paid', { orderId });
+      return this.mapOrderRow(result.rows[0]);
+    } catch (error) {
+      logger.error('Error marking order as paid:', error);
+      throw error;
+    }
+  }
+
   /**
    * Mark order as expired (24h past appointment without completion)
    */

--- a/frontend/src/components/shop/ManualBookingModal.tsx
+++ b/frontend/src/components/shop/ManualBookingModal.tsx
@@ -635,14 +635,13 @@ export const ManualBookingModal: React.FC<ManualBookingModalProps> = ({
               </div>
             ) : (
               <Select
-                value={selectedServiceId || "all"}
-                onValueChange={(value) => setSelectedServiceId(value === "all" ? "" : value)}
+                value={selectedServiceId || undefined}
+                onValueChange={(value) => setSelectedServiceId(value)}
               >
                 <SelectTrigger variant="dark" className="w-full h-auto py-3">
                   <SelectValue placeholder="Select a service..." />
                 </SelectTrigger>
-                <SelectContent variant="dark">
-                  <SelectItem variant="dark" value="all">Select a service...</SelectItem>
+                <SelectContent variant="dark" className="z-[1200]">
                   {services.map((service) => (
                     <SelectItem variant="dark" key={service.serviceId} value={service.serviceId}>
                       {service.serviceName} - ${service.priceUsd.toFixed(2)} ({service.durationMinutes} min)

--- a/frontend/src/components/shop/bookings/BookingCard.tsx
+++ b/frontend/src/components/shop/bookings/BookingCard.tsx
@@ -14,6 +14,7 @@ interface BookingCardProps {
   onComplete: () => void;
   onCancel: () => void;
   onMarkNoShow: () => void;
+  onMarkPaid: () => void;
   isBlocked?: boolean;
   blockReason?: string;
 }
@@ -31,6 +32,7 @@ export const BookingCard: React.FC<BookingCardProps> = ({
   onComplete,
   onCancel,
   onMarkNoShow,
+  onMarkPaid,
   isBlocked = false,
   blockReason = "Action blocked"
 }) => {
@@ -222,9 +224,28 @@ export const BookingCard: React.FC<BookingCardProps> = ({
       </button>
     );
 
+    const markPaidButton = (
+      <button
+        onClick={onMarkPaid}
+        disabled={isBlocked}
+        title={isBlocked ? blockReason : "Mark payment as received"}
+        className={`${baseButtonClass} text-white bg-green-600 ${
+          isBlocked ? disabledClass : "hover:bg-green-700"
+        }`}
+      >
+        <CheckCircle className="w-4 h-4 flex-shrink-0" />
+        <span className="truncate">Mark as Paid</span>
+      </button>
+    );
+
     switch (booking.status) {
       case 'requested':
-        return cancelButton;
+        return (
+          <>
+            {cancelButton}
+            {markPaidButton}
+          </>
+        );
       case 'paid':
         return (
           <>
@@ -299,6 +320,9 @@ export const BookingCard: React.FC<BookingCardProps> = ({
     const actions: { label: string; icon: React.ReactNode; onClick: () => void; variant: 'primary' | 'secondary' | 'danger' }[] = [];
 
     switch (booking.status) {
+      case 'requested':
+        actions.push({ label: 'Mark as Paid', icon: <CheckCircle className="w-4 h-4" />, onClick: onMarkPaid, variant: 'primary' });
+        break;
       case 'paid':
         actions.push({ label: 'Approve', icon: <CheckCircle className="w-4 h-4" />, onClick: onApprove, variant: 'primary' });
         actions.push({ label: 'Reschedule', icon: <RefreshCw className="w-4 h-4" />, onClick: onReschedule, variant: 'secondary' });

--- a/frontend/src/components/shop/bookings/BookingsTabV2.tsx
+++ b/frontend/src/components/shop/bookings/BookingsTabV2.tsx
@@ -7,6 +7,7 @@ import {
   mockBookings,
   MockBooking,
   transformApiOrder,
+  mapApiStatus,
   formatTime12Hour,
 } from "./mockData";
 import { BookingStatsCards } from "./BookingStatsCards";
@@ -22,6 +23,7 @@ import {
   getShopOrderCounts,
   updateOrderStatus,
   approveBooking,
+  markOrderAsPaid,
   ServiceOrderWithDetails,
 } from "@/services/api/services";
 import { appointmentsApi } from "@/services/api/appointments";
@@ -46,13 +48,14 @@ const BookingCardList: React.FC<{
   onComplete: (id: string) => void;
   onCancel: (id: string) => void;
   onMarkNoShow: (booking: MockBooking) => void;
+  onMarkPaid: (id: string) => void;
   isBlocked?: boolean;
   blockReason?: string;
   currentPage: number;
   totalPages: number;
   onPageChange: (page: number) => void;
   loading?: boolean;
-}> = ({ bookings, searchQuery, selectedBookingId, onSelect, onApprove, onReschedule, onSchedule, onComplete, onCancel, onMarkNoShow, isBlocked, blockReason, currentPage, totalPages, onPageChange, loading }) => {
+}> = ({ bookings, searchQuery, selectedBookingId, onSelect, onApprove, onReschedule, onSchedule, onComplete, onCancel, onMarkNoShow, onMarkPaid, isBlocked, blockReason, currentPage, totalPages, onPageChange, loading }) => {
   if (bookings.length === 0) {
     return (
       <div className="bg-[#1A1A1A] border border-gray-800 rounded-xl p-8 text-center">
@@ -81,6 +84,7 @@ const BookingCardList: React.FC<{
           onComplete={() => onComplete(booking.bookingId)}
           onCancel={() => onCancel(booking.bookingId)}
           onMarkNoShow={() => onMarkNoShow(booking)}
+          onMarkPaid={() => onMarkPaid(booking.bookingId)}
           isBlocked={isBlocked}
           blockReason={blockReason}
         />
@@ -273,9 +277,14 @@ export const BookingsTabV2: React.FC<BookingsTabV2Props> = ({
 
     try {
       // Call the API to approve the booking
-      await approveBooking(booking.orderId);
+      const updatedOrder = await approveBooking(booking.orderId);
 
-      // Update local state after successful API call
+      // Derive the new status from the returned order using the same mapping
+      // the list uses, so the optimistic state matches a refresh exactly.
+      const newStatus = updatedOrder
+        ? mapApiStatus(updatedOrder.status, updatedOrder.shopApproved)
+        : booking.status;
+
       setBookings((prev) =>
         prev.map((b) => {
           if (b.bookingId === bookingId) {
@@ -288,7 +297,7 @@ export const BookingsTabV2: React.FC<BookingsTabV2Props> = ({
                 description: "Booking approved by shop",
               },
             ];
-            return { ...b, status: "approved" as const, timeline: newTimeline };
+            return { ...b, status: newStatus, timeline: newTimeline };
           }
           return b;
         }),
@@ -300,6 +309,40 @@ export const BookingsTabV2: React.FC<BookingsTabV2Props> = ({
       const errorMessage =
         error instanceof Error ? error.message : "Unknown error";
       toast.error(`Failed to approve booking: ${errorMessage}`);
+    }
+  };
+
+  const handleMarkPaid = async (bookingId: string) => {
+    const booking = bookings.find((b) => b.bookingId === bookingId);
+    if (!booking) return;
+
+    try {
+      await markOrderAsPaid(booking.orderId);
+
+      setBookings((prev) =>
+        prev.map((b) => {
+          if (b.bookingId === bookingId) {
+            const newTimeline = [
+              ...b.timeline,
+              {
+                id: `tl-${Date.now()}`,
+                type: "approved" as const,
+                timestamp: new Date().toISOString(),
+                description: "Payment marked as received by shop",
+              },
+            ];
+            return { ...b, status: "paid" as const, timeline: newTimeline };
+          }
+          return b;
+        }),
+      );
+      toast.success("Payment marked as received");
+      loadCounts();
+    } catch (error: unknown) {
+      console.error("Error marking booking as paid:", error);
+      const errorMessage =
+        error instanceof Error ? error.message : "Unknown error";
+      toast.error(`Failed to mark as paid: ${errorMessage}`);
     }
   };
 
@@ -561,6 +604,7 @@ export const BookingsTabV2: React.FC<BookingsTabV2Props> = ({
                 onComplete={handleComplete}
                 onCancel={handleCancel}
                 onMarkNoShow={(booking) => setNoShowModalBooking(booking)}
+                onMarkPaid={handleMarkPaid}
                 isBlocked={isBlocked}
                 blockReason={blockReason}
                 currentPage={currentPage}

--- a/frontend/src/services/api/services.ts
+++ b/frontend/src/services/api/services.ts
@@ -581,6 +581,19 @@ export const markOrderAsNoShow = async (
 };
 
 /**
+ * Mark a pending order as paid (Shop only)
+ */
+export const markOrderAsPaid = async (orderId: string): Promise<boolean> => {
+  try {
+    await apiClient.post(`/services/orders/${orderId}/mark-paid`);
+    return true;
+  } catch (error) {
+    console.error('Error marking order as paid:', error);
+    throw error;
+  }
+};
+
+/**
  * Get expired unpaid bookings (Shop only)
  */
 export const getExpiredUnpaidBookings = async (): Promise<ServiceOrderWithDetails[]> => {
@@ -1118,6 +1131,7 @@ export const servicesApi = {
   cancelOrder,
   cancelOrderByShop,
   markOrderAsNoShow,
+  markOrderAsPaid,
   approveBooking,
   rescheduleBooking,
   getPendingApprovalBookings,


### PR DESCRIPTION
## Summary

  Fixes several issues in the shop **manual booking** flow (Service > Appointments → Add booking) and the bookings list.

  ## Changes

  ### Payment status no longer forces "Paid"
  Manual bookings created with **Pending** or **Unpaid** were being saved with order `status = 'paid'`. Now the order is `paid` only when the
  selected payment status is `paid`; `pending`/`unpaid` are created as `pending` (the `payment_status` column still records `pending` vs `unpaid`).

  ### New "Mark as Paid" action
  Pending/"Waiting for Payment" bookings previously had only a **Cancel** action, so there was no way to settle a cash/pending booking in-app.
  - `POST /api/services/orders/:id/mark-paid` (`OrderController.markOrderPaid`) — shop-authenticated, verifies ownership, only allows `pending`
  orders. Backed by `OrderRepository.markAsPaid()` (sets `status` + `payment_status` to `paid`).
  - "Mark as Paid" button + dropdown action on pending bookings, with an optimistic update. The booking then enters the normal Approve → Schedule →
  Complete flow.

  ### Service dropdown fix (ManualBookingModal)
  - Dropdown rendered *behind* the modal (overlay `z-[1100]` vs Select `z-50`) → now rendered above it so it opens.
  - Removed the selectable "Select a service…" placeholder item; it's now only a placeholder.

  ### Approve no longer shows a stray "Schedule" button
  After Approve, the optimistic update hardcoded the `approved` UI state (which renders a "Schedule" button) even though the backend treats paid +
  approved as scheduled. The status is now derived from the returned order via the same `mapApiStatus` the list uses, so the optimistic state
  matches a refresh.

  ## Testing
  - [ ] Create a manual booking with Pending/Unpaid → it appears under **Pending** (not Paid)
  - [ ] "Mark as Paid" on a pending booking → moves to Paid, then Approve/Schedule/Complete works
  - [ ] Service dropdown opens in the Add Booking modal and lists only real services
  - [ ] Approve an already-scheduled booking → shows Scheduled immediately (no refresh needed)
  - [ ] Existing paid/send-link/qr-code booking flows still behave as before