### PR TITLE
fix(mobile): resolve auth refresh deadlock and stale WalletConnect session

### DIFF
--- a/mobile/feature/auth/hooks/useLogout.ts
+++ b/mobile/feature/auth/hooks/useLogout.ts
@@ -1,4 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
+import { useActiveWallet, useDisconnect } from "thirdweb/react";
 import { useAuthStore } from "@/feature/auth/store/auth.store";
 import { router } from "expo-router";
 import { useCallback, useState } from "react";
@@ -17,7 +18,8 @@ const SECURE_STORE_KEYS = [
 
 export const useLogout = () => {
   const queryClient = useQueryClient();
-  const account = useAuthStore((state) => state.account);
+  const activeWallet = useActiveWallet();
+  const { disconnect } = useDisconnect();
   const resetState = useAuthStore((state) => state.resetState);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
 
@@ -32,9 +34,14 @@ export const useLogout = () => {
         console.error("[Logout] Error deactivating push tokens:", error);
       });
 
-      if (account?.disconnect) {
+      // Disconnect the actual thirdweb wallet (not the store's plain
+      // { address } object). This tears down the underlying WalletConnect
+      // session and clears thirdweb's persisted "last connected wallet"
+      // record, preventing a stale "No matching key. session:" error from
+      // useAutoConnect on the next app launch.
+      if (activeWallet) {
         try {
-          await account.disconnect();
+          await disconnect(activeWallet);
         } catch (error) {
           console.error("[Logout] Error disconnecting wallet:", error);
         }
@@ -62,7 +69,7 @@ export const useLogout = () => {
     } finally {
       setIsLoggingOut(false);
     }
-  }, [queryClient, account, resetState, isLoggingOut]);
+  }, [queryClient, activeWallet, disconnect, resetState, isLoggingOut]);
 
   return {
     logout: handleLogout,

--- a/mobile/shared/utilities/axios.ts
+++ b/mobile/shared/utilities/axios.ts
@@ -2,7 +2,6 @@ import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 import { jwtDecode } from "jwt-decode";
 import { router } from "expo-router";
 import { Toast } from "react-native-toast-notifications";
-import { authApi } from "@/feature/auth/services/auth.services";
 import { useAuthStore } from "@/feature/auth/store/auth.store";
 
 interface DecodedToken {
@@ -105,10 +104,24 @@ class ApiClient {
         useAuthStore.getState();
       if (!refreshToken) return null;
 
-      const response = await authApi.getRefreshToken(refreshToken);
+      // IMPORTANT: use a bare axios call (NOT this.instance / apiClient) so the
+      // refresh request does NOT re-enter the request interceptor. Going through
+      // this.instance deadlocks: the access token is expired and isRefreshing is
+      // already true, so the refresh request itself would wait on the refresh it
+      // is supposed to be performing.
+      const response = await axios.post(
+        `${this.baseURL}/auth/refresh`,
+        { refreshToken },
+        { headers: { "Content-Type": "application/json" }, timeout: 60000 },
+      );
 
-      if (response?.data?.success) {
-        const { accessToken, refreshToken: newRefreshToken } = response.data;
+      const body = response?.data;
+
+      if (body?.success) {
+        const accessToken = body.data?.accessToken || body.token;
+        const newRefreshToken = body.data?.refreshToken;
+
+        if (!accessToken) return null;
 
         setAccessToken(accessToken);
         if (newRefreshToken) {
@@ -141,17 +154,21 @@ class ApiClient {
               if (!this.isRefreshing) {
                 this.isRefreshing = true;
 
-                const newToken = await this.refreshToken();
+                try {
+                  const newToken = await this.refreshToken();
 
-                if (newToken) {
-                  token = newToken;
-                  this.onTokenRefreshed(newToken);
-                } else {
-                  await this.clearAuthToken();
-                  this.onTokenRefreshed("");
+                  if (newToken) {
+                    token = newToken;
+                    this.onTokenRefreshed(newToken);
+                  } else {
+                    await this.clearAuthToken();
+                    this.onTokenRefreshed("");
+                  }
+                } finally {
+                  // Always release the gate, even if refresh throws, so later
+                  // requests never hang forever on a stuck isRefreshing flag.
+                  this.isRefreshing = false;
                 }
-
-                this.isRefreshing = false;
               } else {
                 token = await new Promise<string>((resolve) => {
                   this.subscribeTokenRefresh((newToken: string) => {


### PR DESCRIPTION
Two related auth bugs caused the app to freeze ~10 min after login and to log "No matching key. session: ..." on launch.

Refresh deadlock (shared/utilities/axios.ts):
- refreshToken() sent /auth/refresh through the same axios instance, so the request re-entered the request interceptor while the access token was expired and isRefreshing was already true, deadlocking the refresh on itself. isRefreshing stuck true => all later requests hung (infinite
  loading). Now uses a bare axios.post so it bypasses the interceptor.
- Fixed regressed response-shape check (response.data.success ->
  response.success; read body.data.accessToken) so refresh succeeds.
- Reset isRefreshing in a finally block as defense-in-depth.

Stale WalletConnect session (feature/auth/hooks/useLogout.ts):
- Logout called account.disconnect(), but the store's account is a plain { address } object with no disconnect(), so the wallet was never torn down. thirdweb's persisted reconnect record + WC session survived logout, and useAutoConnect failed to restore the dead session on next launch. Now disconnects the real active wallet via useActiveWallet/useDisconnect.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>