### PR TITLE
fix(marketing): campaign builder selection persistence & dropdown UX

### DIFF
--- a/backend/src/domains/MarketingDomain/controllers/MarketingController.ts
+++ b/backend/src/domains/MarketingDomain/controllers/MarketingController.ts
@@ -47,6 +47,41 @@ export class MarketingController {
     }
   };
 
+  private async processManualEmails(shopId: string, manualEmails: unknown): Promise<string[]> {
+    if (!manualEmails || typeof manualEmails !== 'string' || !manualEmails.trim()) {
+      return [];
+    }
+
+    const emailList = manualEmails
+      .split(/[\n,]+/)
+      .map(email => email.trim().toLowerCase())
+      .filter(email => email && email.includes('@'));
+
+    for (const email of emailList) {
+      try {
+        const emailPrefix = email.split('@')[0];
+        const fullName = emailPrefix.charAt(0).toUpperCase() + emailPrefix.slice(1);
+
+        await this.contactRepo.createContact({
+          shopId,
+          fullName,
+          email,
+          source: 'manual',
+          tags: ['campaign-invite']
+        });
+      } catch (error: unknown) {
+        if (error && typeof error === 'object' && 'message' in error) {
+          const errorMessage = (error as { message: string }).message;
+          if (!errorMessage.includes('already exists')) {
+            logger.warn(`Error creating contact for ${email}:`, errorMessage);
+          }
+        }
+      }
+    }
+
+    return emailList;
+  }
+
   /**
    * Get a single campaign
    */
@@ -112,43 +147,7 @@ export class MarketingController {
         return;
       }
 
-      // Process manual emails if provided
-      let processedManualEmails: string[] = [];
-      if (manualEmails && typeof manualEmails === 'string' && manualEmails.trim()) {
-        // Parse emails from the string (split by newline or comma, trim, validate)
-        const emailList = manualEmails
-          .split(/[\n,]+/)
-          .map(email => email.trim().toLowerCase())
-          .filter(email => email && email.includes('@'));
-
-        // Create contacts for emails that don't exist
-        for (const email of emailList) {
-          try {
-            // Extract name from email (part before @) or use generic name
-            const emailPrefix = email.split('@')[0];
-            const fullName = emailPrefix.charAt(0).toUpperCase() + emailPrefix.slice(1);
-
-            await this.contactRepo.createContact({
-              shopId,
-              fullName,
-              email,
-              source: 'manual',
-              tags: ['campaign-invite']
-            });
-          } catch (error: unknown) {
-            // Contact already exists or validation error - continue
-            if (error && typeof error === 'object' && 'message' in error) {
-              const errorMessage = (error as { message: string }).message;
-              // Only log if it's not a duplicate error
-              if (!errorMessage.includes('already exists')) {
-                logger.warn(`Error creating contact for ${email}:`, errorMessage);
-              }
-            }
-          }
-        }
-
-        processedManualEmails = emailList;
-      }
+      const processedManualEmails = await this.processManualEmails(shopId, manualEmails);
 
       // Merge manual emails into audienceFilters
       const updatedAudienceFilters = {
@@ -235,8 +234,17 @@ export class MarketingController {
         couponValue,
         couponType,
         couponExpiresAt,
-        serviceId
+        serviceId,
+        manualEmails
       } = req.body;
+
+      const processedManualEmails = await this.processManualEmails(existing.shopId, manualEmails);
+      const updatedAudienceFilters = audienceFilters !== undefined
+        ? {
+            ...audienceFilters,
+            ...(processedManualEmails.length > 0 && { manualEmails: processedManualEmails })
+          }
+        : audienceFilters;
 
       const campaign = await this.marketingService.updateCampaign(campaignId, {
         name,
@@ -245,7 +253,7 @@ export class MarketingController {
         designContent,
         templateId,
         audienceType,
-        audienceFilters,
+        audienceFilters: updatedAudienceFilters,
         deliveryMethod,
         promoCodeId,
         couponValue,

--- a/frontend/src/components/shop/marketing/CampaignBuilderModal.tsx
+++ b/frontend/src/components/shop/marketing/CampaignBuilderModal.tsx
@@ -369,6 +369,14 @@ export function CampaignBuilderModal({
       setBlocks(blocksWithUniqueIds);
     }
 
+    const audienceFilters = existingCampaign?.audienceFilters;
+    if (Array.isArray(audienceFilters?.selectedAddresses)) {
+      setSelectedCustomers(new Set(audienceFilters.selectedAddresses.map((a: string) => a.toLowerCase())));
+    }
+    if (Array.isArray(audienceFilters?.manualEmails)) {
+      setManualEmails(audienceFilters.manualEmails.join('\n'));
+    }
+
     // Set default subject based on campaign type
     if (!existingCampaign?.subject) {
       const subjects: Record<string, string> = {
@@ -441,7 +449,9 @@ export function CampaignBuilderModal({
       if (!initialLoadDone && result.customers.length > 0) {
         const allAddresses = result.customers.map(c => c.walletAddress);
         setAllCustomerAddresses(allAddresses);
-        setSelectedCustomers(new Set(allAddresses));
+        if (!existingCampaign) {
+          setSelectedCustomers(new Set(allAddresses));
+        }
         setInitialLoadDone(true);
       }
     } catch (error) {
@@ -608,10 +618,11 @@ export function CampaignBuilderModal({
         ...(manualEmails.trim() && { manualEmails: manualEmails.trim() }),
       };
 
-      if (campaignType === 'offer_coupon' && selectedPromoCodeId) {
+      const hasCouponBlock = blocks.some(b => b.type === 'coupon');
+      if (hasCouponBlock && selectedPromoCodeId) {
+        campaignData.promoCodeId = selectedPromoCodeId;
         const selectedPC = promoCodes.find(pc => pc.id === selectedPromoCodeId);
         if (selectedPC) {
-          campaignData.promoCodeId = selectedPromoCodeId;
           campaignData.couponValue = selectedPC.bonus_value;
           campaignData.couponType = selectedPC.bonus_type as 'fixed' | 'percentage';
           campaignData.couponExpiresAt = new Date(selectedPC.end_date).toISOString();
@@ -832,6 +843,10 @@ export function CampaignBuilderModal({
   };
 
   const selectedBlock = selectedBlockId ? blocks.find(b => b.id === selectedBlockId) : null;
+
+  const validManualEmailCount = manualEmails.split(/[\n,]+/).filter(e => e.trim() && e.includes('@')).length;
+  const hasRecipients = selectedCustomers.size > 0 || validManualEmailCount > 0;
+  const totalRecipients = selectedCustomers.size + validManualEmailCount;
 
   // Block editing panel
   const renderBlockEditor = () => {
@@ -1261,13 +1276,24 @@ export function CampaignBuilderModal({
                   <Save className="w-4 h-4 sm:mr-2" />
                   <span className="hidden sm:inline">{saving ? 'Saving...' : 'Save Draft'}</span>
                 </Button>
-                <Button
-                  size="sm"
-                  onClick={() => setStep('audience')}
-                  className="bg-yellow-500 hover:bg-yellow-600 text-black"
-                >
-                  Select Audience
-                </Button>
+                {(() => {
+                  const action = {
+                    design: { label: 'Select Audience', onClick: () => setStep('audience') },
+                    audience: { label: 'Continue to Delivery', onClick: () => setStep('delivery'), disabled: !hasRecipients },
+                    delivery: { label: sending ? 'Sending...' : 'Send Now', onClick: () => handleSave(true), disabled: saving || sending, send: true },
+                  }[step];
+                  return (
+                    <Button
+                      size="sm"
+                      onClick={action.onClick}
+                      disabled={action.disabled}
+                      className={`${action.send ? 'bg-green-600 hover:bg-green-700 text-white' : 'bg-yellow-500 hover:bg-yellow-600 text-black'} disabled:opacity-50`}
+                    >
+                      {action.send && <Send className="w-4 h-4 mr-2" />}
+                      {action.label}
+                    </Button>
+                  );
+                })()}
               </div>
             )}
           </div>
@@ -1526,6 +1552,22 @@ export function CampaignBuilderModal({
                 </div>
               )}
 
+              {viewOnly && validManualEmailCount > 0 && (
+                <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4 mb-6">
+                  <h4 className="text-white font-medium text-sm mb-3 flex items-center gap-2">
+                    <Mail className="w-4 h-4 text-[#FFCC00]" />
+                    Invited New Users ({validManualEmailCount})
+                  </h4>
+                  <div className="flex flex-wrap gap-2">
+                    {manualEmails.split(/[\n,]+/).map(e => e.trim()).filter(e => e && e.includes('@')).map((email) => (
+                      <span key={email} className="px-2 py-1 bg-gray-900 border border-gray-700 rounded text-xs text-gray-300 font-mono">
+                        {email}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+
               {/* Existing Customers Section Header */}
               <h4 className="text-white font-medium text-sm mb-3 flex items-center gap-2">
                 <Users className="w-4 h-4 text-[#FFCC00]" />
@@ -1687,12 +1729,14 @@ export function CampaignBuilderModal({
                   <Users className="w-5 h-5 text-gray-400" />
                   <div>
                     <span className="text-gray-400">Recipients: </span>
-                    <span className="text-white font-semibold">{selectedCustomers.size} customers selected</span>
-                    {customerTotal > 0 && (
-                      <span className="text-gray-500 text-sm ml-2">
-                        (of {customerTotal} total)
-                      </span>
-                    )}
+                    <span className="text-white font-semibold">
+                      {totalRecipients} recipient{totalRecipients === 1 ? '' : 's'}
+                    </span>
+                    <span className="text-gray-500 text-sm ml-2">
+                      ({selectedCustomers.size} customer{selectedCustomers.size === 1 ? '' : 's'}
+                      {customerTotal > 0 && ` of ${customerTotal}`}
+                      {validManualEmailCount > 0 && `, ${validManualEmailCount} new email${validManualEmailCount === 1 ? '' : 's'}`})
+                    </span>
                   </div>
                 </div>
               </div>
@@ -1709,7 +1753,7 @@ export function CampaignBuilderModal({
                   </Button>
                   <Button
                     onClick={() => setStep('delivery')}
-                    disabled={selectedCustomers.size === 0}
+                    disabled={!hasRecipients}
                     className="bg-yellow-500 hover:bg-yellow-600 text-black disabled:opacity-50 w-full sm:w-auto"
                   >
                     Continue to Delivery
@@ -1762,7 +1806,10 @@ export function CampaignBuilderModal({
                 </div>
                 <div className="flex justify-between text-sm">
                   <span className="text-gray-400">Audience:</span>
-                  <span className="text-white">{selectedCustomers.size} customers</span>
+                  <span className="text-white">
+                    {totalRecipients} recipient{totalRecipients === 1 ? '' : 's'}
+                    {validManualEmailCount > 0 && ` (${selectedCustomers.size} customers, ${validManualEmailCount} new)`}
+                  </span>
                 </div>
                 <div className="flex justify-between text-sm">
                   <span className="text-gray-400">Delivery:</span>
@@ -1854,7 +1901,7 @@ export function CampaignBuilderModal({
                 <Button
                   size="sm"
                   onClick={() => setStep('delivery')}
-                  disabled={selectedCustomers.size === 0}
+                  disabled={!hasRecipients}
                   className="flex-1 bg-yellow-500 hover:bg-yellow-600 text-black disabled:opacity-50"
                 >
                   Next

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -82,7 +82,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-xl shadow-lg",
+        "relative z-[1300] max-h-96 min-w-[8rem] overflow-hidden rounded-xl shadow-lg",
         variant === "dark"
           ? "border border-gray-700 bg-[#1A1A1A]"
           : "border border-gray-200 bg-white",


### PR DESCRIPTION
## Summary

  Fixes a cluster of bugs in the shop **Campaign Builder** where audience/delivery/promo selections weren't being saved or restored, dropdowns
  inside the modal couldn't be used, and recipient counts ignored manually-entered emails.

  ## Changes

  ### Frontend — `CampaignBuilderModal.tsx` / `ui/select.tsx`
  - **Dropdowns unclickable in the modal:** `SelectContent` was `z-50` while the shared `Dialog` is `z-[1210]`, so the promo/service dropdowns
  rendered *behind* the dialog. Raised `SelectContent` to `z-[1300]`.
  - **Stuck header button:** the desktop top-right CTA was hardcoded to "Select Audience". It's now a single button driven by a step→action map
  (Select Audience → Continue to Delivery → Send Now).
  - **Manual-email gating:** Continue/Next/Send are now enabled when only manual ("new user") emails are entered, not just when existing customers
  are selected.
  - **Audience not restored:** reopening a draft now restores selected customers and manual emails from `audienceFilters`, and `loadCustomers` no
  longer overwrites the restored selection with select-all for existing campaigns.
  - **View details:** invited non-customer emails are now shown (read-only) when viewing a sent campaign.
  - **Recipient counts:** audience and delivery steps now include manual emails in the totals.
  - **Promo code not saved:** persistence is now gated on the coupon block's presence (not the campaign type), and the id is always saved when
  selected rather than being dropped when the promo isn't in the loaded active list.

  ### Backend — `MarketingController.ts`
  - Extracted manual-email parsing/contact-creation into a shared `processManualEmails` helper and applied it in `updateCampaign`, so editing a
  draft no longer drops manual emails (previously only `createCampaign` handled them).