### PR TITLE
fix(mobile): invalidate caches for reward, booking completion, and service reviews

### DIFF
--- a/mobile/feature/services/booking/hooks/useBookingDetail.ts
+++ b/mobile/feature/services/booking/hooks/useBookingDetail.ts
@@ -130,7 +130,7 @@ export function useBookingDetail() {
       "Are you sure you want to mark this booking as complete? Customer will receive their RCN rewards.",
       [
         { text: "Cancel", style: "cancel" },
-        { text: "Complete", onPress: () => completeOrderMutation.mutate(booking.orderId) },
+        { text: "Complete", onPress: () => completeOrderMutation.mutate({ orderId: booking.orderId, customerAddress: booking.customerAddress }) },
       ]
     );
   }, [booking, completeOrderMutation]);

--- a/mobile/feature/services/booking/hooks/useBookingMutations.ts
+++ b/mobile/feature/services/booking/hooks/useBookingMutations.ts
@@ -137,13 +137,18 @@ export function useCompleteOrderMutation() {
   const { guard, reset } = useSubmitGuard();
 
   const mutation = useMutation({
-    mutationFn: async (orderId: string) => {
+    mutationFn: async ({ orderId }: { orderId: string; customerAddress?: string }) => {
       return serviceApi.updateOrderStatus(orderId, "completed");
     },
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: ["repaircoin", "bookings", "shop"],
       });
+      if (variables.customerAddress) {
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.customerTransactions(variables.customerAddress),
+        });
+      }
       showSuccess("Booking complete! Customer will receive RCN rewards.");
     },
     onError: (error: any) => {
@@ -158,10 +163,10 @@ export function useCompleteOrderMutation() {
   return {
     ...mutation,
     mutate: (
-      orderId: string,
+      variables: { orderId: string; customerAddress?: string },
       options?: Parameters<typeof mutation.mutate>[1]
     ) => {
-      guard(() => mutation.mutate(orderId, options));
+      guard(() => mutation.mutate(variables, options));
     },
   };
 }

--- a/mobile/feature/services/services-main/feature-tab/hooks/useServiceReviews.ts
+++ b/mobile/feature/services/services-main/feature-tab/hooks/useServiceReviews.ts
@@ -25,6 +25,8 @@ export function useServiceReviews() {
         limit: 50,
       }),
     enabled: !!id,
+    staleTime: 0,
+    refetchOnMount: true,
   });
 
   // Check if user is shop owner of this service

--- a/mobile/feature/services/services-main/feature-tab/hooks/useWriteReview.ts
+++ b/mobile/feature/services/services-main/feature-tab/hooks/useWriteReview.ts
@@ -30,6 +30,10 @@ export function useWriteReview() {
     onSuccess: () => {
       setIsSubmitted(true);
       queryClient.invalidateQueries({ queryKey: queryKeys.appointments() });
+      if (serviceId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.serviceReviews(serviceId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.service(serviceId) });
+      }
       showSuccess("Thank you for your feedback!");
       router.back();
     },

--- a/mobile/feature/shop/reward/hooks/useRewardQuery.ts
+++ b/mobile/feature/shop/reward/hooks/useRewardQuery.ts
@@ -57,6 +57,9 @@ export function useIssueReward(resetInputs?: () => void) {
         rqClient.invalidateQueries({
           queryKey: queryKeys.customerInfo(variables.customerAddress),
         });
+        rqClient.invalidateQueries({
+          queryKey: queryKeys.customerTransactions(variables.customerAddress),
+        });
       }
 
       if (shopWalletAddress) {


### PR DESCRIPTION
## Summary

- **Reward Cache Fix** — After a shop issues RCN reward to a customer, the customer's History tab was not updating in real time. Added `customerTransactions` cache invalidation in `useRewardQuery.ts` on reward success.

- **Booking Completion Cache Fix** — After a shop marks a booking as complete, the customer's History tab was not updating. Updated `useCompleteOrderMutation` to accept `customerAddress` and invalidate `customerTransactions` on completion. Updated call site in `useBookingDetail.ts` to pass `customerAddress`.

- **Service Reviews Cache Fix** — After a customer submits a review, it was not appearing in the service's Reviews section until the 5-minute cache expired. Added `serviceReviews` and `service` query invalidation in `useWriteReview.ts` on success. Also overrode global `staleTime: 0` and `refetchOnMount: true` in `useServiceReviews.ts` so reviews always fetch fresh on navigation.

## Root Cause

Global query config sets `staleTime: 5 minutes` and `refetchOnMount: false`. These three flows were missing proper cache invalidation after mutations, causing stale data to persist until re-login or cache expiry.

## Files Changed

- `mobile/feature/shop/reward/hooks/useRewardQuery.ts`
- `mobile/feature/services/booking/hooks/useBookingMutations.ts`
- `mobile/feature/services/booking/hooks/useBookingDetail.ts`
- `mobile/feature/services/services-main/feature-tab/hooks/useWriteReview.ts`
- `mobile/feature/services/services-main/feature-tab/hooks/useServiceReviews.ts`
