### PR TITLE
fix(shop): inventory modal UX + service import reliability

### DIFF
--- a/frontend/src/components/shop/modals/AddInventoryItemModal.tsx
+++ b/frontend/src/components/shop/modals/AddInventoryItemModal.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { X, Upload, Plus, Loader2, Package, Tag, DollarSign, Hash, BarChart3 } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { inventoryApi } from '@/services/api/inventory';
+import { NumberInput } from '@/components/ui/NumberInput';
 import type { InventoryCategory, InventoryVendor, CreateInventoryItemData } from '@/types/inventory';
 
 interface AddInventoryItemModalProps {
@@ -180,8 +181,8 @@ export const AddInventoryItemModal: React.FC<AddInventoryItemModalProps> = ({ on
   }
 
   return (
-    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4 overflow-y-auto">
-      <div className="bg-[#1A1A1A] rounded-lg w-full max-w-3xl border border-gray-800 my-8">
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+      <div className="bg-[#1A1A1A] rounded-lg w-full max-w-3xl border border-gray-800 max-h-[90vh] flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between p-6 border-b border-gray-800">
           <div className="flex items-center gap-3">
@@ -203,7 +204,8 @@ export const AddInventoryItemModal: React.FC<AddInventoryItemModalProps> = ({ on
         </div>
 
         {/* Form */}
-        <form onSubmit={handleSubmit} className="p-6 space-y-6">
+        <form onSubmit={handleSubmit} className="flex flex-col min-h-0 flex-1">
+          <div className="flex-1 overflow-y-auto p-6 space-y-6">
           {/* Image Upload */}
           <div>
             <label className="block text-sm font-medium text-gray-300 mb-2">Item Image</label>
@@ -314,20 +316,20 @@ export const AddInventoryItemModal: React.FC<AddInventoryItemModalProps> = ({ on
                     value={newCategoryName}
                     onChange={(e) => setNewCategoryName(e.target.value)}
                     placeholder="Category name"
-                    className="flex-1 px-4 py-2 bg-[#101010] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-[#FFCC00] transition-colors"
+                    className="flex-1 min-w-0 px-4 py-2 bg-[#101010] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-[#FFCC00] transition-colors"
                     onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), handleQuickAddCategory())}
                   />
                   <button
                     type="button"
                     onClick={handleQuickAddCategory}
-                    className="px-3 py-2 bg-[#FFCC00] text-black rounded-lg hover:bg-[#FFD700] transition-colors"
+                    className="shrink-0 px-3 py-2 bg-[#FFCC00] text-black rounded-lg hover:bg-[#FFD700] transition-colors"
                   >
                     Add
                   </button>
                   <button
                     type="button"
                     onClick={() => setShowQuickAddCategory(false)}
-                    className="px-3 py-2 bg-[#101010] border border-gray-700 text-gray-300 rounded-lg hover:border-gray-600 transition-colors"
+                    className="shrink-0 px-3 py-2 bg-[#101010] border border-gray-700 text-gray-300 rounded-lg hover:border-gray-600 transition-colors"
                   >
                     Cancel
                   </button>
@@ -369,20 +371,20 @@ export const AddInventoryItemModal: React.FC<AddInventoryItemModalProps> = ({ on
                     value={newVendorName}
                     onChange={(e) => setNewVendorName(e.target.value)}
                     placeholder="Vendor name"
-                    className="flex-1 px-4 py-2 bg-[#101010] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-[#FFCC00] transition-colors"
+                    className="flex-1 min-w-0 px-4 py-2 bg-[#101010] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-[#FFCC00] transition-colors"
                     onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), handleQuickAddVendor())}
                   />
                   <button
                     type="button"
                     onClick={handleQuickAddVendor}
-                    className="px-3 py-2 bg-[#FFCC00] text-black rounded-lg hover:bg-[#FFD700] transition-colors"
+                    className="shrink-0 px-3 py-2 bg-[#FFCC00] text-black rounded-lg hover:bg-[#FFD700] transition-colors"
                   >
                     Add
                   </button>
                   <button
                     type="button"
                     onClick={() => setShowQuickAddVendor(false)}
-                    className="px-3 py-2 bg-[#101010] border border-gray-700 text-gray-300 rounded-lg hover:border-gray-600 transition-colors"
+                    className="shrink-0 px-3 py-2 bg-[#101010] border border-gray-700 text-gray-300 rounded-lg hover:border-gray-600 transition-colors"
                   >
                     Cancel
                   </button>
@@ -424,12 +426,11 @@ export const AddInventoryItemModal: React.FC<AddInventoryItemModalProps> = ({ on
               </label>
               <div className="relative">
                 <DollarSign className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
-                <input
-                  type="number"
+                <NumberInput
                   step="0.01"
                   min="0"
                   value={formData.price}
-                  onChange={(e) => handleInputChange('price', parseFloat(e.target.value) || 0)}
+                  onValueChange={(value) => handleInputChange('price', value)}
                   placeholder="0.00"
                   className="w-full pl-10 pr-4 py-2 bg-[#101010] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-[#FFCC00] transition-colors"
                   required
@@ -443,12 +444,11 @@ export const AddInventoryItemModal: React.FC<AddInventoryItemModalProps> = ({ on
               <label className="block text-sm font-medium text-gray-300 mb-2">Cost (optional)</label>
               <div className="relative">
                 <DollarSign className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
-                <input
-                  type="number"
+                <NumberInput
                   step="0.01"
                   min="0"
-                  value={formData.cost}
-                  onChange={(e) => handleInputChange('cost', parseFloat(e.target.value) || 0)}
+                  value={formData.cost ?? 0}
+                  onValueChange={(value) => handleInputChange('cost', value)}
                   placeholder="0.00"
                   className="w-full pl-10 pr-4 py-2 bg-[#101010] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-[#FFCC00] transition-colors"
                   disabled={loading}
@@ -462,11 +462,11 @@ export const AddInventoryItemModal: React.FC<AddInventoryItemModalProps> = ({ on
             {/* Initial Stock Quantity */}
             <div>
               <label className="block text-sm font-medium text-gray-300 mb-2">Initial Stock Quantity</label>
-              <input
-                type="number"
+              <NumberInput
+                integer
                 min="0"
-                value={formData.stockQuantity}
-                onChange={(e) => handleInputChange('stockQuantity', parseInt(e.target.value) || 0)}
+                value={formData.stockQuantity ?? 0}
+                onValueChange={(value) => handleInputChange('stockQuantity', value)}
                 placeholder="0"
                 className="w-full px-4 py-2 bg-[#101010] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-[#FFCC00] transition-colors"
                 disabled={loading}
@@ -476,11 +476,11 @@ export const AddInventoryItemModal: React.FC<AddInventoryItemModalProps> = ({ on
             {/* Low Stock Threshold */}
             <div>
               <label className="block text-sm font-medium text-gray-300 mb-2">Low Stock Threshold</label>
-              <input
-                type="number"
+              <NumberInput
+                integer
                 min="0"
-                value={formData.lowStockThreshold}
-                onChange={(e) => handleInputChange('lowStockThreshold', parseInt(e.target.value) || 0)}
+                value={formData.lowStockThreshold ?? 0}
+                onValueChange={(value) => handleInputChange('lowStockThreshold', value)}
                 placeholder="10"
                 className="w-full px-4 py-2 bg-[#101010] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-[#FFCC00] transition-colors"
                 disabled={loading}
@@ -488,8 +488,10 @@ export const AddInventoryItemModal: React.FC<AddInventoryItemModalProps> = ({ on
             </div>
           </div>
 
+          </div>
+
           {/* Footer */}
-          <div className="flex items-center justify-end gap-3 pt-4 border-t border-gray-800">
+          <div className="shrink-0 flex items-center justify-end gap-3 p-6 border-t border-gray-800">
             <button
               type="button"
               onClick={onClose}

--- a/frontend/src/components/shop/modals/EditInventoryItemModal.tsx
+++ b/frontend/src/components/shop/modals/EditInventoryItemModal.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { X, Upload, Plus, Loader2, Package, Tag, DollarSign, Hash, BarChart3 } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { inventoryApi } from '@/services/api/inventory';
+import { NumberInput } from '@/components/ui/NumberInput';
 import type {
   InventoryItemWithDetails,
   InventoryCategory,
@@ -186,8 +187,8 @@ export const EditInventoryItemModal: React.FC<EditInventoryItemModalProps> = ({ 
   }
 
   return (
-    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4 overflow-y-auto">
-      <div className="bg-[#1A1A1A] rounded-lg w-full max-w-3xl border border-gray-800 my-8">
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+      <div className="bg-[#1A1A1A] rounded-lg w-full max-w-3xl border border-gray-800 max-h-[90vh] flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between p-6 border-b border-gray-800">
           <div className="flex items-center gap-3">
@@ -209,7 +210,8 @@ export const EditInventoryItemModal: React.FC<EditInventoryItemModalProps> = ({ 
         </div>
 
         {/* Form */}
-        <form onSubmit={handleSubmit} className="p-6 space-y-6">
+        <form onSubmit={handleSubmit} className="flex flex-col min-h-0 flex-1">
+          <div className="flex-1 overflow-y-auto p-6 space-y-6">
           {/* Image Upload */}
           <div>
             <label className="block text-sm font-medium text-gray-300 mb-2">Item Image</label>
@@ -430,12 +432,11 @@ export const EditInventoryItemModal: React.FC<EditInventoryItemModalProps> = ({ 
               </label>
               <div className="relative">
                 <DollarSign className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
-                <input
-                  type="number"
+                <NumberInput
                   step="0.01"
                   min="0"
-                  value={formData.price}
-                  onChange={(e) => handleInputChange('price', parseFloat(e.target.value) || 0)}
+                  value={formData.price ?? 0}
+                  onValueChange={(value) => handleInputChange('price', value)}
                   placeholder="0.00"
                   className="w-full pl-10 pr-4 py-2 bg-[#101010] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-[#FFCC00] transition-colors"
                   required
@@ -449,12 +450,11 @@ export const EditInventoryItemModal: React.FC<EditInventoryItemModalProps> = ({ 
               <label className="block text-sm font-medium text-gray-300 mb-2">Cost (optional)</label>
               <div className="relative">
                 <DollarSign className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
-                <input
-                  type="number"
+                <NumberInput
                   step="0.01"
                   min="0"
-                  value={formData.cost}
-                  onChange={(e) => handleInputChange('cost', parseFloat(e.target.value) || 0)}
+                  value={formData.cost ?? 0}
+                  onValueChange={(value) => handleInputChange('cost', value)}
                   placeholder="0.00"
                   className="w-full pl-10 pr-4 py-2 bg-[#101010] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-[#FFCC00] transition-colors"
                   disabled={loading}
@@ -468,11 +468,11 @@ export const EditInventoryItemModal: React.FC<EditInventoryItemModalProps> = ({ 
             {/* Low Stock Threshold */}
             <div>
               <label className="block text-sm font-medium text-gray-300 mb-2">Low Stock Threshold</label>
-              <input
-                type="number"
+              <NumberInput
+                integer
                 min="0"
-                value={formData.lowStockThreshold}
-                onChange={(e) => handleInputChange('lowStockThreshold', parseInt(e.target.value) || 0)}
+                value={formData.lowStockThreshold ?? 0}
+                onValueChange={(value) => handleInputChange('lowStockThreshold', value)}
                 placeholder="10"
                 className="w-full px-4 py-2 bg-[#101010] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-[#FFCC00] transition-colors"
                 disabled={loading}
@@ -504,8 +504,10 @@ export const EditInventoryItemModal: React.FC<EditInventoryItemModalProps> = ({ 
             </p>
           </div>
 
+          </div>
+
           {/* Footer */}
-          <div className="flex items-center justify-end gap-3 pt-4 border-t border-gray-800">
+          <div className="shrink-0 flex items-center justify-end gap-3 p-6 border-t border-gray-800">
             <button
               type="button"
               onClick={onClose}

--- a/frontend/src/components/shop/modals/ServiceImportModal.tsx
+++ b/frontend/src/components/shop/modals/ServiceImportModal.tsx
@@ -66,11 +66,13 @@ export const ServiceImportModal: React.FC<ServiceImportModalProps> = ({ onClose,
     }
   };
 
-  const handleImport = async () => {
+  const handleImport = async (dryRunOverride?: boolean) => {
     if (!selectedFile) {
       toast.error('Please select a file first');
       return;
     }
+
+    const effectiveDryRun = dryRunOverride ?? dryRun;
 
     setImporting(true);
     setViewState('validating');
@@ -78,7 +80,7 @@ export const ServiceImportModal: React.FC<ServiceImportModalProps> = ({ onClose,
     try {
       const result = await importServices(selectedFile, {
         mode: importMode,
-        dryRun,
+        dryRun: effectiveDryRun,
         onDuplicateName: 'skip',
       });
 
@@ -86,7 +88,7 @@ export const ServiceImportModal: React.FC<ServiceImportModalProps> = ({ onClose,
       setViewState('results');
 
       if (result.success) {
-        if (dryRun) {
+        if (effectiveDryRun) {
           toast.success(`Validation successful! ${result.summary.validRows} rows ready to import`, {
             icon: '✅',
           });
@@ -499,9 +501,8 @@ export const ServiceImportModal: React.FC<ServiceImportModalProps> = ({ onClose,
                   type="button"
                   onClick={() => {
                     setDryRun(false);
-                    setViewState('upload');
-                    // Auto-trigger import after setting dryRun to false
-                    setTimeout(() => handleImport(), 100);
+                    setImportResult(null);
+                    handleImport(false);
                   }}
                   className="flex-1 px-4 py-3 rounded-xl bg-[#FFCC00] text-black font-semibold hover:bg-[#FFD700] transition-colors flex items-center justify-center gap-2"
                 >

--- a/frontend/src/components/shop/modals/StockAdjustmentModal.tsx
+++ b/frontend/src/components/shop/modals/StockAdjustmentModal.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { X, Plus, Minus, Loader2, Package, TrendingUp, TrendingDown, AlertTriangle } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { inventoryApi } from '@/services/api/inventory';
+import { NumberInput } from '@/components/ui/NumberInput';
 import type { InventoryItemWithDetails, AdjustmentType } from '@/types/inventory';
 
 interface StockAdjustmentModalProps {
@@ -78,7 +79,7 @@ export const StockAdjustmentModal: React.FC<StockAdjustmentModalProps> = ({ item
 
   return (
     <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-      <div className="bg-[#1A1A1A] rounded-lg w-full max-w-2xl border border-gray-800">
+      <div className="bg-[#1A1A1A] rounded-lg w-full max-w-2xl border border-gray-800 max-h-[90vh] flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between p-6 border-b border-gray-800">
           <div className="flex items-center gap-3">
@@ -100,7 +101,8 @@ export const StockAdjustmentModal: React.FC<StockAdjustmentModalProps> = ({ item
         </div>
 
         {/* Form */}
-        <form onSubmit={handleSubmit} className="p-6 space-y-6">
+        <form onSubmit={handleSubmit} className="flex flex-col min-h-0 flex-1">
+          <div className="flex-1 overflow-y-auto p-6 space-y-6">
           {/* Current Stock Display */}
           <div className="bg-[#101010] border border-gray-700 rounded-lg p-4">
             <div className="grid grid-cols-3 gap-4 text-center">
@@ -195,11 +197,11 @@ export const StockAdjustmentModal: React.FC<StockAdjustmentModalProps> = ({ item
               </div>
 
               {/* Input */}
-              <input
-                type="number"
+              <NumberInput
+                integer
                 value={quantityChange}
-                onChange={(e) => setQuantityChange(parseInt(e.target.value) || 0)}
-                className="flex-1 px-4 py-2 bg-[#101010] border border-gray-700 rounded-lg text-white text-center font-bold focus:outline-none focus:border-[#FFCC00] transition-colors"
+                onValueChange={setQuantityChange}
+                className="flex-1 min-w-0 px-4 py-2 bg-[#101010] border border-gray-700 rounded-lg text-white text-center font-bold focus:outline-none focus:border-[#FFCC00] transition-colors"
                 placeholder="0"
                 disabled={loading}
               />
@@ -255,8 +257,10 @@ export const StockAdjustmentModal: React.FC<StockAdjustmentModalProps> = ({ item
             />
           </div>
 
+          </div>
+
           {/* Footer */}
-          <div className="flex items-center justify-end gap-3 pt-4 border-t border-gray-800">
+          <div className="shrink-0 flex items-center justify-end gap-3 p-6 border-t border-gray-800">
             <button
               type="button"
               onClick={onClose}

--- a/frontend/src/components/shop/tabs/InventoryTab.tsx
+++ b/frontend/src/components/shop/tabs/InventoryTab.tsx
@@ -300,7 +300,7 @@ export const InventoryTab: React.FC<InventoryTabProps> = ({ shopId }) => {
             Manage your inventory items and track stock levels
           </p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center justify-end gap-2">
           <button
             onClick={() => setShowCategoryModal(true)}
             className="px-4 py-2 bg-[#101010] border border-gray-700 text-gray-300 rounded-lg hover:border-[#FFCC00] hover:text-[#FFCC00] transition-colors flex items-center gap-2"
@@ -812,12 +812,25 @@ export const InventoryTab: React.FC<InventoryTabProps> = ({ shopId }) => {
       )}
 
       {/* Modals */}
-      {showAddModal && <AddInventoryItemModal onClose={() => setShowAddModal(false)} onSuccess={loadInventory} />}
+      {showAddModal && (
+        <AddInventoryItemModal
+          onClose={() => setShowAddModal(false)}
+          onSuccess={() => {
+            loadInventory();
+            loadCategories();
+            loadVendors();
+          }}
+        />
+      )}
       {showEditModal && selectedItem && (
         <EditInventoryItemModal
           item={selectedItem}
           onClose={() => setShowEditModal(false)}
-          onSuccess={loadInventory}
+          onSuccess={() => {
+            loadInventory();
+            loadCategories();
+            loadVendors();
+          }}
         />
       )}
       {showAdjustStockModal && selectedItem && (

--- a/frontend/src/components/ui/NumberInput.tsx
+++ b/frontend/src/components/ui/NumberInput.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+
+interface NumberInputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "value" | "onChange" | "type"> {
+  value: number;
+  onValueChange: (value: number) => void;
+  integer?: boolean;
+  emptyValue?: number;
+}
+
+export const NumberInput: React.FC<NumberInputProps> = ({
+  value,
+  onValueChange,
+  integer = false,
+  emptyValue = 0,
+  ...props
+}) => {
+  const [text, setText] = useState<string>(value === emptyValue ? "" : String(value));
+
+  useEffect(() => {
+    const parsed = text === "" ? emptyValue : integer ? parseInt(text, 10) : parseFloat(text);
+    if (parsed !== value && !(Number.isNaN(parsed) && value === emptyValue)) {
+      setText(value === emptyValue ? "" : String(value));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value;
+    setText(raw);
+
+    if (raw === "") {
+      onValueChange(emptyValue);
+      return;
+    }
+
+    const parsed = integer ? parseInt(raw, 10) : parseFloat(raw);
+    onValueChange(Number.isNaN(parsed) ? emptyValue : parsed);
+  };
+
+  return (
+    <input
+      {...props}
+      type="number"
+      inputMode={integer ? "numeric" : "decimal"}
+      value={text}
+      onChange={handleChange}
+    />
+  );
+};


### PR DESCRIPTION
## Summary
  Fixes several shop-side bugs: services not saving on import, inventory
  modal UX issues, and the category/vendor filter not updating after
  creating an item.

  ## Changes
  - Service import: "Proceed with Import" re-ran a dry-run instead of the
    real import (stale `dryRun` closure) — items now actually save.
  - Number fields (price/cost/stock/threshold/adjust): can now be cleared
    and accept decimals/negatives instead of snapping back to 0. Added a
    shared `NumberInput` used across add/edit item and stock-adjust modals.
  - Inventory modals fit short screens: `max-h-[90vh]`, scrollable body,
    fixed header/footer.
  - Category/vendor quick-add row no longer overflows its column.
  - Category/vendor filter lists refresh after saving an item, so newly
    created ones appear without a page refresh.
  - Inventory toolbar buttons wrap on narrow screens.

  ## How to test
  1. Service → Services → Import a file → Validate → Proceed with Import →
     items appear and persist.
  2. Inventory → Add item: clear a number field (stays empty), type 0.99.
  3. Open Add/Edit on a short window: header + Save/Cancel stay visible,
     body scrolls.
  4. Add item → "+" on Category/Vendor → Cancel stays inside the modal.
  5. Create a category/vendor while adding an item → shows in the filter
     dropdown without refreshing.