### PR TITLE
fix(shop): sidebar search, mobile sidebar close, subscription 404 links

### DIFF
--- a/frontend/src/components/customer/FindShop.tsx
+++ b/frontend/src/components/customer/FindShop.tsx
@@ -32,6 +32,9 @@ import "leaflet/dist/leaflet.css";
 if (typeof window !== "undefined") {
   const style = document.createElement("style");
   style.textContent = `
+    .leaflet-container {
+      isolation: isolate;
+    }
     .leaflet-popup-content-wrapper {
       background-color: #1F2937 !important;
       color: white !important;

--- a/frontend/src/components/notifications/SubscriptionSettings.tsx
+++ b/frontend/src/components/notifications/SubscriptionSettings.tsx
@@ -108,7 +108,7 @@ export function SubscriptionSettings({ userType = 'shop' }: SubscriptionSettings
 
         {subscription && (
           <Link
-            href="/shop/settings"
+            href="/shop?tab=subscription"
             className="text-sm px-4 py-2 bg-[#2F2F2F] text-[#FFCC00] rounded-full font-medium hover:bg-[#3F3F3F] transition-colors flex items-center gap-2"
           >
             Manage
@@ -199,7 +199,7 @@ export function SubscriptionSettings({ userType = 'shop' }: SubscriptionSettings
                 </p>
               </div>
               <Link
-                href="/shop/settings"
+                href="/shop?tab=subscription"
                 className="px-4 py-2 bg-[#FFCC00] hover:bg-yellow-400 text-black rounded-lg text-sm font-medium transition-colors whitespace-nowrap"
               >
                 Go to Settings
@@ -228,7 +228,7 @@ export function SubscriptionSettings({ userType = 'shop' }: SubscriptionSettings
                 You cannot issue rewards or process redemptions while paused. Contact support to resolve any issues.
               </p>
               <Link
-                href="/shop/settings"
+                href="/shop?tab=subscription"
                 className="inline-flex items-center gap-2 px-4 py-2 bg-[#FFCC00] hover:bg-yellow-400 text-black rounded-lg text-sm font-medium transition-colors"
               >
                 View Details
@@ -315,7 +315,7 @@ export function SubscriptionSettings({ userType = 'shop' }: SubscriptionSettings
                 Subscribe Now
               </Link>
               <Link
-                href="/shop/settings"
+                href="/shop?tab=subscription"
                 className="px-4 py-2 bg-[#2F2F2F] hover:bg-[#3F3F3F] text-gray-300 rounded-lg text-sm font-medium transition-colors flex items-center gap-2"
               >
                 Learn More

--- a/frontend/src/components/ui/DashboardLayout.tsx
+++ b/frontend/src/components/ui/DashboardLayout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { usePathname } from "next/navigation";
 import { Menu, X } from "lucide-react";
 import { CustomerSidebar, ShopSidebar, AdminSidebar } from "./sidebar";
 import { NotificationBell } from "@/components/notifications/NotificationBell";
@@ -49,10 +50,16 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
+  const pathname = usePathname();
 
   // Initialize notification system for all users
   // Admins need WebSocket for subscription status change events
   useNotifications({ enabled: true });
+
+  // Close the mobile sidebar after navigating to a page or switching tabs.
+  useEffect(() => {
+    setIsSidebarOpen(false);
+  }, [pathname, activeTab]);
 
   // Track scroll position for header padding
   useEffect(() => {

--- a/frontend/src/components/ui/sidebar/ShopSidebar.tsx
+++ b/frontend/src/components/ui/sidebar/ShopSidebar.tsx
@@ -267,6 +267,29 @@ const ShopSidebar: React.FC<ShopSidebarProps> = ({
     },
   ];
 
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const isSearching = normalizedQuery.length > 0;
+  const matchesQuery = (text: string) =>
+    text.toLowerCase().includes(normalizedQuery);
+
+  const filteredSections = isSearching
+    ? shopSections
+        .map((section) => ({
+          ...section,
+          items: matchesQuery(section.title)
+            ? section.items
+            : section.items.filter((item) => matchesQuery(item.title)),
+        }))
+        .filter((section) => section.items.length > 0)
+    : shopSections;
+
+  const filteredBottomItems = isSearching
+    ? bottomMenuItems.filter((item) => matchesQuery(item.title))
+    : bottomMenuItems;
+
+  const hasResults =
+    filteredSections.length > 0 || filteredBottomItems.length > 0;
+
   return (
     <BaseSidebar
       isOpen={isOpen}
@@ -297,8 +320,13 @@ const ShopSidebar: React.FC<ShopSidebarProps> = ({
         {!isCollapsed ? (
           /* Shop Sidebar with Sections */
           <div className="space-y-4 px-2 sm:px-3">
-            {shopSections.map((section) => {
-              const sectionExpanded = isSectionExpanded(section.id);
+            {isSearching && !hasResults && (
+              <p className="px-2 py-3 text-sm text-gray-400">
+                No results for &ldquo;{searchQuery.trim()}&rdquo;
+              </p>
+            )}
+            {filteredSections.map((section) => {
+              const sectionExpanded = isSearching || isSectionExpanded(section.id);
 
               return (
                 <div key={section.id}>
@@ -348,7 +376,7 @@ const ShopSidebar: React.FC<ShopSidebarProps> = ({
         ) : (
           /* Collapsed state - show icons only */
           <ul className="space-y-1 px-2 sm:px-3">
-            {shopSections.flatMap((section) =>
+            {filteredSections.flatMap((section) =>
               section.items.map((item) => {
                 const isActive = isItemActive(item);
 
@@ -405,8 +433,9 @@ const ShopSidebar: React.FC<ShopSidebarProps> = ({
       </nav>
 
       {/* Settings Section */}
+      {(!isSearching || filteredBottomItems.length > 0) && (
       <div className="border-t border-gray-800 p-3 sm:p-4">
-        {!isCollapsed && (
+        {!isCollapsed && !isSearching && (
           <button
             onClick={() => toggleSection("settings")}
             className="flex items-center justify-between w-full px-2 py-2 text-[#FFCC00] text-xs font-semibold tracking-wider hover:opacity-80 transition-opacity mb-2"
@@ -421,9 +450,9 @@ const ShopSidebar: React.FC<ShopSidebarProps> = ({
         )}
 
         {/* Show items if: collapsed, OR section is expanded */}
-        {(isCollapsed || isSectionExpanded("settings")) && (
+        {(isCollapsed || isSearching || isSectionExpanded("settings")) && (
           <ul className="space-y-1">
-            {bottomMenuItems.map((item) => {
+            {filteredBottomItems.map((item) => {
               const isActive = item.tabId ? activeTab === item.tabId : false;
 
               const handleClick = (e: React.MouseEvent) => {
@@ -470,6 +499,7 @@ const ShopSidebar: React.FC<ShopSidebarProps> = ({
           </ul>
         )}
       </div>
+      )}
     </BaseSidebar>
   );
 };


### PR DESCRIPTION
## Summary
  Three shop-dashboard UX bug fixes.

  ## Changes

  ### 1. Sidebar search now works
  `ShopSidebar.tsx` — the sidebar search box was a dead input (state captured, never read). It now filters the navigation links live (sections
  auto-expand to reveal matches, with a "No results" message). Scope is nav-link filtering only — not global record search.

  ### 2. Mobile sidebar closes on navigation
  `DashboardLayout.tsx` — added an effect that closes the mobile sidebar whenever the route or active tab changes. Covers both tab switches and
  direct page routes, and applies to all three roles (shop/customer/admin) since the layout is shared. No-op on desktop (sidebar is pinned there).

  ### 3. Subscription links no longer 404
  `SubscriptionSettings.tsx` — "Manage" / "Go to Settings" / "View Details" / "Learn More" linked to `/shop/settings`, which doesn't exist
  (settings is a tab, not a route). Repointed all four to `/shop?tab=subscription`, which renders `SubscriptionManagement`. The valid
  `/shop/subscription-form` links were left unchanged.