### PR TITLE
fix(mobile): notification tab routing, favorites layout, and social sharing fixes

### DIFF
--- a/mobile/feature/customer/referral/hooks/useReferral.ts
+++ b/mobile/feature/customer/referral/hooks/useReferral.ts
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from "react";
 import { Share, Linking } from "react-native";
 import { router } from "expo-router";
 import * as Clipboard from "expo-clipboard";
+import * as WebBrowser from "expo-web-browser";
 import { useAuthStore } from "@/feature/auth/store/auth.store";
 import { useAppToast } from "@/shared/hooks";
 import { REFERRER_REWARD, COPY_FEEDBACK_DURATION } from "@/shared/constants/referral";
@@ -76,15 +77,9 @@ export function useReferral() {
 
   const handleWhatsAppShare = () => {
     const url = `whatsapp://send?text=${encodeURIComponent(referralMessage)}`;
-    Linking.canOpenURL(url)
-      .then((supported) => {
-        if (supported) {
-          Linking.openURL(url);
-        } else {
-          showWarning("WhatsApp not installed. Please install WhatsApp to share.");
-        }
-      })
-      .catch((err) => console.log("WhatsApp error:", err));
+    Linking.openURL(url).catch(() => {
+      showWarning("WhatsApp is not installed on this device.");
+    });
   };
 
   const handleTwitterShare = () => {
@@ -102,9 +97,12 @@ export function useReferral() {
       .catch(() => Linking.openURL(webUrl));
   };
 
-  const handleFacebookShare = () => {
-    const url = `https://www.facebook.com/sharer/sharer.php?quote=${encodeURIComponent(referralMessage)}`;
-    Linking.openURL(url);
+  const handleFacebookShare = async () => {
+    await Clipboard.setStringAsync(referralMessage);
+    showWarning("Message copied — paste it as your caption on Facebook.");
+    const shareLink = "https://repaircoin.app";
+    const url = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareLink)}`;
+    await WebBrowser.openBrowserAsync(url);
   };
 
   const handleGoBack = () => {

--- a/mobile/feature/services/services-main/feature-tab/components/FavoritesTabContent.tsx
+++ b/mobile/feature/services/services-main/feature-tab/components/FavoritesTabContent.tsx
@@ -4,8 +4,11 @@ import {
   TouchableOpacity,
   FlatList,
   RefreshControl,
+  Dimensions,
 } from "react-native";
-import React from "react";
+
+const { width: SCREEN_WIDTH } = Dimensions.get("window");
+const CARD_WIDTH = (SCREEN_WIDTH - 32 - 16) / 2;
 import { Ionicons } from "@expo/vector-icons";
 import ServiceCard from "@/shared/components/shared/ServiceCard";
 import { SkeletonServiceGrid } from "@/shared/components/ui/Skeleton";
@@ -24,19 +27,22 @@ export default function FavoritesTabContent() {
   } = useFavoritesTab();
 
   const renderServiceItem = ({ item }: { item: ServiceData }) => (
-    <ServiceCard
-      imageUrl={item.imageUrl}
-      category={getCategoryLabel(item.category)}
-      title={item.serviceName}
-      description={item.description}
-      price={item.priceUsd}
+    <View style={{ width: CARD_WIDTH, marginHorizontal: 4, marginVertical: 8 }}>
+      <ServiceCard
+        imageUrl={item.imageUrl}
+        category={getCategoryLabel(item.category)}
+        title={item.serviceName}
+        description={item.description}
+        price={item.priceUsd}
         avgRating={item.avgRating}
-        reviewCount={item.reviewCount}      duration={item.durationMinutes}
-      onPress={() => handleServicePress(item)}
-      showFavoriteButton
-      serviceId={item.serviceId}
-      isFavorited={true}
-    />
+        reviewCount={item.reviewCount}
+        duration={item.durationMinutes}
+        onPress={() => handleServicePress(item)}
+        showFavoriteButton
+        serviceId={item.serviceId}
+        isFavorited={true}
+      />
+    </View>
   );
 
   if (isLoading) {
@@ -59,7 +65,7 @@ export default function FavoritesTabContent() {
   }
 
   return (
-    <React.Fragment>
+    <View style={{ flex: 1 }}>
       {/* Favorites count */}
       <View className="mb-4">
         <Text className="text-gray-400 text-sm">
@@ -72,6 +78,7 @@ export default function FavoritesTabContent() {
         keyExtractor={(item, index) => `${item.serviceId}-${index}`}
         renderItem={renderServiceItem}
         numColumns={2}
+        style={{ flex: 1 }}
         contentContainerStyle={{ paddingBottom: 100 }}
         refreshControl={
           <RefreshControl
@@ -98,6 +105,6 @@ export default function FavoritesTabContent() {
           </View>
         }
       />
-    </React.Fragment>
+    </View>
   );
 }

--- a/mobile/feature/services/services-main/feature-tab/hooks/useCustomerServiceTab.ts
+++ b/mobile/feature/services/services-main/feature-tab/hooks/useCustomerServiceTab.ts
@@ -1,9 +1,12 @@
 import { useState, useCallback } from "react";
+import { useLocalSearchParams } from "expo-router";
 import { CustomerServiceTab } from "@/feature/services/services/service.interface";
 import { CUSTOMER_SERVICE_TABS } from "@/shared/constants/services";
 
 export function useCustomerServiceTab() {
-  const [activeTab, setActiveTab] = useState<CustomerServiceTab>("Services");
+  const params = useLocalSearchParams<{ tab?: string }>();
+  const initialTab = (params.tab as CustomerServiceTab) || "Services";
+  const [activeTab, setActiveTab] = useState<CustomerServiceTab>(initialTab);
 
   const handleTabChange = useCallback((tab: CustomerServiceTab) => {
     setActiveTab(tab);

--- a/mobile/feature/services/services-main/feature-tab/hooks/useUnifiedServiceDetail.ts
+++ b/mobile/feature/services/services-main/feature-tab/hooks/useUnifiedServiceDetail.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
-import { Linking, Share } from "react-native";
+import { Linking, Share, Alert } from "react-native";
+import * as WebBrowser from "expo-web-browser";
 import * as Clipboard from "expo-clipboard";
 import { useLocalSearchParams, router } from "expo-router";
 import { goBack } from "expo-router/build/global-state/routing";
@@ -136,8 +137,11 @@ export function useUnifiedServiceDetail() {
   const handleShareWhatsApp = async () => {
     const message = `${getShareMessage()}\n${getShareUrl()}`;
     const url = `whatsapp://send?text=${encodeURIComponent(message)}`;
-    const canOpen = await Linking.canOpenURL(url);
-    if (canOpen) await Linking.openURL(url);
+    try {
+      await Linking.openURL(url);
+    } catch {
+      Alert.alert("WhatsApp Not Found", "WhatsApp is not installed on this device.");
+    }
     setShowShareModal(false);
   };
 
@@ -152,9 +156,10 @@ export function useUnifiedServiceDetail() {
   };
 
   const handleShareFacebook = async () => {
-    const url = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(getShareUrl())}`;
-    await Linking.openURL(url);
     setShowShareModal(false);
+    const shareUrl = getShareUrl();
+    const fbUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`;
+    await WebBrowser.openBrowserAsync(fbUrl);
   };
 
   const handleNativeShare = async () => {

--- a/mobile/shared/constants/notifications.ts
+++ b/mobile/shared/constants/notifications.ts
@@ -30,27 +30,27 @@ export const NOTIFICATION_ROUTES = {
   // Booking notifications
   booking_confirmed: {
     shop: "/(dashboard)/shop/service-orders",
-    customer: "/(dashboard)/customer/tabs/service/",
+    customer: "/(dashboard)/customer/tabs/service/?tab=Bookings",
   },
   service_booking_received: {
     shop: "/(dashboard)/shop/service-orders",
-    customer: "/(dashboard)/customer/tabs/service/",
+    customer: "/(dashboard)/customer/tabs/service/?tab=Bookings",
   },
   appointment_reminder: {
     shop: "/(dashboard)/shop/service-orders",
-    customer: "/(dashboard)/customer/tabs/service/",
+    customer: "/(dashboard)/customer/tabs/service/?tab=Bookings",
   },
   upcoming_appointment: {
     shop: "/(dashboard)/shop/service-orders",
-    customer: "/(dashboard)/customer/tabs/service/",
+    customer: "/(dashboard)/customer/tabs/service/?tab=Bookings",
   },
   service_order_completed: {
     shop: "/(dashboard)/shop/service-orders",
-    customer: "/(dashboard)/customer/tabs/service/",
+    customer: "/(dashboard)/customer/tabs/service/?tab=Bookings",
   },
   order_completed: {
     shop: "/(dashboard)/shop/service-orders",
-    customer: "/(dashboard)/customer/tabs/service/",
+    customer: "/(dashboard)/customer/tabs/service/?tab=Bookings",
   },
   // Reschedule notifications
   reschedule_request_created: {


### PR DESCRIPTION
## Summary

- **Notification deep links** — booking/appointment notifications now open the Services screen with the Bookings tab pre-selected via `?tab=Bookings` URL param; updated all 6 customer notification routes in `notifications.ts` and read the param in `useCustomerServiceTab.ts`
- **Favorites layout** — replaced `React.Fragment` with `View style={{ flex: 1 }}`, added `style={{ flex: 1 }}` to `FlatList`, and added `CARD_WIDTH` constraint so all favorited services render in a consistent 2-column grid matching the Services tab
- **WhatsApp share** — removed `canOpenURL` check (blocked on Android 11+ due to package visibility); now calls `Linking.openURL` directly with catch fallback
- **Facebook share** — fixed missing `u=` param, switched from `Linking.openURL` to `WebBrowser.openBrowserAsync`, copies caption to clipboard before opening

## Files Changed

- `mobile/shared/constants/notifications.ts`
- `mobile/feature/services/services-main/feature-tab/hooks/useCustomerServiceTab.ts`
- `mobile/feature/services/services-main/feature-tab/components/FavoritesTabContent.tsx`
- `mobile/feature/customer/referral/hooks/useReferral.ts`
- `mobile/feature/services/services-main/feature-tab/hooks/useUnifiedServiceDetail.ts`

## Test Plan

- [ ] Tap a booking notification → opens Services screen on Bookings tab
- [ ] Tap an appointment reminder → opens Services screen on Bookings tab
- [ ] Favorite 4+ services → all appear in Favorites tab in 2-column grid
- [ ] Referral screen → Share via WhatsApp opens directly on Android 11+
- [ ] Referral screen → Share via Facebook opens browser with correct URL + caption copied
- [ ] Service detail → Share via WhatsApp and Facebook both work
