### PR TITLE
Tavie/dev

### DIFF
--- a/backend/src/domains/customer/services/CustomerService.ts
+++ b/backend/src/domains/customer/services/CustomerService.ts
@@ -145,6 +145,29 @@ export class CustomerService {
     }
   }
 
+  // Generates an 8-char uppercase alphanumeric referral code.
+  private generateReferralCodeValue(): string {
+    const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    let code = '';
+    for (let i = 0; i < 8; i++) {
+      code += chars.charAt(Math.floor(Math.random() * chars.length));
+    }
+    return code;
+  }
+
+  // Returns a referral code not already used by another customer. Collisions in
+  // a 36^8 space are astronomically unlikely, so a few attempts is plenty.
+  private async generateUniqueReferralCode(): Promise<string> {
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const code = this.generateReferralCodeValue();
+      const existing = await this.customerRepository.getCustomerByReferralCode(code);
+      if (!existing) {
+        return code;
+      }
+    }
+    throw new Error('Failed to generate a unique referral code');
+  }
+
   async registerCustomer(data: CustomerRegistrationData) {
     let referrer: CustomerData | null = null;
     try {
@@ -189,7 +212,8 @@ export class CustomerService {
       const customerWithWalletInfo = {
         ...newCustomer,
         wallet_type: data.walletType || 'external',
-        auth_method: data.authMethod || 'wallet'
+        auth_method: data.authMethod || 'wallet',
+        referralCode: await this.generateUniqueReferralCode()
       };
 
       await customerRepository.createCustomer(customerWithWalletInfo);

--- a/backend/src/domains/token/services/TokenService.ts
+++ b/backend/src/domains/token/services/TokenService.ts
@@ -3,6 +3,7 @@
   import { TierManager, CustomerData } from '../../../contracts/TierManager';
   import { customerRepository, shopRepository, transactionRepository, adminRepository } from '../../../repositories';
   import { ReferralRepository } from '../../../repositories/ReferralRepository';
+  import { ReferralService } from '../../../services/ReferralService';
   import { logger } from '../../../utils/logger';
 
   export interface TokenEarningRequest {
@@ -43,9 +44,17 @@
     private tokenMinter: TokenMinter | null = null;
     private tierManager: TierManager | null = null;
     private referralRepository: ReferralRepository;
+    private referralService: ReferralService | null = null;
 
     constructor() {
       this.referralRepository = new ReferralRepository();
+    }
+
+    private getReferralService(): ReferralService {
+      if (!this.referralService) {
+        this.referralService = new ReferralService();
+      }
+      return this.referralService;
     }
 
     private getTokenMinter(): TokenMinter {
@@ -307,6 +316,27 @@
             orderId,
             transactionHash: result.transactionHash
           });
+
+          // Trigger referral completion if this is the referee's first repair.
+          // Wrapped in its own try/catch so a referral-side failure can never
+          // roll back the customer's already-minted service earning.
+          try {
+            const referralResult = await this.getReferralService().completeReferralOnFirstRepair(
+              customerAddress,
+              shopId,
+              serviceAmount // use the service amount as repair-equivalent
+            );
+            if (referralResult.referralCompleted) {
+              logger.info('Referral completed on first service marketplace booking', {
+                customerAddress,
+                shopId,
+                orderId
+              });
+            }
+          } catch (referralError) {
+            logger.error('Error checking referral completion after service marketplace earning:', referralError);
+            // Do not re-throw — keep the successful earning intact.
+          }
 
           // Return result with updated total tokens
           return {

--- a/backend/src/repositories/CustomerRepository.ts
+++ b/backend/src/repositories/CustomerRepository.ts
@@ -182,8 +182,8 @@ export class CustomerRepository extends BaseRepository {
       const query = `
         INSERT INTO customers (
           address, wallet_address, name, first_name, last_name, email, phone, tier, lifetime_earnings,
-          last_earned_date, is_active, referral_count
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+          last_earned_date, is_active, referral_count, referral_code
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
       `;
 
       await this.pool.query(query, [
@@ -198,7 +198,8 @@ export class CustomerRepository extends BaseRepository {
         customer.lifetimeEarnings,
         customer.lastEarnedDate,
         customer.isActive,
-        customer.referralCount
+        customer.referralCount,
+        customer.referralCode ?? null
       ]);
 
       logger.info('Customer created successfully', { address: customer.address });

--- a/backend/src/scripts/backfill-pending-referrals.ts
+++ b/backend/src/scripts/backfill-pending-referrals.ts
@@ -1,0 +1,106 @@
+// One-time backfill: complete referrals that got stuck `pending` because the
+// referee completed their first repair through the service-marketplace flow,
+// which (before the TokenService fix) never called completeReferralOnFirstRepair.
+//
+// Usage:
+//   npx ts-node src/scripts/backfill-pending-referrals.ts            # dry-run (default, no writes)
+//   npx ts-node src/scripts/backfill-pending-referrals.ts --apply    # live run
+//
+// Idempotent: completeReferralOnFirstRepair only acts on `pending` referrals,
+// so re-running never double-pays.
+import { getSharedPool } from '../utils/database-pool';
+import { ReferralService } from '../services/ReferralService';
+
+interface Candidate {
+  id: number;
+  referee_address: string;
+  referrer_address: string;
+  shop_id: string;
+  repair_amount: number;
+  first_completed_order: string;
+}
+
+async function backfillPendingReferrals() {
+  const apply = process.argv.includes('--apply');
+  console.log(`🔄 Backfill pending referrals — mode: ${apply ? 'LIVE (--apply)' : 'DRY RUN'}\n`);
+
+  const pool = getSharedPool();
+  const referralService = new ReferralService();
+
+  try {
+    // Candidates: pending referrals whose referee has at least one completed
+    // service_order. We pull the referee's earliest completed order to use as
+    // the trigger-equivalent (its shop_id + total_amount drive the bonus call).
+    const { rows } = await pool.query<Candidate>(`
+      SELECT r.id,
+             r.referee_address,
+             r.referrer_address,
+             fo.shop_id,
+             fo.total_amount AS repair_amount,
+             fo.created_at   AS first_completed_order
+      FROM referrals r
+      JOIN LATERAL (
+        SELECT so.shop_id, so.total_amount, so.created_at
+        FROM service_orders so
+        WHERE LOWER(so.customer_address) = LOWER(r.referee_address)
+          AND so.status = 'completed'
+        ORDER BY so.created_at ASC
+        LIMIT 1
+      ) fo ON TRUE
+      WHERE r.status = 'pending'
+        AND r.metadata->>'awaitingFirstRepair' = 'true'
+      ORDER BY r.id ASC
+    `);
+
+    console.log(`📊 Found ${rows.length} stuck referral(s) eligible for completion\n`);
+
+    if (rows.length === 0) {
+      console.log('✅ Nothing to backfill.');
+      process.exit(0);
+    }
+
+    let completed = 0;
+    let skipped = 0;
+    let failed = 0;
+
+    for (const c of rows) {
+      const label = `referral id=${c.id} (referee ${c.referee_address} ← referrer ${c.referrer_address}), shop=${c.shop_id}, $${c.repair_amount}`;
+
+      if (!apply) {
+        console.log(`   [dry-run] would complete ${label}`);
+        continue;
+      }
+
+      try {
+        const result = await referralService.completeReferralOnFirstRepair(
+          c.referee_address,
+          c.shop_id,
+          Number(c.repair_amount)
+        );
+        if (result.referralCompleted) {
+          completed++;
+          console.log(`   ✅ completed ${label}`);
+        } else {
+          skipped++;
+          console.log(`   ⏭️  skipped ${label} — ${result.message}`);
+        }
+      } catch (err: any) {
+        failed++;
+        console.error(`   ❌ failed ${label} — ${err.message}`);
+      }
+    }
+
+    if (apply) {
+      console.log(`\n📊 Done: ${completed} completed, ${skipped} skipped, ${failed} failed`);
+    } else {
+      console.log(`\nℹ️  Dry run complete. Re-run with --apply to distribute bonuses.`);
+    }
+
+    process.exit(failed > 0 ? 1 : 0);
+  } catch (error) {
+    console.error('❌ Error during referral backfill:', error);
+    process.exit(1);
+  }
+}
+
+backfillPendingReferrals();

--- a/frontend/src/components/customer/ReferralDashboard.tsx
+++ b/frontend/src/components/customer/ReferralDashboard.tsx
@@ -30,7 +30,10 @@ export function ReferralDashboard() {
   const [copying, setCopying] = useState(false);
   const [generatingCode, setGeneratingCode] = useState(false);
   const [generateError, setGenerateError] = useState<string | null>(null);
-  const generateAttemptedRef = useRef(false);
+  // Tracks the wallet address we've already requested a code for. Refs survive
+  // StrictMode's double-invoked effects and re-renders, so keying the guard by
+  // address makes the POST fire exactly once per wallet.
+  const generateRequestedForRef = useRef<string | null>(null);
   const [retryNonce, setRetryNonce] = useState(0);
   const [referralStats, setReferralStats] = useState<{
     totalReferrals: number;
@@ -69,26 +72,31 @@ export function ReferralDashboard() {
     }
   }, [customerData?.address]);
 
-  // Reset the generate-attempt guard whenever the wallet changes
+  // Clear any stale error when the wallet changes (the guard itself is keyed by
+  // address, so it doesn't need an explicit reset here).
   useEffect(() => {
-    generateAttemptedRef.current = false;
     setGenerateError(null);
   }, [customerData?.address]);
 
   // If the customer record exists but has no referral code yet, request the
   // backend to generate one and then refresh customer data so the UI updates.
+  //
+  // The guard is keyed by wallet address rather than a boolean so React's
+  // StrictMode double-invoke (and any incidental re-render) can't fire a second
+  // POST. We intentionally do NOT cancel the in-flight request on cleanup:
+  // earlier this effect listed `generatingCode` in its deps and set it inside,
+  // which made the cleanup run mid-flight and skip `fetchCustomerData`, leaving
+  // referralCode empty. The backend /referrals/generate call is idempotent.
   useEffect(() => {
-    if (
-      !customerData?.address ||
-      customerData?.referralCode ||
-      generateAttemptedRef.current ||
-      generatingCode
-    ) {
+    const address = customerData?.address;
+    if (!address || customerData?.referralCode) {
       return;
     }
+    if (generateRequestedForRef.current === address) {
+      return;
+    }
+    generateRequestedForRef.current = address;
 
-    generateAttemptedRef.current = true;
-    let cancelled = false;
     let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
 
     (async () => {
@@ -115,9 +123,7 @@ export function ReferralDashboard() {
         ]);
 
         const generatedCode: string | undefined =
-          resp?.data?.data?.referralCode ?? resp?.data?.referralCode ?? resp?.referralCode;
-
-        if (cancelled) return;
+          resp?.data?.referralCode ?? resp?.data?.data?.referralCode ?? resp?.referralCode;
 
         if (!generatedCode) {
           throw new Error(
@@ -127,7 +133,6 @@ export function ReferralDashboard() {
 
         await fetchCustomerData(true);
       } catch (error: any) {
-        if (cancelled) return;
         const message =
           error?.response?.data?.error ||
           error?.message ||
@@ -137,24 +142,18 @@ export function ReferralDashboard() {
         toast.error(message);
       } finally {
         if (timeoutHandle) clearTimeout(timeoutHandle);
-        if (!cancelled) setGeneratingCode(false);
+        setGeneratingCode(false);
       }
     })();
-
-    return () => {
-      cancelled = true;
-      if (timeoutHandle) clearTimeout(timeoutHandle);
-    };
   }, [
     customerData?.address,
     customerData?.referralCode,
-    generatingCode,
     fetchCustomerData,
     retryNonce,
   ]);
 
   const retryGenerateReferralCode = () => {
-    generateAttemptedRef.current = false;
+    generateRequestedForRef.current = null;
     setGenerateError(null);
     setRetryNonce((n) => n + 1);
   };


### PR DESCRIPTION
Generate a unique referral code server-side when a customer registers, storing it directly on customers.referral_code via createCustomer. Checks uniqueness against existing customer codes and regenerates on collision.

No row is written to the referrals table at registration; that table is reserved for actual referral relationships (registering with a parent's code). Removes reliance on the lazy POST /referrals/generate path for new customers.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>