### PR TITLE
feat(reviews): add multi-turn reply thread with collapse/expand

### DIFF
--- a/backend/migrations/136_add_customer_reply_to_reviews.sql
+++ b/backend/migrations/136_add_customer_reply_to_reviews.sql
@@ -1,0 +1,6 @@
+-- Migration 136: Add customer reply to service reviews
+-- Allows the original reviewer to post a single counter-reply after the shop responds
+
+ALTER TABLE service_reviews
+  ADD COLUMN IF NOT EXISTS customer_reply TEXT,
+  ADD COLUMN IF NOT EXISTS customer_reply_at TIMESTAMPTZ;

--- a/backend/migrations/137_add_shop_rejoinder_to_reviews.sql
+++ b/backend/migrations/137_add_shop_rejoinder_to_reviews.sql
@@ -1,0 +1,6 @@
+-- Migration 137: Add shop rejoinder to service reviews
+-- Allows the shop to reply back after a customer has counter-replied
+
+ALTER TABLE service_reviews
+  ADD COLUMN IF NOT EXISTS shop_rejoinder TEXT,
+  ADD COLUMN IF NOT EXISTS shop_rejoinder_at TIMESTAMPTZ;

--- a/backend/migrations/138_add_review_replies_table.sql
+++ b/backend/migrations/138_add_review_replies_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS review_replies (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  review_id UUID NOT NULL,
+  author_address TEXT NOT NULL,
+  author_type TEXT NOT NULL CHECK (author_type IN ('customer', 'shop')),
+  content TEXT NOT NULL CHECK (char_length(content) <= 1000),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_review_replies_review_id ON review_replies(review_id);

--- a/backend/src/domains/ServiceDomain/controllers/ReviewController.ts
+++ b/backend/src/domains/ServiceDomain/controllers/ReviewController.ts
@@ -347,6 +347,192 @@ export class ReviewController {
   }
 
   /**
+   * Edit shop response
+   * PUT /api/services/reviews/:reviewId/respond
+   */
+  async updateShopResponse(req: Request, res: Response): Promise<void> {
+    try {
+      const { reviewId } = req.params;
+      const { response } = req.body;
+      const shopId = req.user?.shopId;
+
+      if (!shopId) { res.status(401).json({ error: 'Unauthorized' }); return; }
+      if (!response?.trim()) { res.status(400).json({ error: 'Response text is required' }); return; }
+      if (response.length > 2000) { res.status(400).json({ error: 'Response cannot exceed 2,000 characters' }); return; }
+
+      const existing = await reviewRepository.getReviewById(reviewId);
+      if (!existing) { res.status(404).json({ error: 'Review not found' }); return; }
+      if (existing.shopId !== shopId) { res.status(403).json({ error: 'You can only edit responses on your own reviews' }); return; }
+      if (!existing.shopResponse) { res.status(400).json({ error: 'No response to edit' }); return; }
+
+      const updated = await reviewRepository.updateShopResponse(reviewId, response.trim());
+      res.json({ success: true, data: updated });
+    } catch (error) {
+      logger.error('Error updating shop response:', error);
+      res.status(500).json({ error: 'Failed to update response' });
+    }
+  }
+
+  /**
+   * Shop reply to customer's counter-reply
+   * POST /api/services/reviews/:reviewId/rejoinder
+   */
+  async addShopRejoinder(req: Request, res: Response): Promise<void> {
+    try {
+      const { reviewId } = req.params;
+      const { rejoinder } = req.body;
+      const shopId = req.user?.shopId;
+
+      if (!shopId) { res.status(401).json({ error: 'Unauthorized' }); return; }
+      if (!rejoinder?.trim()) { res.status(400).json({ error: 'Rejoinder text is required' }); return; }
+      if (rejoinder.length > 1000) { res.status(400).json({ error: 'Rejoinder cannot exceed 1,000 characters' }); return; }
+
+      const existing = await reviewRepository.getReviewById(reviewId);
+      if (!existing) { res.status(404).json({ error: 'Review not found' }); return; }
+      if (existing.shopId !== shopId) { res.status(403).json({ error: 'You can only reply to reviews for your shop' }); return; }
+      if (!existing.customerReply) { res.status(400).json({ error: 'Customer has not replied yet' }); return; }
+      if (existing.shopRejoinder) { res.status(400).json({ error: 'You have already replied to this customer reply' }); return; }
+
+      const updated = await reviewRepository.addShopRejoinder(reviewId, rejoinder.trim());
+      res.json({ success: true, data: updated });
+    } catch (error) {
+      logger.error('Error adding shop rejoinder:', error);
+      res.status(500).json({ error: 'Failed to add reply' });
+    }
+  }
+
+  /**
+   * Edit shop rejoinder
+   * PUT /api/services/reviews/:reviewId/rejoinder
+   */
+  async updateShopRejoinder(req: Request, res: Response): Promise<void> {
+    try {
+      const { reviewId } = req.params;
+      const { rejoinder } = req.body;
+      const shopId = req.user?.shopId;
+
+      if (!shopId) { res.status(401).json({ error: 'Unauthorized' }); return; }
+      if (!rejoinder?.trim()) { res.status(400).json({ error: 'Rejoinder text is required' }); return; }
+      if (rejoinder.length > 1000) { res.status(400).json({ error: 'Rejoinder cannot exceed 1,000 characters' }); return; }
+
+      const existing = await reviewRepository.getReviewById(reviewId);
+      if (!existing) { res.status(404).json({ error: 'Review not found' }); return; }
+      if (existing.shopId !== shopId) { res.status(403).json({ error: 'You can only edit replies on your own reviews' }); return; }
+      if (!existing.shopRejoinder) { res.status(400).json({ error: 'No reply to edit' }); return; }
+
+      const updated = await reviewRepository.updateShopRejoinder(reviewId, rejoinder.trim());
+      res.json({ success: true, data: updated });
+    } catch (error) {
+      logger.error('Error updating shop rejoinder:', error);
+      res.status(500).json({ error: 'Failed to update reply' });
+    }
+  }
+
+  /**
+   * Add customer counter-reply to a shop response
+   * POST /api/services/reviews/:reviewId/reply
+   */
+  async addCustomerReply(req: Request, res: Response): Promise<void> {
+    try {
+      const { reviewId } = req.params;
+      const { reply } = req.body;
+      const customerAddress = req.user?.address;
+
+      if (!customerAddress) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      if (!reply || !reply.trim()) {
+        res.status(400).json({ error: 'Reply text is required' });
+        return;
+      }
+
+      if (reply.length > 1000) {
+        res.status(400).json({ error: 'Reply cannot exceed 1,000 characters' });
+        return;
+      }
+
+      const existingReview = await reviewRepository.getReviewById(reviewId);
+      if (!existingReview) {
+        res.status(404).json({ error: 'Review not found' });
+        return;
+      }
+
+      if (existingReview.customerAddress.toLowerCase() !== customerAddress.toLowerCase()) {
+        res.status(403).json({ error: 'You can only reply to your own reviews' });
+        return;
+      }
+
+      if (!existingReview.shopResponse) {
+        res.status(400).json({ error: 'You can only reply after the shop has responded' });
+        return;
+      }
+
+      if (existingReview.customerReply) {
+        res.status(400).json({ error: 'You have already replied to this review' });
+        return;
+      }
+
+      const updatedReview = await reviewRepository.addCustomerReply(reviewId, reply.trim());
+
+      res.json({ success: true, data: updatedReview });
+    } catch (error) {
+      logger.error('Error adding customer reply:', error);
+      res.status(500).json({ error: 'Failed to add reply' });
+    }
+  }
+
+  /**
+   * Edit customer reply
+   * PUT /api/services/reviews/:reviewId/reply
+   */
+  async updateCustomerReply(req: Request, res: Response): Promise<void> {
+    try {
+      const { reviewId } = req.params;
+      const { reply } = req.body;
+      const customerAddress = req.user?.address;
+
+      if (!customerAddress) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      if (!reply || !reply.trim()) {
+        res.status(400).json({ error: 'Reply text is required' });
+        return;
+      }
+
+      if (reply.length > 1000) {
+        res.status(400).json({ error: 'Reply cannot exceed 1,000 characters' });
+        return;
+      }
+
+      const existingReview = await reviewRepository.getReviewById(reviewId);
+      if (!existingReview) {
+        res.status(404).json({ error: 'Review not found' });
+        return;
+      }
+
+      if (existingReview.customerAddress.toLowerCase() !== customerAddress.toLowerCase()) {
+        res.status(403).json({ error: 'You can only edit your own reply' });
+        return;
+      }
+
+      if (!existingReview.customerReply) {
+        res.status(400).json({ error: 'No reply to edit' });
+        return;
+      }
+
+      const updatedReview = await reviewRepository.updateCustomerReply(reviewId, reply.trim());
+      res.json({ success: true, data: updatedReview });
+    } catch (error) {
+      logger.error('Error updating customer reply:', error);
+      res.status(500).json({ error: 'Failed to update reply' });
+    }
+  }
+
+  /**
    * Toggle helpful vote for a review (unique per account)
    * POST /api/services/reviews/:reviewId/helpful
    */
@@ -520,6 +706,105 @@ export class ReviewController {
       res.status(500).json({
         error: 'Failed to check review eligibility'
       });
+    }
+  }
+
+  /**
+   * Add a reply to a review thread (customer or shop, unlimited turns)
+   * POST /api/services/reviews/:reviewId/thread
+   */
+  async addThreadReply(req: Request, res: Response): Promise<void> {
+    try {
+      const { reviewId } = req.params;
+      const { content } = req.body;
+      const userAddress = req.user?.address;
+      const userRole = req.user?.role;
+
+      if (!userAddress) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      if (!content || !content.trim()) {
+        res.status(400).json({ error: 'Reply content is required' });
+        return;
+      }
+
+      if (content.length > 1000) {
+        res.status(400).json({ error: 'Reply cannot exceed 1,000 characters' });
+        return;
+      }
+
+      const review = await reviewRepository.getReviewById(reviewId);
+      if (!review) {
+        res.status(404).json({ error: 'Review not found' });
+        return;
+      }
+
+      if (!review.shopResponse) {
+        res.status(400).json({ error: 'Thread cannot start until the shop has responded' });
+        return;
+      }
+
+      // Determine author type
+      const isCustomer = review.customerAddress.toLowerCase() === userAddress.toLowerCase();
+      const isShop = userRole === 'shop';
+
+      if (!isCustomer && !isShop) {
+        res.status(403).json({ error: 'Only the reviewer or the shop can reply' });
+        return;
+      }
+
+      const authorType = isCustomer ? 'customer' : 'shop';
+
+      // Enforce alternating turns — last reply must not be from the same party
+      const existingReplies = await reviewRepository.getRepliesForReview(reviewId);
+      if (existingReplies.length > 0) {
+        const lastReply = existingReplies[existingReplies.length - 1];
+        if (lastReply.authorType === authorType) {
+          res.status(400).json({ error: 'Wait for the other party to reply before posting again' });
+          return;
+        }
+      }
+
+      const reply = await reviewRepository.addReply(reviewId, userAddress, authorType, content.trim());
+      res.json({ success: true, data: reply });
+    } catch (error) {
+      logger.error('Error adding thread reply:', error);
+      res.status(500).json({ error: 'Failed to add reply' });
+    }
+  }
+
+  /**
+   * Edit a thread reply (author only)
+   * PUT /api/services/reviews/thread/:replyId
+   */
+  async editThreadReply(req: Request, res: Response): Promise<void> {
+    try {
+      const { replyId } = req.params;
+      const { content } = req.body;
+      const userAddress = req.user?.address;
+
+      if (!userAddress) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      if (!content || !content.trim()) {
+        res.status(400).json({ error: 'Reply content is required' });
+        return;
+      }
+
+      if (content.length > 1000) {
+        res.status(400).json({ error: 'Reply cannot exceed 1,000 characters' });
+        return;
+      }
+
+      const reply = await reviewRepository.editReply(replyId, userAddress, content.trim());
+      res.json({ success: true, data: reply });
+    } catch (error) {
+      logger.error('Error editing thread reply:', error);
+      res.status(500).json({ error: 'Failed to edit reply' });
     }
   }
 }

--- a/backend/src/domains/ServiceDomain/controllers/ReviewController.ts
+++ b/backend/src/domains/ServiceDomain/controllers/ReviewController.ts
@@ -5,6 +5,7 @@ import { OrderRepository } from '../../../repositories/OrderRepository';
 import { ServiceRepository } from '../../../repositories/ServiceRepository';
 import { customerRepository, shopRepository } from '../../../repositories';
 import { EmailService } from '../../../services/EmailService';
+import { eventBus, createDomainEvent } from '../../../events/EventBus';
 import { logger } from '../../../utils/logger';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -78,29 +79,48 @@ export class ReviewController {
         images: images || []
       });
 
-      // Send review email to shop (preference-gated on 'customerReview')
+      // Send review email + in-app/push notification to shop
       try {
-        const shop = await shopRepository.getShop(order.shopId);
+        const [shop, service, customer] = await Promise.all([
+          shopRepository.getShop(order.shopId),
+          serviceRepository.getServiceById(order.serviceId),
+          customerRepository.getCustomer(customerAddress),
+        ]);
+        const customerDisplayName =
+          customer?.name ||
+          [(customer as any)?.first_name, (customer as any)?.last_name].filter(Boolean).join(' ').trim() ||
+          'A customer';
+        const serviceName = service?.serviceName || 'Service';
+
         if (shop?.email) {
-          const service = await serviceRepository.getServiceById(order.serviceId);
-          const customer = await customerRepository.getCustomer(customerAddress);
-          // Prefer customer.name; fall back to first_name + last_name; finally "A customer"
-          const customerDisplayName =
-            customer?.name ||
-            [(customer as any)?.first_name, (customer as any)?.last_name].filter(Boolean).join(' ').trim() ||
-            'A customer';
           await emailService.sendCustomerReviewNotification(shop.email, shop.shopId, {
             shopName: shop.name,
             customerName: customerDisplayName,
-            serviceName: service?.serviceName || 'Service',
+            serviceName,
             rating,
             comment: (comment || '').slice(0, 500),
           });
           logger.info('Customer review email sent to shop', { shopId: order.shopId, reviewId });
         }
-      } catch (emailError) {
-        logger.error('Failed to send review email to shop:', emailError);
-        // Don't fail the review creation if email fails
+
+        if (shop?.walletAddress) {
+          await eventBus.publish(createDomainEvent(
+            'review:created',
+            reviewId,
+            {
+              shopAddress: shop.walletAddress,
+              customerAddress,
+              customerName: customerDisplayName,
+              serviceId: order.serviceId,
+              serviceName,
+              rating,
+              reviewId,
+            },
+            'ServiceDomain'
+          ));
+        }
+      } catch (notifError) {
+        logger.error('Failed to send review notifications to shop:', notifError);
       }
 
       res.status(201).json({
@@ -333,6 +353,31 @@ export class ReviewController {
 
       // Add response
       const updatedReview = await reviewRepository.addShopResponse(reviewId, response);
+
+      // In-app/push notification to customer
+      try {
+        const [shop, service] = await Promise.all([
+          shopRepository.getShop(shopId),
+          serviceRepository.getServiceById(existingReview.serviceId),
+        ]);
+        if (shop) {
+          await eventBus.publish(createDomainEvent(
+            'review:shop_responded',
+            reviewId,
+            {
+              customerAddress: existingReview.customerAddress,
+              shopAddress: shop.walletAddress,
+              shopName: shop.name,
+              serviceId: existingReview.serviceId,
+              serviceName: service?.serviceName || 'your service',
+              reviewId,
+            },
+            'ServiceDomain'
+          ));
+        }
+      } catch (notifError) {
+        logger.error('Failed to send shop response notification:', notifError);
+      }
 
       res.json({
         success: true,
@@ -757,17 +802,51 @@ export class ReviewController {
 
       const authorType = isCustomer ? 'customer' : 'shop';
 
-      // Enforce alternating turns — last reply must not be from the same party
-      const existingReplies = await reviewRepository.getRepliesForReview(reviewId);
-      if (existingReplies.length > 0) {
-        const lastReply = existingReplies[existingReplies.length - 1];
-        if (lastReply.authorType === authorType) {
-          res.status(400).json({ error: 'Wait for the other party to reply before posting again' });
-          return;
+      const reply = await reviewRepository.addReply(reviewId, userAddress, authorType, content.trim());
+
+      // In-app/push notification to the other party
+      try {
+        const shop = await shopRepository.getShop(review.shopId);
+        if (isCustomer) {
+          // Customer commented → notify shop
+          if (shop?.walletAddress) {
+            const customer = await customerRepository.getCustomer(userAddress);
+            const senderName = customer?.name || 'A customer';
+            await eventBus.publish(createDomainEvent(
+              'review:comment_added',
+              reviewId,
+              {
+                recipientAddress: shop.walletAddress,
+                senderAddress: userAddress,
+                senderName,
+                authorType: 'customer',
+                serviceId: review.serviceId,
+                reviewId,
+              },
+              'ServiceDomain'
+            ));
+          }
+        } else {
+          // Shop commented → notify customer
+          const senderName = shop?.name || 'The shop';
+          await eventBus.publish(createDomainEvent(
+            'review:comment_added',
+            reviewId,
+            {
+              recipientAddress: review.customerAddress,
+              senderAddress: userAddress,
+              senderName,
+              authorType: 'shop',
+              serviceId: review.serviceId,
+              reviewId,
+            },
+            'ServiceDomain'
+          ));
         }
+      } catch (notifError) {
+        logger.error('Failed to send review comment notification:', notifError);
       }
 
-      const reply = await reviewRepository.addReply(reviewId, userAddress, authorType, content.trim());
       res.json({ success: true, data: reply });
     } catch (error) {
       logger.error('Error adding thread reply:', error);

--- a/backend/src/domains/ServiceDomain/routes.ts
+++ b/backend/src/domains/ServiceDomain/routes.ts
@@ -1473,6 +1473,56 @@ export function initializeRoutes(stripe: StripeService): Router {
     reviewController.addShopResponse
   );
 
+  router.put(
+    '/reviews/:reviewId/respond',
+    authMiddleware,
+    requireRole(['shop']),
+    reviewController.updateShopResponse.bind(reviewController)
+  );
+
+  router.post(
+    '/reviews/:reviewId/rejoinder',
+    authMiddleware,
+    requireRole(['shop']),
+    reviewController.addShopRejoinder.bind(reviewController)
+  );
+
+  router.put(
+    '/reviews/:reviewId/rejoinder',
+    authMiddleware,
+    requireRole(['shop']),
+    reviewController.updateShopRejoinder.bind(reviewController)
+  );
+
+  router.post(
+    '/reviews/:reviewId/reply',
+    authMiddleware,
+    requireRole(['customer']),
+    reviewController.addCustomerReply.bind(reviewController)
+  );
+
+  router.put(
+    '/reviews/:reviewId/reply',
+    authMiddleware,
+    requireRole(['customer']),
+    reviewController.updateCustomerReply.bind(reviewController)
+  );
+
+  // Review thread — unlimited alternating replies (customer or shop)
+  router.post(
+    '/reviews/:reviewId/thread',
+    authMiddleware,
+    requireRole(['customer', 'shop']),
+    reviewController.addThreadReply.bind(reviewController)
+  );
+
+  router.put(
+    '/reviews/thread/:replyId',
+    authMiddleware,
+    requireRole(['customer', 'shop']),
+    reviewController.editThreadReply.bind(reviewController)
+  );
+
   /**
    * @swagger
    * /api/services/reviews/{reviewId}/helpful:

--- a/backend/src/domains/notification/NotificationDomain.ts
+++ b/backend/src/domains/notification/NotificationDomain.ts
@@ -77,6 +77,11 @@ export class NotificationDomain implements DomainModule {
     // Listen to manual booking payment completion events
     eventBus.subscribe('manual_booking:payment_completed', this.handleManualBookingPaymentCompleted.bind(this), 'NotificationDomain');
 
+    // Listen to review/comment events
+    eventBus.subscribe('review:created', this.handleReviewCreated.bind(this), 'NotificationDomain');
+    eventBus.subscribe('review:shop_responded', this.handleReviewShopResponded.bind(this), 'NotificationDomain');
+    eventBus.subscribe('review:comment_added', this.handleReviewCommentAdded.bind(this), 'NotificationDomain');
+
     logger.info('Notification domain event subscriptions set up');
   }
 
@@ -103,6 +108,66 @@ export class NotificationDomain implements DomainModule {
       await this.pushDispatcher.sendRewardNotification(customerAddress, shopName, amount, transactionId);
     } catch (error: any) {
       logger.error('Error handling reward issued event:', error);
+    }
+  }
+
+  private async handleReviewCreated(event: any): Promise<void> {
+    try {
+      const { shopAddress, customerAddress, customerName, serviceId, serviceName, rating, reviewId } = event.data;
+
+      logger.info(`Creating review received notification for shop ${shopAddress} (review ${reviewId})`);
+
+      const notification = await this.notificationService.createReviewReceivedNotification(
+        customerAddress, shopAddress, customerName, serviceId, serviceName, rating, reviewId
+      );
+
+      if (this.wsManager) {
+        this.wsManager.sendNotificationToUser(shopAddress, notification);
+      }
+
+      await this.pushDispatcher.sendReviewReceivedToShop(shopAddress, customerName, serviceName, rating, reviewId);
+    } catch (error: any) {
+      logger.error('Error handling review created event:', error);
+    }
+  }
+
+  private async handleReviewShopResponded(event: any): Promise<void> {
+    try {
+      const { customerAddress, shopAddress, shopName, serviceId, serviceName, reviewId } = event.data;
+
+      logger.info(`Creating shop review response notification for customer ${customerAddress} (review ${reviewId})`);
+
+      const notification = await this.notificationService.createShopReviewResponseNotification(
+        shopAddress || customerAddress, customerAddress, shopName, serviceId, serviceName, reviewId
+      );
+
+      if (this.wsManager) {
+        this.wsManager.sendNotificationToUser(customerAddress, notification);
+      }
+
+      await this.pushDispatcher.sendShopRespondedToCustomer(customerAddress, shopName, serviceName, reviewId);
+    } catch (error: any) {
+      logger.error('Error handling shop review response event:', error);
+    }
+  }
+
+  private async handleReviewCommentAdded(event: any): Promise<void> {
+    try {
+      const { recipientAddress, senderAddress, senderName, authorType, serviceId, reviewId } = event.data;
+
+      logger.info(`Creating review comment notification for ${recipientAddress} (review ${reviewId}, from ${authorType})`);
+
+      const notification = await this.notificationService.createReviewCommentNotification(
+        senderAddress, recipientAddress, senderName, authorType, serviceId, reviewId
+      );
+
+      if (this.wsManager) {
+        this.wsManager.sendNotificationToUser(recipientAddress, notification);
+      }
+
+      await this.pushDispatcher.sendReviewCommentNotification(recipientAddress, senderName, authorType, reviewId);
+    } catch (error: any) {
+      logger.error('Error handling review comment event:', error);
     }
   }
 

--- a/backend/src/domains/notification/services/NotificationService.ts
+++ b/backend/src/domains/notification/services/NotificationService.ts
@@ -698,6 +698,61 @@ export class NotificationService {
     });
   }
 
+  async createReviewReceivedNotification(
+    customerAddress: string,
+    shopAddress: string,
+    customerName: string,
+    serviceId: string,
+    serviceName: string,
+    rating: number,
+    reviewId: string
+  ): Promise<Notification> {
+    return this.createNotification({
+      senderAddress: customerAddress,
+      receiverAddress: shopAddress,
+      notificationType: 'customer_review_received',
+      message: `${customerName} left a ${rating}-star review on ${serviceName}`,
+      metadata: { customerName, serviceId, serviceName, rating, reviewId, timestamp: new Date().toISOString() }
+    });
+  }
+
+  async createShopReviewResponseNotification(
+    shopAddress: string,
+    customerAddress: string,
+    shopName: string,
+    serviceId: string,
+    serviceName: string,
+    reviewId: string
+  ): Promise<Notification> {
+    return this.createNotification({
+      senderAddress: shopAddress,
+      receiverAddress: customerAddress,
+      notificationType: 'shop_review_response',
+      message: `${shopName} responded to your review on ${serviceName}`,
+      metadata: { shopName, serviceId, serviceName, reviewId, timestamp: new Date().toISOString() }
+    });
+  }
+
+  async createReviewCommentNotification(
+    senderAddress: string,
+    recipientAddress: string,
+    senderName: string,
+    authorType: 'customer' | 'shop',
+    serviceId: string,
+    reviewId: string
+  ): Promise<Notification> {
+    const message = authorType === 'customer'
+      ? `${senderName} added a comment on a review`
+      : `${senderName} added a comment on your review`;
+    return this.createNotification({
+      senderAddress,
+      receiverAddress: recipientAddress,
+      notificationType: 'review_comment',
+      message,
+      metadata: { senderName, authorType, serviceId, reviewId, timestamp: new Date().toISOString() }
+    });
+  }
+
   async createServicePaymentFailedNotification(
     customerAddress: string,
     serviceName: string,

--- a/backend/src/repositories/ReviewRepository.ts
+++ b/backend/src/repositories/ReviewRepository.ts
@@ -14,8 +14,22 @@ export interface ServiceReview {
   helpfulCount: number;
   shopResponse?: string;
   shopResponseAt?: Date;
+  customerReply?: string;
+  customerReplyAt?: Date;
+  shopRejoinder?: string;
+  shopRejoinderAt?: Date;
   createdAt: Date;
   updatedAt: Date;
+}
+
+export interface ReviewReply {
+  id: string;
+  reviewId: string;
+  authorAddress: string;
+  authorType: 'customer' | 'shop';
+  content: string;
+  createdAt: Date;
+  updatedAt?: Date;
 }
 
 export interface ServiceReviewWithDetails extends ServiceReview {
@@ -23,6 +37,7 @@ export interface ServiceReviewWithDetails extends ServiceReview {
   customerProfileImageUrl?: string;
   serviceName?: string;
   shopName?: string;
+  replies?: ReviewReply[];
 }
 
 export interface CreateReviewParams {
@@ -172,6 +187,21 @@ export class ReviewRepository extends BaseRepository {
       const result = await this.pool.query(query, params);
       const items = result.rows.map(row => this.mapReviewWithDetailsRow(row));
 
+      // Attach replies
+      if (items.length > 0) {
+        const reviewIds = items.map(r => r.reviewId);
+        const repliesResult = await this.pool.query(
+          `SELECT * FROM review_replies WHERE review_id = ANY($1) ORDER BY created_at ASC`,
+          [reviewIds]
+        );
+        const repliesByReview = repliesResult.rows.reduce((acc, row) => {
+          if (!acc[row.review_id]) acc[row.review_id] = [];
+          acc[row.review_id].push(this.mapReplyRow(row));
+          return acc;
+        }, {} as Record<string, ReviewReply[]>);
+        items.forEach(r => { r.replies = repliesByReview[r.reviewId] || []; });
+      }
+
       return {
         items,
         pagination: {
@@ -301,6 +331,21 @@ export class ReviewRepository extends BaseRepository {
       const result = await this.pool.query(query, params);
       const items = result.rows.map(row => this.mapReviewWithDetailsRow(row));
 
+      // Attach replies
+      if (items.length > 0) {
+        const reviewIds = items.map(r => r.reviewId);
+        const repliesResult = await this.pool.query(
+          `SELECT * FROM review_replies WHERE review_id = ANY($1) ORDER BY created_at ASC`,
+          [reviewIds]
+        );
+        const repliesByReview = repliesResult.rows.reduce((acc, row) => {
+          if (!acc[row.review_id]) acc[row.review_id] = [];
+          acc[row.review_id].push(this.mapReplyRow(row));
+          return acc;
+        }, {} as Record<string, ReviewReply[]>);
+        items.forEach(r => { r.replies = repliesByReview[r.reviewId] || []; });
+      }
+
       return {
         items,
         pagination: {
@@ -396,6 +441,107 @@ export class ReviewRepository extends BaseRepository {
       return this.mapReviewRow(result.rows[0]);
     } catch (error) {
       logger.error('Error adding shop response:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Edit shop response
+   */
+  async updateShopResponse(reviewId: string, response: string): Promise<ServiceReview> {
+    try {
+      const result = await this.pool.query(
+        `UPDATE service_reviews SET shop_response = $1, updated_at = NOW() WHERE review_id = $2 RETURNING *`,
+        [response, reviewId]
+      );
+      if (result.rows.length === 0) throw new Error('Review not found');
+      logger.info('Shop response updated', { reviewId });
+      return this.mapReviewRow(result.rows[0]);
+    } catch (error) {
+      logger.error('Error updating shop response:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Add shop rejoinder (reply to customer's counter-reply)
+   */
+  async addShopRejoinder(reviewId: string, rejoinder: string): Promise<ServiceReview> {
+    try {
+      const result = await this.pool.query(
+        `UPDATE service_reviews SET shop_rejoinder = $1, shop_rejoinder_at = NOW(), updated_at = NOW() WHERE review_id = $2 RETURNING *`,
+        [rejoinder, reviewId]
+      );
+      if (result.rows.length === 0) throw new Error('Review not found');
+      logger.info('Shop rejoinder added', { reviewId });
+      return this.mapReviewRow(result.rows[0]);
+    } catch (error) {
+      logger.error('Error adding shop rejoinder:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Edit shop rejoinder
+   */
+  async updateShopRejoinder(reviewId: string, rejoinder: string): Promise<ServiceReview> {
+    try {
+      const result = await this.pool.query(
+        `UPDATE service_reviews SET shop_rejoinder = $1, updated_at = NOW() WHERE review_id = $2 RETURNING *`,
+        [rejoinder, reviewId]
+      );
+      if (result.rows.length === 0) throw new Error('Review not found');
+      logger.info('Shop rejoinder updated', { reviewId });
+      return this.mapReviewRow(result.rows[0]);
+    } catch (error) {
+      logger.error('Error updating shop rejoinder:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Edit an existing customer reply
+   */
+  async updateCustomerReply(reviewId: string, reply: string): Promise<ServiceReview> {
+    try {
+      const query = `
+        UPDATE service_reviews
+        SET customer_reply = $1, updated_at = NOW()
+        WHERE review_id = $2
+        RETURNING *
+      `;
+      const result = await this.pool.query(query, [reply, reviewId]);
+      if (result.rows.length === 0) throw new Error('Review not found');
+      logger.info('Customer reply updated', { reviewId });
+      return this.mapReviewRow(result.rows[0]);
+    } catch (error) {
+      logger.error('Error updating customer reply:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Add customer counter-reply to a shop response (one reply per review)
+   */
+  async addCustomerReply(reviewId: string, reply: string): Promise<ServiceReview> {
+    try {
+      const query = `
+        UPDATE service_reviews
+        SET customer_reply = $1, customer_reply_at = NOW(), updated_at = NOW()
+        WHERE review_id = $2
+        RETURNING *
+      `;
+
+      const result = await this.pool.query(query, [reply, reviewId]);
+
+      if (result.rows.length === 0) {
+        throw new Error('Review not found');
+      }
+
+      logger.info('Customer reply added', { reviewId });
+      return this.mapReviewRow(result.rows[0]);
+    } catch (error) {
+      logger.error('Error adding customer reply:', error);
       throw error;
     }
   }
@@ -514,6 +660,59 @@ export class ReviewRepository extends BaseRepository {
   }
 
   /**
+   * Add a reply to a review thread (customer or shop, unlimited turns)
+   */
+  async addReply(reviewId: string, authorAddress: string, authorType: 'customer' | 'shop', content: string): Promise<ReviewReply> {
+    try {
+      const result = await this.pool.query(
+        `INSERT INTO review_replies (review_id, author_address, author_type, content)
+         VALUES ($1, $2, $3, $4) RETURNING *`,
+        [reviewId, authorAddress.toLowerCase(), authorType, content]
+      );
+      logger.info('Review reply added', { reviewId, authorType });
+      return this.mapReplyRow(result.rows[0]);
+    } catch (error) {
+      logger.error('Error adding review reply:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Edit an existing reply (author only)
+   */
+  async editReply(replyId: string, authorAddress: string, content: string): Promise<ReviewReply> {
+    try {
+      const result = await this.pool.query(
+        `UPDATE review_replies SET content = $1, updated_at = NOW()
+         WHERE id = $2 AND author_address = $3 RETURNING *`,
+        [content, replyId, authorAddress.toLowerCase()]
+      );
+      if (result.rows.length === 0) throw new Error('Reply not found or not authorized');
+      logger.info('Review reply edited', { replyId });
+      return this.mapReplyRow(result.rows[0]);
+    } catch (error) {
+      logger.error('Error editing review reply:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get all replies for a review
+   */
+  async getRepliesForReview(reviewId: string): Promise<ReviewReply[]> {
+    try {
+      const result = await this.pool.query(
+        `SELECT * FROM review_replies WHERE review_id = $1 ORDER BY created_at ASC`,
+        [reviewId]
+      );
+      return result.rows.map(row => this.mapReplyRow(row));
+    } catch (error) {
+      logger.error('Error fetching review replies:', error);
+      throw error;
+    }
+  }
+
+  /**
    * Map database row to ServiceReview
    */
   private mapReviewRow(row: any): ServiceReview {
@@ -529,6 +728,22 @@ export class ReviewRepository extends BaseRepository {
       helpfulCount: row.helpful_count || 0,
       shopResponse: row.shop_response,
       shopResponseAt: row.shop_response_at,
+      customerReply: row.customer_reply,
+      customerReplyAt: row.customer_reply_at,
+      shopRejoinder: row.shop_rejoinder,
+      shopRejoinderAt: row.shop_rejoinder_at,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at
+    };
+  }
+
+  private mapReplyRow(row: any): ReviewReply {
+    return {
+      id: row.id,
+      reviewId: row.review_id,
+      authorAddress: row.author_address,
+      authorType: row.author_type,
+      content: row.content,
       createdAt: row.created_at,
       updatedAt: row.updated_at
     };

--- a/backend/src/services/PushNotificationDispatcher.ts
+++ b/backend/src/services/PushNotificationDispatcher.ts
@@ -239,6 +239,54 @@ export class PushNotificationDispatcher {
       data: { type: 'subscription_expiring', shopName, daysRemaining, expirationDate },
     });
   }
+
+  async sendReviewReceivedToShop(
+    shopWalletAddress: string,
+    customerName: string,
+    serviceName: string,
+    rating: number,
+    reviewId: string
+  ): Promise<SendPushResult> {
+    const stars = '★'.repeat(rating) + '☆'.repeat(5 - rating);
+    return this.sendToUser(shopWalletAddress, {
+      title: 'New Review',
+      body: `${customerName} reviewed ${serviceName} ${stars}`,
+      channelId: NotificationChannels.APPOINTMENTS,
+      data: { type: 'customer_review_received', reviewId, customerName, serviceName, rating },
+    });
+  }
+
+  async sendShopRespondedToCustomer(
+    customerAddress: string,
+    shopName: string,
+    serviceName: string,
+    reviewId: string
+  ): Promise<SendPushResult> {
+    return this.sendToUser(customerAddress, {
+      title: 'Shop Responded',
+      body: `${shopName} responded to your review on ${serviceName}`,
+      channelId: NotificationChannels.APPOINTMENTS,
+      data: { type: 'shop_review_response', reviewId, shopName, serviceName },
+    });
+  }
+
+  async sendReviewCommentNotification(
+    recipientAddress: string,
+    senderName: string,
+    authorType: 'customer' | 'shop',
+    reviewId: string
+  ): Promise<SendPushResult> {
+    const title = authorType === 'customer' ? 'New Comment on Review' : 'Shop Commented';
+    const body = authorType === 'customer'
+      ? `${senderName} added a comment on the review`
+      : `${senderName} added a comment on your review`;
+    return this.sendToUser(recipientAddress, {
+      title,
+      body,
+      channelId: NotificationChannels.APPOINTMENTS,
+      data: { type: 'review_comment', reviewId, senderName, authorType },
+    });
+  }
 }
 
 // Singleton instance

--- a/docs/tasks/feature-customer-reply-to-shop-review-response.md
+++ b/docs/tasks/feature-customer-reply-to-shop-review-response.md
@@ -1,0 +1,175 @@
+# Feature — Customer Reply to Shop Review Response
+
+## Overview
+
+Customers can write a review on a completed service order, and shops can respond to that review. However, the conversation ends there — customers have no way to reply back to the shop's response. This ticket covers adding a single customer counter-reply to the existing shop response.
+
+**Created**: June 5, 2026
+**Status**: Open
+**Priority**: Medium
+**Category**: Feature / Mobile + Backend
+
+---
+
+## Current Behavior
+
+| Actor | Action | Supported |
+|---|---|---|
+| Customer | Write a review | ✅ |
+| Shop | Reply to review | ✅ |
+| Customer | Reply back to shop response | ❌ |
+
+The review thread is currently one-way. Once a shop responds, customers can read the reply but cannot engage further.
+
+---
+
+## Desired Behavior
+
+After a shop has responded to a review, the customer who wrote the review can post a single counter-reply visible beneath the shop's response.
+
+```
+Customer Review: "Great service, very fast!"
+  └── Shop Response: "Thank you! Hope to see you again."
+        └── Customer Reply: "Will definitely be back!"   ← NEW
+```
+
+---
+
+## Affected Files
+
+| File | Change |
+|---|---|
+| `backend/migrations/???_add_customer_reply_to_reviews.sql` | Add `customer_reply` + `customer_reply_at` columns |
+| `backend/src/repositories/ReviewRepository.ts` | Add `addCustomerReply()` method |
+| `backend/src/domains/ServiceDomain/controllers/ReviewController.ts` | Add `addCustomerReply` handler |
+| `backend/src/domains/ServiceDomain/routes.ts` | Register `POST /reviews/:reviewId/reply` |
+| `mobile/feature/services/services/service.interface.ts` | Add `customerReply` + `customerReplyAt` fields to `ReviewData` |
+| `mobile/feature/services/services/service.services.ts` | Add `addCustomerReply()` API call |
+| `mobile/feature/services/services-main/feature-tab/components/ReviewCard.tsx` | Display reply + input field |
+| `mobile/feature/services/services-main/feature-tab/components/UnifiedReviewsSection.tsx` | Display reply in service detail view |
+
+---
+
+## Implementation Plan
+
+### 1. Database Migration
+
+```sql
+ALTER TABLE service_reviews
+  ADD COLUMN customer_reply TEXT,
+  ADD COLUMN customer_reply_at TIMESTAMPTZ;
+```
+
+### 2. Backend — Repository
+
+Add to `ReviewRepository.ts`:
+
+```typescript
+async addCustomerReply(reviewId: string, reply: string): Promise<ReviewData> {
+  const result = await this.pool.query(
+    `UPDATE service_reviews
+     SET customer_reply = $1, customer_reply_at = NOW()
+     WHERE review_id = $2
+     RETURNING *`,
+    [reply, reviewId]
+  );
+  return this.mapRow(result.rows[0]);
+}
+```
+
+### 3. Backend — Controller
+
+Add to `ReviewController.ts`:
+
+```typescript
+/**
+ * POST /api/services/reviews/:reviewId/reply
+ * Customer counter-reply to shop response (one reply per review)
+ */
+async addCustomerReply(req: Request, res: Response): Promise<void> {
+  const { reviewId } = req.params;
+  const { reply } = req.body;
+  const customerAddress = req.user?.address;
+
+  // Validate ownership — only the original reviewer can reply
+  // Only allow reply if shop has responded
+  // Only allow one reply (block if customerReply already exists)
+}
+```
+
+### 4. Backend — Route
+
+```typescript
+router.post(
+  '/reviews/:reviewId/reply',
+  authMiddleware,
+  requireRole(['customer']),
+  reviewController.addCustomerReply.bind(reviewController)
+);
+```
+
+### 5. Mobile — Interface
+
+```typescript
+// service.interface.ts
+export interface ReviewData {
+  // existing fields...
+  shopResponse: string | null;
+  shopResponseAt: string | null;
+  customerReply: string | null;       // NEW
+  customerReplyAt: string | null;     // NEW
+}
+```
+
+### 6. Mobile — API Service
+
+```typescript
+// service.services.ts
+async addCustomerReply(reviewId: string, reply: string) {
+  return await apiClient.post(`/services/reviews/${reviewId}/reply`, { reply });
+}
+```
+
+### 7. Mobile — UI (ReviewCard.tsx)
+
+Show the customer reply beneath the shop response. If no reply yet and the current user is the original reviewer, show a reply input field.
+
+```
+Shop Response box
+  └── Customer reply text (if exists)
+      OR
+      [Reply input + Submit button] (if current user = reviewer AND no reply yet)
+```
+
+---
+
+## Business Rules
+
+- Only the customer who wrote the original review can post a reply
+- A reply can only be posted after the shop has responded (no reply without a shop response)
+- Only one customer reply allowed per review (not an open thread)
+- Reply length limit: 1,000 characters
+- Reply cannot be edited after submission
+
+---
+
+## Verification Checklist
+
+- [ ] Customer sees a reply input under shop response on their own review
+- [ ] Customer cannot reply to reviews they did not write
+- [ ] Reply input does not appear if shop has not yet responded
+- [ ] Reply input does not appear if customer has already replied
+- [ ] Submitted reply appears immediately without re-login (cache invalidation)
+- [ ] Other customers viewing the service can see the customer reply
+- [ ] Shop can see the customer reply in their Reviews tab
+- [ ] Reply is capped at 1,000 characters with validation
+
+---
+
+## References
+
+- **Existing shop respond endpoint**: `backend/src/domains/ServiceDomain/controllers/ReviewController.ts:305` — `addShopResponse`
+- **Review interface**: `mobile/feature/services/services/service.interface.ts:259`
+- **ReviewCard component**: `mobile/feature/services/services-main/feature-tab/components/ReviewCard.tsx:165`
+- **UnifiedReviewsSection**: `mobile/feature/services/services-main/feature-tab/components/UnifiedReviewsSection.tsx:162`
+- **Shop reply API call**: `mobile/feature/services/services/service.services.ts:222`

--- a/mobile/docs/tasks/enhancements/review-shop-rejoinder-edit-response.md
+++ b/mobile/docs/tasks/enhancements/review-shop-rejoinder-edit-response.md
@@ -1,0 +1,74 @@
+# Feature: Review Thread — Shop Rejoinder, Edit Response & Edit Reply
+
+**Status:** In Progress
+**Priority:** Medium
+**Est. Effort:** 4-5 hrs
+**Created:** 2026-06-08
+**Updated:** 2026-06-08
+
+## Problem / Goal
+
+The review system only supported a one-way exchange (customer review → shop response). Customers had no way to reply to a shop's response, and shops had no way to continue the conversation after a customer replied. Additionally, shops and customers could not edit their existing reviews or responses.
+
+Full thread needed:
+1. Customer writes review
+2. Shop responds
+3. Customer replies to shop's response
+4. Shop replies back (rejoinder)
+
+All parties should be able to edit their own contributions.
+
+## Analysis
+
+- `service_reviews` table was missing `customer_reply`, `customer_reply_at`, `shop_rejoinder`, `shop_rejoinder_at` columns
+- No backend endpoints existed for reply/rejoinder/edit operations
+- Mobile `ReviewCard` component had no UI for these interactions
+- Two separate ReviewCard implementations exist: `ReviewCard.tsx` (full screen) and the inline one inside `UnifiedReviewsSection.tsx` (service details page)
+
+## Implementation
+
+### Backend
+- **Migration 136** (`backend/migrations/136_add_customer_reply_to_reviews.sql`): adds `customer_reply`, `customer_reply_at`
+- **Migration 137** (`backend/migrations/137_add_shop_rejoinder_to_reviews.sql`): adds `shop_rejoinder`, `shop_rejoinder_at`
+- **`ReviewRepository.ts`**: added `addCustomerReply()`, `updateCustomerReply()`, `updateShopResponse()`, `addShopRejoinder()`, `updateShopRejoinder()`
+- **`ReviewController.ts`**: handlers for all new operations with ownership checks and business rules
+- **`ServiceDomain/routes.ts`**: new routes:
+  - `POST /reviews/:reviewId/reply` — customer adds reply
+  - `PUT /reviews/:reviewId/reply` — customer edits reply
+  - `PUT /reviews/:reviewId/respond` — shop edits response
+  - `POST /reviews/:reviewId/rejoinder` — shop adds rejoinder
+  - `PUT /reviews/:reviewId/rejoinder` — shop edits rejoinder
+
+### Mobile
+- **`service.interface.ts`**: `ReviewData` extended with `customerReply`, `customerReplyAt`, `shopRejoinder`, `shopRejoinderAt`
+- **`service.services.ts`**: API methods for all new endpoints
+- **`ReviewCard.tsx`**: full thread timeline UI (avatar circles + vertical connector line) with edit/reply/rejoinder interactions
+- **`UnifiedReviewsSection.tsx`**: same thread timeline UI for the compact embedded view on service details page
+
+### Business Rules
+- Customer can only reply once (no second reply)
+- Customer can edit their reply anytime
+- Customer cannot edit review after shop has responded
+- Shop can only add rejoinder after customer has replied
+- Shop can edit response and rejoinder anytime
+
+## Verification Checklist
+
+- [ ] Migration 136 applied (`customer_reply`, `customer_reply_at` columns exist)
+- [ ] Migration 137 applied (`shop_rejoinder`, `shop_rejoinder_at` columns exist)
+- [ ] Customer can reply to a shop response
+- [ ] Customer can edit their reply
+- [ ] Customer cannot reply twice
+- [ ] Customer cannot edit review after shop responds
+- [ ] Shop can edit their response (pencil icon)
+- [ ] Shop can add rejoinder after customer replies
+- [ ] Shop can edit their rejoinder
+- [ ] Thread displays correctly on service details page (UnifiedReviewsSection)
+- [ ] Thread displays correctly on full reviews screen (ReviewCard)
+- [ ] Thread timeline design is consistent across both views
+
+## Notes
+
+- Both `ReviewCard.tsx` and `UnifiedReviewsSection.tsx` have independent ReviewCard implementations — changes must be applied to both
+- Migration 137 must be run from WSL terminal: `npm run db:migrate` from `backend/` directory
+- Branch: `fix/mobile-notifications-favorites-sharing-2026-06-05`

--- a/mobile/feature/services/services-main/feature-tab/components/ReviewCard.tsx
+++ b/mobile/feature/services/services-main/feature-tab/components/ReviewCard.tsx
@@ -77,7 +77,7 @@ export default function ReviewCard({ review, isShopOwner = false, currentUserAdd
   const [editComment, setEditComment] = useState(review.comment ?? "");
 
   // Thread replies state
-  const [threadExpanded, setThreadExpanded] = useState(false);
+  const [commentsVisible, setCommentsVisible] = useState(false);
   const [isAddingReply, setIsAddingReply] = useState(false);
   const [newReplyText, setNewReplyText] = useState("");
   const [editingReplyId, setEditingReplyId] = useState<string | null>(null);
@@ -90,16 +90,12 @@ export default function ReviewCard({ review, isShopOwner = false, currentUserAdd
   const canEditReview = isReviewer && !review.shopResponse;
   const canEditShopResponse = isShopOwner && !!review.shopResponse;
 
-  // Thread reply eligibility — alternating turns
   const replies: ReviewReply[] = review.replies ?? [];
-  const lastReply = replies[replies.length - 1];
-  const canCustomerReply = isReviewer && !!review.shopResponse && (replies.length === 0 || lastReply?.authorType === 'shop');
-  const canShopReply = isShopOwner && replies.length > 0 && lastReply?.authorType === 'customer';
+  const canCustomerReply = isReviewer && !!review.shopResponse;
+  const canShopReply = isShopOwner;
   const canAddReply = canCustomerReply || canShopReply;
 
-  const COLLAPSED_COUNT = 2;
-  const visibleReplies = threadExpanded ? replies : replies.slice(-COLLAPSED_COUNT);
-  const hiddenCount = replies.length - COLLAPSED_COUNT;
+  const commentCount = replies.length;
 
   const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleDateString("en-US", {
@@ -325,103 +321,112 @@ export default function ReviewCard({ review, isShopOwner = false, currentUserAdd
             </View>
           </View>
 
-          {/* "Show X more" collapse button */}
-          {hiddenCount > 0 && !threadExpanded && (
-            <TouchableOpacity onPress={() => setThreadExpanded(true)} className="flex-row items-center ml-9 mb-2">
-              <Ionicons name="chevron-down-outline" size={13} color="#9CA3AF" />
-              <Text className="text-gray-400 text-xs ml-1">Show {hiddenCount} more {hiddenCount === 1 ? "reply" : "replies"}</Text>
+          {/* Comments toggle button */}
+          {(commentCount > 0 || canAddReply) && (
+            <TouchableOpacity
+              onPress={() => { setCommentsVisible(!commentsVisible); setIsAddingReply(false); setNewReplyText(""); }}
+              className="flex-row items-center mt-2 ml-9"
+            >
+              <Ionicons name={commentsVisible ? "chatbubble" : "chatbubble-outline"} size={13} color="#9CA3AF" />
+              <Text className="text-gray-400 text-xs ml-1">
+                {commentCount > 0 ? `${commentCount} ${commentCount === 1 ? "comment" : "comments"}` : "Comment"}
+              </Text>
+              {commentsVisible && <Ionicons name="chevron-up-outline" size={11} color="#9CA3AF" className="ml-1" />}
             </TouchableOpacity>
           )}
 
-          {/* Thread replies */}
-          {visibleReplies.map((reply, index) => {
-            const isShopReply = reply.authorType === 'shop';
-            const isOwnReply = currentUserAddress?.toLowerCase() === reply.authorAddress.toLowerCase();
-            const isLast = index === visibleReplies.length - 1;
-            const hasMore = replies.length > 0 && !isLast;
+          {/* Comments section */}
+          {commentsVisible && (
+            <View className="mt-2">
+              {replies.map((reply, index) => {
+                const isShopReply = reply.authorType === 'shop';
+                const isOwnReply = currentUserAddress?.toLowerCase() === reply.authorAddress.toLowerCase();
+                const isLast = index === replies.length - 1;
 
-            return (
-              <View key={reply.id} className="flex-row">
-                <View className="items-center mr-3" style={{ width: 24 }}>
-                  {isShopReply ? (
-                    <View className="w-6 h-6 rounded-full items-center justify-center" style={{ backgroundColor: isShopOwner ? "rgba(96,165,250,0.15)" : "rgba(255,204,0,0.15)" }}>
-                      <Ionicons name="storefront-outline" size={11} color={isShopOwner ? "#60A5FA" : "#FFCC00"} />
+                return (
+                  <View key={reply.id} className="flex-row">
+                    <View className="items-center mr-3" style={{ width: 24 }}>
+                      {isShopReply ? (
+                        <View className="w-6 h-6 rounded-full items-center justify-center" style={{ backgroundColor: isShopOwner ? "rgba(96,165,250,0.15)" : "rgba(255,204,0,0.15)" }}>
+                          <Ionicons name="storefront-outline" size={11} color={isShopOwner ? "#60A5FA" : "#FFCC00"} />
+                        </View>
+                      ) : (
+                        <View className="w-6 h-6 rounded-full bg-[#333] items-center justify-center">
+                          <Text className="text-white font-bold" style={{ fontSize: 9 }}>{getInitials(review.customerName, review.customerAddress)}</Text>
+                        </View>
+                      )}
+                      {(!isLast || canAddReply || isAddingReply) && (
+                        <View className="flex-1 mt-1" style={{ width: 1, backgroundColor: "#374151" }} />
+                      )}
                     </View>
-                  ) : (
-                    <View className="w-6 h-6 rounded-full bg-[#333] items-center justify-center">
-                      <Text className="text-white font-bold" style={{ fontSize: 9 }}>{getInitials(review.customerName, review.customerAddress)}</Text>
+                    <View className="flex-1 pb-3">
+                      <View className="flex-row items-center mb-1">
+                        <Text className={`text-xs font-semibold ${isShopReply ? (isShopOwner ? "text-blue-400" : "text-[#FFCC00]") : "text-gray-300"}`}>
+                          {isShopReply ? (isShopOwner ? "You" : "Shop") : (isReviewer ? "You" : (review.customerName || "Customer"))}
+                        </Text>
+                        <Text className="text-gray-500 text-xs ml-2">{formatDate(reply.createdAt)}</Text>
+                        {isOwnReply && editingReplyId !== reply.id && (
+                          <TouchableOpacity onPress={() => { setEditingReplyId(reply.id); setEditReplyContent(reply.content); }} className="ml-auto p-1">
+                            <Ionicons name="pencil-outline" size={13} color="#6B7280" />
+                          </TouchableOpacity>
+                        )}
+                      </View>
+                      {editingReplyId === reply.id ? (
+                        <>
+                          <TextInput value={editReplyContent} onChangeText={setEditReplyContent} placeholder="Edit your comment..." placeholderTextColor="#6B7280" multiline maxLength={1000} className="text-white text-sm min-h-[60px]" style={{ textAlignVertical: "top" }} />
+                          <Text className="text-gray-500 text-xs mt-1 text-right">{editReplyContent.length}/1000</Text>
+                          <View className="flex-row gap-2 mt-2">
+                            <TouchableOpacity onPress={handleSubmitEditThreadReply} disabled={isSubmitting || !editReplyContent.trim()} className={`flex-1 bg-[#FFCC00] rounded-lg py-2 items-center ${isSubmitting || !editReplyContent.trim() ? "opacity-50" : ""}`}>
+                              {isSubmitting ? <ActivityIndicator size="small" color="#000" /> : <Text className="text-black font-semibold text-sm">Save</Text>}
+                            </TouchableOpacity>
+                            <TouchableOpacity onPress={() => { setEditingReplyId(null); setEditReplyContent(""); }} className="px-4 py-2 bg-[#1a1a1a] border border-gray-700 rounded-lg">
+                              <Text className="text-white text-sm">Cancel</Text>
+                            </TouchableOpacity>
+                          </View>
+                        </>
+                      ) : (
+                        <Text className="text-gray-300 text-sm">{reply.content}</Text>
+                      )}
                     </View>
-                  )}
-                  {(hasMore || (!isLast) || canAddReply || isAddingReply) && (
-                    <View className="flex-1 mt-1" style={{ width: 1, backgroundColor: "#374151" }} />
-                  )}
-                </View>
-                <View className="flex-1 pb-3">
-                  <View className="flex-row items-center mb-1">
-                    <Text className={`text-xs font-semibold ${isShopReply ? (isShopOwner ? "text-blue-400" : "text-[#FFCC00]") : "text-gray-300"}`}>
-                      {isShopReply ? (isShopOwner ? "You" : "Shop") : (isReviewer ? "You" : (review.customerName || "Customer"))}
-                    </Text>
-                    <Text className="text-gray-500 text-xs ml-2">{formatDate(reply.createdAt)}</Text>
-                    {isOwnReply && editingReplyId !== reply.id && (
-                      <TouchableOpacity onPress={() => { setEditingReplyId(reply.id); setEditReplyContent(reply.content); }} className="ml-auto p-1">
-                        <Ionicons name="pencil-outline" size={13} color="#6B7280" />
-                      </TouchableOpacity>
+                  </View>
+                );
+              })}
+
+              {/* Add comment input */}
+              {isAddingReply ? (
+                <View className="flex-row">
+                  <View className="items-center mr-3" style={{ width: 24 }}>
+                    {canCustomerReply ? (
+                      <View className="w-6 h-6 rounded-full bg-[#333] items-center justify-center">
+                        <Text className="text-white font-bold" style={{ fontSize: 9 }}>{getInitials(review.customerName, review.customerAddress)}</Text>
+                      </View>
+                    ) : (
+                      <View className="w-6 h-6 rounded-full items-center justify-center" style={{ backgroundColor: "rgba(96,165,250,0.15)" }}>
+                        <Ionicons name="storefront-outline" size={11} color="#60A5FA" />
+                      </View>
                     )}
                   </View>
-                  {editingReplyId === reply.id ? (
-                    <>
-                      <TextInput value={editReplyContent} onChangeText={setEditReplyContent} placeholder="Edit your reply..." placeholderTextColor="#6B7280" multiline maxLength={1000} className="text-white text-sm min-h-[60px]" style={{ textAlignVertical: "top" }} />
-                      <Text className="text-gray-500 text-xs mt-1 text-right">{editReplyContent.length}/1000</Text>
-                      <View className="flex-row gap-2 mt-2">
-                        <TouchableOpacity onPress={handleSubmitEditThreadReply} disabled={isSubmitting || !editReplyContent.trim()} className={`flex-1 bg-[#FFCC00] rounded-lg py-2 items-center ${isSubmitting || !editReplyContent.trim() ? "opacity-50" : ""}`}>
-                          {isSubmitting ? <ActivityIndicator size="small" color="#000" /> : <Text className="text-black font-semibold text-sm">Save</Text>}
-                        </TouchableOpacity>
-                        <TouchableOpacity onPress={() => { setEditingReplyId(null); setEditReplyContent(""); }} className="px-4 py-2 bg-[#1a1a1a] border border-gray-700 rounded-lg">
-                          <Text className="text-white text-sm">Cancel</Text>
-                        </TouchableOpacity>
-                      </View>
-                    </>
-                  ) : (
-                    <Text className="text-gray-300 text-sm">{reply.content}</Text>
-                  )}
-                </View>
-              </View>
-            );
-          })}
-
-          {/* Add reply input */}
-          {isAddingReply ? (
-            <View className="flex-row">
-              <View className="items-center mr-3" style={{ width: 24 }}>
-                {canCustomerReply ? (
-                  <View className="w-6 h-6 rounded-full bg-[#333] items-center justify-center">
-                    <Text className="text-white font-bold" style={{ fontSize: 9 }}>{getInitials(review.customerName, review.customerAddress)}</Text>
+                  <View className="flex-1">
+                    <TextInput value={newReplyText} onChangeText={setNewReplyText} placeholder="Write a comment..." placeholderTextColor="#6B7280" multiline maxLength={1000} className="text-white text-sm min-h-[60px] bg-[#0d0d0d] border border-gray-700 rounded-lg p-2" style={{ textAlignVertical: "top" }} />
+                    <Text className="text-gray-500 text-xs mt-1 text-right">{newReplyText.length}/1000</Text>
+                    <View className="flex-row gap-2 mt-2">
+                      <TouchableOpacity onPress={handleSubmitThreadReply} disabled={isSubmitting || !newReplyText.trim()} className={`flex-1 bg-[#FFCC00] rounded-lg py-2 items-center ${isSubmitting || !newReplyText.trim() ? "opacity-50" : ""}`}>
+                        {isSubmitting ? <ActivityIndicator size="small" color="#000" /> : <Text className="text-black font-semibold text-sm">Submit</Text>}
+                      </TouchableOpacity>
+                      <TouchableOpacity onPress={() => { setIsAddingReply(false); setNewReplyText(""); }} className="px-4 py-2 bg-[#1a1a1a] border border-gray-700 rounded-lg">
+                        <Text className="text-white text-sm">Cancel</Text>
+                      </TouchableOpacity>
+                    </View>
                   </View>
-                ) : (
-                  <View className="w-6 h-6 rounded-full items-center justify-center" style={{ backgroundColor: "rgba(96,165,250,0.15)" }}>
-                    <Ionicons name="storefront-outline" size={11} color="#60A5FA" />
-                  </View>
-                )}
-              </View>
-              <View className="flex-1">
-                <TextInput value={newReplyText} onChangeText={setNewReplyText} placeholder="Write a reply..." placeholderTextColor="#6B7280" multiline maxLength={1000} className="text-white text-sm min-h-[60px] bg-[#0d0d0d] border border-gray-700 rounded-lg p-2" style={{ textAlignVertical: "top" }} />
-                <Text className="text-gray-500 text-xs mt-1 text-right">{newReplyText.length}/1000</Text>
-                <View className="flex-row gap-2 mt-2">
-                  <TouchableOpacity onPress={handleSubmitThreadReply} disabled={isSubmitting || !newReplyText.trim()} className={`flex-1 bg-[#FFCC00] rounded-lg py-2 items-center ${isSubmitting || !newReplyText.trim() ? "opacity-50" : ""}`}>
-                    {isSubmitting ? <ActivityIndicator size="small" color="#000" /> : <Text className="text-black font-semibold text-sm">Submit</Text>}
-                  </TouchableOpacity>
-                  <TouchableOpacity onPress={() => { setIsAddingReply(false); setNewReplyText(""); }} className="px-4 py-2 bg-[#1a1a1a] border border-gray-700 rounded-lg">
-                    <Text className="text-white text-sm">Cancel</Text>
-                  </TouchableOpacity>
                 </View>
-              </View>
+              ) : canAddReply ? (
+                <TouchableOpacity onPress={() => setIsAddingReply(true)} className="flex-row items-center ml-9">
+                  <Ionicons name="add-circle-outline" size={13} color="#9CA3AF" />
+                  <Text className="text-gray-400 text-xs ml-1">Add a comment</Text>
+                </TouchableOpacity>
+              ) : null}
             </View>
-          ) : canAddReply ? (
-            <TouchableOpacity onPress={() => setIsAddingReply(true)} className="flex-row items-center ml-9">
-              <Ionicons name="chatbubble-outline" size={13} color="#9CA3AF" />
-              <Text className="text-gray-400 text-xs ml-1">{canCustomerReply ? "Reply to shop" : "Reply to customer"}</Text>
-            </TouchableOpacity>
-          ) : null}
+          )}
 
         </View>
       ) : isShopOwner && isResponding ? (

--- a/mobile/feature/services/services-main/feature-tab/components/ReviewCard.tsx
+++ b/mobile/feature/services/services-main/feature-tab/components/ReviewCard.tsx
@@ -1,12 +1,13 @@
 import { View, Text, TouchableOpacity, ScrollView, Image, TextInput, ActivityIndicator, Alert } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useState } from "react";
-import { ReviewData } from "@/feature/services/services/service.interface";
+import { ReviewData, ReviewReply } from "@/feature/services/services/service.interface";
 import { serviceApi } from "@/feature/services/services/service.services";
 
 interface ReviewCardProps {
   review: ReviewData;
   isShopOwner?: boolean;
+  currentUserAddress?: string;
   onReviewUpdated?: () => void;
 }
 
@@ -25,9 +26,24 @@ function StarDisplay({ rating, size = 14 }: { rating: number; size?: number }) {
   );
 }
 
+function StarPicker({ rating, onSelect }: { rating: number; onSelect: (r: number) => void }) {
+  return (
+    <View className="flex-row gap-1 mb-2">
+      {[1, 2, 3, 4, 5].map((star) => (
+        <TouchableOpacity key={star} onPress={() => onSelect(star)}>
+          <Ionicons
+            name={star <= rating ? "star" : "star-outline"}
+            size={22}
+            color={star <= rating ? "#FFCC00" : "#4B5563"}
+          />
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+}
+
 function ReviewImage({ uri }: { uri: string }) {
   const [hasError, setHasError] = useState(false);
-
   if (hasError) {
     return (
       <View className="w-20 h-20 rounded-lg bg-zinc-800 items-center justify-center">
@@ -35,7 +51,6 @@ function ReviewImage({ uri }: { uri: string }) {
       </View>
     );
   }
-
   return (
     <Image
       source={{ uri }}
@@ -46,36 +61,48 @@ function ReviewImage({ uri }: { uri: string }) {
   );
 }
 
-export default function ReviewCard({ review, isShopOwner = false, onReviewUpdated }: ReviewCardProps) {
+export default function ReviewCard({ review, isShopOwner = false, currentUserAddress, onReviewUpdated }: ReviewCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const [isResponding, setIsResponding] = useState(false);
-  const [responseText, setResponseText] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleSubmitResponse = async () => {
-    if (!responseText.trim()) {
-      Alert.alert("Error", "Please enter a response");
-      return;
-    }
+  // Shop response state
+  const [isResponding, setIsResponding] = useState(false);
+  const [responseText, setResponseText] = useState("");
+  const [isEditingResponse, setIsEditingResponse] = useState(false);
+  const [editResponseText, setEditResponseText] = useState(review.shopResponse ?? "");
 
-    setIsSubmitting(true);
-    try {
-      await serviceApi.addShopResponse(review.reviewId, responseText);
-      Alert.alert("Success", "Response added successfully!");
-      setIsResponding(false);
-      setResponseText("");
-      onReviewUpdated?.();
-    } catch (error) {
-      console.error("Error adding response:", error);
-      Alert.alert("Error", "Failed to add response");
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
+  // Edit review state
+  const [isEditingReview, setIsEditingReview] = useState(false);
+  const [editRating, setEditRating] = useState(review.rating);
+  const [editComment, setEditComment] = useState(review.comment ?? "");
+
+  // Thread replies state
+  const [threadExpanded, setThreadExpanded] = useState(false);
+  const [isAddingReply, setIsAddingReply] = useState(false);
+  const [newReplyText, setNewReplyText] = useState("");
+  const [editingReplyId, setEditingReplyId] = useState<string | null>(null);
+  const [editReplyContent, setEditReplyContent] = useState("");
+
+  const isReviewer =
+    !!currentUserAddress &&
+    review.customerAddress.toLowerCase() === currentUserAddress.toLowerCase();
+
+  const canEditReview = isReviewer && !review.shopResponse;
+  const canEditShopResponse = isShopOwner && !!review.shopResponse;
+
+  // Thread reply eligibility — alternating turns
+  const replies: ReviewReply[] = review.replies ?? [];
+  const lastReply = replies[replies.length - 1];
+  const canCustomerReply = isReviewer && !!review.shopResponse && (replies.length === 0 || lastReply?.authorType === 'shop');
+  const canShopReply = isShopOwner && replies.length > 0 && lastReply?.authorType === 'customer';
+  const canAddReply = canCustomerReply || canShopReply;
+
+  const COLLAPSED_COUNT = 2;
+  const visibleReplies = threadExpanded ? replies : replies.slice(-COLLAPSED_COUNT);
+  const hiddenCount = replies.length - COLLAPSED_COUNT;
 
   const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString("en-US", {
+    return new Date(dateString).toLocaleDateString("en-US", {
       month: "short",
       day: "numeric",
       year: "numeric",
@@ -83,15 +110,82 @@ export default function ReviewCard({ review, isShopOwner = false, onReviewUpdate
   };
 
   const getInitials = (name: string | null, address: string) => {
-    if (name) {
-      return name
-        .split(" ")
-        .map((n) => n[0])
-        .join("")
-        .toUpperCase()
-        .slice(0, 2);
-    }
+    if (name) return name.split(" ").map((n) => n[0]).join("").toUpperCase().slice(0, 2);
     return address.slice(2, 4).toUpperCase();
+  };
+
+  // ── Handlers ────────────────────────────────────────────────────────────────
+
+  const handleSubmitResponse = async () => {
+    if (!responseText.trim()) { Alert.alert("Error", "Please enter a response"); return; }
+    setIsSubmitting(true);
+    try {
+      await serviceApi.addShopResponse(review.reviewId, responseText);
+      setIsResponding(false);
+      setResponseText("");
+      onReviewUpdated?.();
+    } catch {
+      Alert.alert("Error", "Failed to add response");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleSubmitEditReview = async () => {
+    setIsSubmitting(true);
+    try {
+      await serviceApi.updateReview(review.reviewId, { rating: editRating, comment: editComment });
+      setIsEditingReview(false);
+      onReviewUpdated?.();
+    } catch {
+      Alert.alert("Error", "Failed to update review");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleSubmitEditResponse = async () => {
+    if (!editResponseText.trim()) { Alert.alert("Error", "Please enter a response"); return; }
+    setIsSubmitting(true);
+    try {
+      await serviceApi.updateShopResponse(review.reviewId, editResponseText);
+      setIsEditingResponse(false);
+      onReviewUpdated?.();
+    } catch {
+      Alert.alert("Error", "Failed to update response");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleSubmitThreadReply = async () => {
+    if (!newReplyText.trim()) return;
+    setIsSubmitting(true);
+    try {
+      await serviceApi.addThreadReply(review.reviewId, newReplyText);
+      setIsAddingReply(false);
+      setNewReplyText("");
+      onReviewUpdated?.();
+    } catch {
+      Alert.alert("Error", "Failed to add reply");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleSubmitEditThreadReply = async () => {
+    if (!editReplyContent.trim() || !editingReplyId) return;
+    setIsSubmitting(true);
+    try {
+      await serviceApi.editThreadReply(editingReplyId, editReplyContent);
+      setEditingReplyId(null);
+      setEditReplyContent("");
+      onReviewUpdated?.();
+    } catch {
+      Alert.alert("Error", "Failed to update reply");
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const shouldTruncate = review.comment && review.comment.length > 150;
@@ -107,75 +201,228 @@ export default function ReviewCard({ review, isShopOwner = false, onReviewUpdate
         </View>
         <View className="flex-1">
           <Text className="text-white font-medium" numberOfLines={1}>
-            {review.customerName ||
-              `${review.customerAddress.slice(0, 6)}...${review.customerAddress.slice(-4)}`}
+            {review.customerName || `${review.customerAddress.slice(0, 6)}...${review.customerAddress.slice(-4)}`}
           </Text>
           <View className="flex-row items-center mt-1">
             <StarDisplay rating={review.rating} />
-            <Text className="text-gray-500 text-xs ml-2">
-              {formatDate(review.createdAt)}
-            </Text>
+            <Text className="text-gray-500 text-xs ml-2">{formatDate(review.createdAt)}</Text>
           </View>
         </View>
-        {review.helpfulCount > 0 && (
-          <View className="flex-row items-center bg-[#252525] rounded-full px-2 py-1">
-            <Ionicons name="thumbs-up" size={12} color="#9CA3AF" />
-            <Text className="text-gray-400 text-xs ml-1">
-              {review.helpfulCount}
-            </Text>
-          </View>
-        )}
+        <View className="flex-row items-center gap-2">
+          {review.helpfulCount > 0 && (
+            <View className="flex-row items-center bg-[#252525] rounded-full px-2 py-1">
+              <Ionicons name="thumbs-up" size={12} color="#9CA3AF" />
+              <Text className="text-gray-400 text-xs ml-1">{review.helpfulCount}</Text>
+            </View>
+          )}
+          {canEditReview && !isEditingReview && (
+            <TouchableOpacity
+              onPress={() => { setEditRating(review.rating); setEditComment(review.comment ?? ""); setIsEditingReview(true); }}
+              className="p-1"
+            >
+              <Ionicons name="pencil-outline" size={15} color="#9CA3AF" />
+            </TouchableOpacity>
+          )}
+        </View>
       </View>
 
-      {/* Comment */}
-      {review.comment && (
-        <TouchableOpacity
-          onPress={() => shouldTruncate && setIsExpanded(!isExpanded)}
-          activeOpacity={shouldTruncate ? 0.7 : 1}
-        >
-          <Text
-            className="text-gray-300 text-sm leading-5"
-            numberOfLines={isExpanded ? undefined : 4}
+      {/* Edit review form */}
+      {isEditingReview ? (
+        <View className="bg-[#0d0d0d] border border-gray-700 rounded-lg p-3 mb-2">
+          <StarPicker rating={editRating} onSelect={setEditRating} />
+          <TextInput
+            value={editComment}
+            onChangeText={setEditComment}
+            placeholder="Update your review..."
+            placeholderTextColor="#6B7280"
+            multiline
+            maxLength={2000}
+            className="text-white text-sm min-h-[70px]"
+            style={{ textAlignVertical: "top" }}
+          />
+          <View className="flex-row gap-2 mt-3">
+            <TouchableOpacity
+              onPress={handleSubmitEditReview}
+              disabled={isSubmitting}
+              className={`flex-1 bg-[#FFCC00] rounded-lg py-2 items-center ${isSubmitting ? "opacity-50" : ""}`}
+            >
+              {isSubmitting ? <ActivityIndicator size="small" color="#000" /> : <Text className="text-black font-semibold text-sm">Save</Text>}
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => setIsEditingReview(false)}
+              className="px-4 py-2 bg-[#1a1a1a] border border-gray-700 rounded-lg"
+            >
+              <Text className="text-white text-sm">Cancel</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      ) : (
+        /* Comment display */
+        review.comment && (
+          <TouchableOpacity
+            onPress={() => shouldTruncate && setIsExpanded(!isExpanded)}
+            activeOpacity={shouldTruncate ? 0.7 : 1}
           >
-            {review.comment}
-          </Text>
-          {shouldTruncate && (
-            <Text className="text-[#FFCC00] text-sm mt-1">
-              {isExpanded ? "Show less" : "Read more"}
+            <Text className="text-gray-300 text-sm leading-5" numberOfLines={isExpanded ? undefined : 4}>
+              {review.comment}
             </Text>
-          )}
-        </TouchableOpacity>
+            {shouldTruncate && (
+              <Text className="text-[#FFCC00] text-sm mt-1">{isExpanded ? "Show less" : "Read more"}</Text>
+            )}
+          </TouchableOpacity>
+        )
       )}
 
       {/* Images */}
       {review.images && review.images.length > 0 && (
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          className="mt-3"
-          contentContainerStyle={{ gap: 8 }}
-        >
-          {review.images.map((image, index) => (
-            <ReviewImage key={index} uri={image} />
-          ))}
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} className="mt-3" contentContainerStyle={{ gap: 8 }}>
+          {review.images.map((image, index) => <ReviewImage key={index} uri={image} />)}
         </ScrollView>
       )}
 
-      {/* Shop Response */}
+      {/* Response Thread */}
       {review.shopResponse ? (
-        <View className="mt-3 bg-[#252525] rounded-lg p-3">
-          <View className="flex-row items-center mb-2">
-            <Ionicons name="storefront-outline" size={14} color={isShopOwner ? "#60A5FA" : "#FFCC00"} />
-            <Text className={`text-xs ml-1 font-medium ${isShopOwner ? "text-blue-400" : "text-[#FFCC00]"}`}>
-              {isShopOwner ? "Your Response" : "Shop Response"}
-            </Text>
-            {review.shopResponseAt && (
-              <Text className="text-gray-500 text-xs ml-2">
-                {formatDate(review.shopResponseAt)}
-              </Text>
-            )}
+        <View className="mt-3">
+
+          {/* Shop Response */}
+          <View className="flex-row">
+            <View className="items-center mr-3" style={{ width: 24 }}>
+              <View className="w-6 h-6 rounded-full items-center justify-center" style={{ backgroundColor: isShopOwner ? "rgba(96,165,250,0.15)" : "rgba(255,204,0,0.15)" }}>
+                <Ionicons name="storefront-outline" size={11} color={isShopOwner ? "#60A5FA" : "#FFCC00"} />
+              </View>
+              {(replies.length > 0 || canAddReply || isAddingReply) && (
+                <View className="flex-1 mt-1" style={{ width: 1, backgroundColor: "#374151" }} />
+              )}
+            </View>
+            <View className="flex-1 pb-3">
+              <View className="flex-row items-center mb-1">
+                <Text className={`text-xs font-semibold ${isShopOwner ? "text-blue-400" : "text-[#FFCC00]"}`}>
+                  {isShopOwner ? "You" : "Shop"}
+                </Text>
+                {review.shopResponseAt && <Text className="text-gray-500 text-xs ml-2">{formatDate(review.shopResponseAt)}</Text>}
+                {canEditShopResponse && !isEditingResponse && (
+                  <TouchableOpacity onPress={() => { setEditResponseText(review.shopResponse ?? ""); setIsEditingResponse(true); }} className="ml-auto p-1">
+                    <Ionicons name="pencil-outline" size={13} color="#6B7280" />
+                  </TouchableOpacity>
+                )}
+              </View>
+              {isEditingResponse ? (
+                <>
+                  <TextInput value={editResponseText} onChangeText={setEditResponseText} placeholder="Edit your response..." placeholderTextColor="#6B7280" multiline maxLength={2000} className="text-white text-sm min-h-[70px]" style={{ textAlignVertical: "top" }} />
+                  <Text className="text-gray-500 text-xs mt-1 text-right">{editResponseText.length}/2000</Text>
+                  <View className="flex-row gap-2 mt-2">
+                    <TouchableOpacity onPress={handleSubmitEditResponse} disabled={isSubmitting || !editResponseText.trim()} className={`flex-1 bg-[#FFCC00] rounded-lg py-2 items-center ${isSubmitting || !editResponseText.trim() ? "opacity-50" : ""}`}>
+                      {isSubmitting ? <ActivityIndicator size="small" color="#000" /> : <Text className="text-black font-semibold text-sm">Save</Text>}
+                    </TouchableOpacity>
+                    <TouchableOpacity onPress={() => setIsEditingResponse(false)} className="px-4 py-2 bg-[#1a1a1a] border border-gray-700 rounded-lg">
+                      <Text className="text-white text-sm">Cancel</Text>
+                    </TouchableOpacity>
+                  </View>
+                </>
+              ) : (
+                <Text className="text-gray-300 text-sm">{review.shopResponse}</Text>
+              )}
+            </View>
           </View>
-          <Text className="text-gray-300 text-sm">{review.shopResponse}</Text>
+
+          {/* "Show X more" collapse button */}
+          {hiddenCount > 0 && !threadExpanded && (
+            <TouchableOpacity onPress={() => setThreadExpanded(true)} className="flex-row items-center ml-9 mb-2">
+              <Ionicons name="chevron-down-outline" size={13} color="#9CA3AF" />
+              <Text className="text-gray-400 text-xs ml-1">Show {hiddenCount} more {hiddenCount === 1 ? "reply" : "replies"}</Text>
+            </TouchableOpacity>
+          )}
+
+          {/* Thread replies */}
+          {visibleReplies.map((reply, index) => {
+            const isShopReply = reply.authorType === 'shop';
+            const isOwnReply = currentUserAddress?.toLowerCase() === reply.authorAddress.toLowerCase();
+            const isLast = index === visibleReplies.length - 1;
+            const hasMore = replies.length > 0 && !isLast;
+
+            return (
+              <View key={reply.id} className="flex-row">
+                <View className="items-center mr-3" style={{ width: 24 }}>
+                  {isShopReply ? (
+                    <View className="w-6 h-6 rounded-full items-center justify-center" style={{ backgroundColor: isShopOwner ? "rgba(96,165,250,0.15)" : "rgba(255,204,0,0.15)" }}>
+                      <Ionicons name="storefront-outline" size={11} color={isShopOwner ? "#60A5FA" : "#FFCC00"} />
+                    </View>
+                  ) : (
+                    <View className="w-6 h-6 rounded-full bg-[#333] items-center justify-center">
+                      <Text className="text-white font-bold" style={{ fontSize: 9 }}>{getInitials(review.customerName, review.customerAddress)}</Text>
+                    </View>
+                  )}
+                  {(hasMore || (!isLast) || canAddReply || isAddingReply) && (
+                    <View className="flex-1 mt-1" style={{ width: 1, backgroundColor: "#374151" }} />
+                  )}
+                </View>
+                <View className="flex-1 pb-3">
+                  <View className="flex-row items-center mb-1">
+                    <Text className={`text-xs font-semibold ${isShopReply ? (isShopOwner ? "text-blue-400" : "text-[#FFCC00]") : "text-gray-300"}`}>
+                      {isShopReply ? (isShopOwner ? "You" : "Shop") : (isReviewer ? "You" : (review.customerName || "Customer"))}
+                    </Text>
+                    <Text className="text-gray-500 text-xs ml-2">{formatDate(reply.createdAt)}</Text>
+                    {isOwnReply && editingReplyId !== reply.id && (
+                      <TouchableOpacity onPress={() => { setEditingReplyId(reply.id); setEditReplyContent(reply.content); }} className="ml-auto p-1">
+                        <Ionicons name="pencil-outline" size={13} color="#6B7280" />
+                      </TouchableOpacity>
+                    )}
+                  </View>
+                  {editingReplyId === reply.id ? (
+                    <>
+                      <TextInput value={editReplyContent} onChangeText={setEditReplyContent} placeholder="Edit your reply..." placeholderTextColor="#6B7280" multiline maxLength={1000} className="text-white text-sm min-h-[60px]" style={{ textAlignVertical: "top" }} />
+                      <Text className="text-gray-500 text-xs mt-1 text-right">{editReplyContent.length}/1000</Text>
+                      <View className="flex-row gap-2 mt-2">
+                        <TouchableOpacity onPress={handleSubmitEditThreadReply} disabled={isSubmitting || !editReplyContent.trim()} className={`flex-1 bg-[#FFCC00] rounded-lg py-2 items-center ${isSubmitting || !editReplyContent.trim() ? "opacity-50" : ""}`}>
+                          {isSubmitting ? <ActivityIndicator size="small" color="#000" /> : <Text className="text-black font-semibold text-sm">Save</Text>}
+                        </TouchableOpacity>
+                        <TouchableOpacity onPress={() => { setEditingReplyId(null); setEditReplyContent(""); }} className="px-4 py-2 bg-[#1a1a1a] border border-gray-700 rounded-lg">
+                          <Text className="text-white text-sm">Cancel</Text>
+                        </TouchableOpacity>
+                      </View>
+                    </>
+                  ) : (
+                    <Text className="text-gray-300 text-sm">{reply.content}</Text>
+                  )}
+                </View>
+              </View>
+            );
+          })}
+
+          {/* Add reply input */}
+          {isAddingReply ? (
+            <View className="flex-row">
+              <View className="items-center mr-3" style={{ width: 24 }}>
+                {canCustomerReply ? (
+                  <View className="w-6 h-6 rounded-full bg-[#333] items-center justify-center">
+                    <Text className="text-white font-bold" style={{ fontSize: 9 }}>{getInitials(review.customerName, review.customerAddress)}</Text>
+                  </View>
+                ) : (
+                  <View className="w-6 h-6 rounded-full items-center justify-center" style={{ backgroundColor: "rgba(96,165,250,0.15)" }}>
+                    <Ionicons name="storefront-outline" size={11} color="#60A5FA" />
+                  </View>
+                )}
+              </View>
+              <View className="flex-1">
+                <TextInput value={newReplyText} onChangeText={setNewReplyText} placeholder="Write a reply..." placeholderTextColor="#6B7280" multiline maxLength={1000} className="text-white text-sm min-h-[60px] bg-[#0d0d0d] border border-gray-700 rounded-lg p-2" style={{ textAlignVertical: "top" }} />
+                <Text className="text-gray-500 text-xs mt-1 text-right">{newReplyText.length}/1000</Text>
+                <View className="flex-row gap-2 mt-2">
+                  <TouchableOpacity onPress={handleSubmitThreadReply} disabled={isSubmitting || !newReplyText.trim()} className={`flex-1 bg-[#FFCC00] rounded-lg py-2 items-center ${isSubmitting || !newReplyText.trim() ? "opacity-50" : ""}`}>
+                    {isSubmitting ? <ActivityIndicator size="small" color="#000" /> : <Text className="text-black font-semibold text-sm">Submit</Text>}
+                  </TouchableOpacity>
+                  <TouchableOpacity onPress={() => { setIsAddingReply(false); setNewReplyText(""); }} className="px-4 py-2 bg-[#1a1a1a] border border-gray-700 rounded-lg">
+                    <Text className="text-white text-sm">Cancel</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            </View>
+          ) : canAddReply ? (
+            <TouchableOpacity onPress={() => setIsAddingReply(true)} className="flex-row items-center ml-9">
+              <Ionicons name="chatbubble-outline" size={13} color="#9CA3AF" />
+              <Text className="text-gray-400 text-xs ml-1">{canCustomerReply ? "Reply to shop" : "Reply to customer"}</Text>
+            </TouchableOpacity>
+          ) : null}
+
         </View>
       ) : isShopOwner && isResponding ? (
         <View className="mt-3 bg-[#0d0d0d] border border-gray-700 rounded-lg p-3">
@@ -192,21 +439,12 @@ export default function ReviewCard({ review, isShopOwner = false, onReviewUpdate
             <TouchableOpacity
               onPress={handleSubmitResponse}
               disabled={isSubmitting || !responseText.trim()}
-              className={`flex-1 bg-[#FFCC00] rounded-lg py-3 items-center ${
-                isSubmitting || !responseText.trim() ? "opacity-50" : ""
-              }`}
+              className={`flex-1 bg-[#FFCC00] rounded-lg py-3 items-center ${isSubmitting || !responseText.trim() ? "opacity-50" : ""}`}
             >
-              {isSubmitting ? (
-                <ActivityIndicator size="small" color="#000" />
-              ) : (
-                <Text className="text-black font-semibold">Submit Response</Text>
-              )}
+              {isSubmitting ? <ActivityIndicator size="small" color="#000" /> : <Text className="text-black font-semibold">Submit Response</Text>}
             </TouchableOpacity>
             <TouchableOpacity
-              onPress={() => {
-                setIsResponding(false);
-                setResponseText("");
-              }}
+              onPress={() => { setIsResponding(false); setResponseText(""); }}
               className="px-4 py-3 bg-[#1a1a1a] border border-gray-700 rounded-lg"
             >
               <Text className="text-white">Cancel</Text>
@@ -214,10 +452,7 @@ export default function ReviewCard({ review, isShopOwner = false, onReviewUpdate
           </View>
         </View>
       ) : isShopOwner ? (
-        <TouchableOpacity
-          onPress={() => setIsResponding(true)}
-          className="mt-3 flex-row items-center"
-        >
+        <TouchableOpacity onPress={() => setIsResponding(true)} className="mt-3 flex-row items-center">
           <Ionicons name="chatbubble-outline" size={16} color="#60A5FA" />
           <Text className="text-blue-400 text-sm ml-2">Respond to this review</Text>
         </TouchableOpacity>

--- a/mobile/feature/services/services-main/feature-tab/components/UnifiedReviewsSection.tsx
+++ b/mobile/feature/services/services-main/feature-tab/components/UnifiedReviewsSection.tsx
@@ -9,7 +9,7 @@ import {
   Alert,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
-import { ReviewData, ReviewStats } from "@/feature/services/services/service.interface";
+import { ReviewData, ReviewReply, ReviewStats } from "@/feature/services/services/service.interface";
 import { serviceApi } from "@/feature/services/services/service.services";
 
 interface UnifiedReviewsSectionProps {
@@ -69,6 +69,17 @@ function ReviewCard({
   const [isResponding, setIsResponding] = useState(false);
   const [responseText, setResponseText] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [threadExpanded, setThreadExpanded] = useState(false);
+  const [isAddingReply, setIsAddingReply] = useState(false);
+  const [newReplyText, setNewReplyText] = useState("");
+
+  const replies: ReviewReply[] = review.replies ?? [];
+  const COLLAPSED_COUNT = 2;
+  const visibleReplies = threadExpanded ? replies : replies.slice(-COLLAPSED_COUNT);
+  const hiddenCount = replies.length - COLLAPSED_COUNT;
+  const lastReply = replies[replies.length - 1];
+  const canShopReply = isShopOwner && replies.length > 0 && lastReply?.authorType === 'customer';
+  const canAddReply = canShopReply;
 
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
@@ -158,35 +169,122 @@ function ReviewCard({
         </View>
       )}
 
-      {/* Shop Response */}
+      {/* Response Thread */}
       {review.shopResponse ? (
-        <View
-          className={`mt-3 rounded-lg p-3 ${
-            isShopOwner
-              ? "bg-blue-500/10 border border-blue-500/30"
-              : "bg-[#252525]"
-          }`}
-        >
-          <View className="flex-row items-center mb-2">
-            <Ionicons
-              name={isShopOwner ? "chatbubble" : "storefront-outline"}
-              size={isShopOwner ? 12 : 14}
-              color={isShopOwner ? "#60A5FA" : "#9CA3AF"}
-            />
-            <Text
-              className={`text-xs ml-1 font-medium ${
-                isShopOwner ? "text-blue-400" : "text-gray-400"
-              }`}
-            >
-              {isShopOwner ? "Your Response" : "Shop Response"}
-            </Text>
+        <View className="mt-3">
+
+          {/* Shop Response */}
+          <View className="flex-row">
+            <View className="items-center mr-3" style={{ width: 22 }}>
+              <View className="w-[22px] h-[22px] rounded-full items-center justify-center" style={{ backgroundColor: isShopOwner ? "rgba(96,165,250,0.15)" : "rgba(255,204,0,0.12)" }}>
+                <Ionicons name="storefront-outline" size={11} color={isShopOwner ? "#60A5FA" : "#FFCC00"} />
+              </View>
+              {(replies.length > 0 || canAddReply || isAddingReply) && (
+                <View className="flex-1 mt-1" style={{ width: 1, backgroundColor: "#374151" }} />
+              )}
+            </View>
+            <View className="flex-1 pb-2">
+              <Text className={`text-xs font-semibold mb-1 ${isShopOwner ? "text-blue-400" : "text-[#FFCC00]"}`}>
+                {isShopOwner ? "You" : "Shop"}
+              </Text>
+              <Text className="text-gray-300 text-sm" numberOfLines={2}>
+                {review.shopResponse}
+              </Text>
+            </View>
           </View>
-          <Text
-            className={`text-sm ${isShopOwner ? "text-blue-200" : "text-gray-300"}`}
-            numberOfLines={2}
-          >
-            {review.shopResponse}
-          </Text>
+
+          {/* "X more replies" collapse */}
+          {hiddenCount > 0 && !threadExpanded && (
+            <TouchableOpacity onPress={() => setThreadExpanded(true)} className="flex-row items-center ml-9 mb-1">
+              <Ionicons name="chevron-down-outline" size={12} color="#9CA3AF" />
+              <Text className="text-gray-500 text-xs ml-1">{hiddenCount} more {hiddenCount === 1 ? "reply" : "replies"}</Text>
+            </TouchableOpacity>
+          )}
+
+          {/* Thread replies (compact, read-only) */}
+          {visibleReplies.map((reply, index) => {
+            const isShopReply = reply.authorType === 'shop';
+            const isLast = index === visibleReplies.length - 1;
+            return (
+              <View key={reply.id} className="flex-row">
+                <View className="items-center mr-3" style={{ width: 22 }}>
+                  {isShopReply ? (
+                    <View className="w-[22px] h-[22px] rounded-full items-center justify-center" style={{ backgroundColor: isShopOwner ? "rgba(96,165,250,0.15)" : "rgba(255,204,0,0.12)" }}>
+                      <Ionicons name="storefront-outline" size={11} color={isShopOwner ? "#60A5FA" : "#FFCC00"} />
+                    </View>
+                  ) : (
+                    <View className="w-[22px] h-[22px] rounded-full bg-[#333] items-center justify-center">
+                      <Text className="text-white font-bold" style={{ fontSize: 8 }}>{getInitials(review.customerName, review.customerAddress)}</Text>
+                    </View>
+                  )}
+                  {(!isLast || canAddReply || isAddingReply) && (
+                    <View className="flex-1 mt-1" style={{ width: 1, backgroundColor: "#374151" }} />
+                  )}
+                </View>
+                <View className="flex-1 pb-2">
+                  <Text className={`text-xs font-semibold mb-0.5 ${isShopReply ? (isShopOwner ? "text-blue-400" : "text-[#FFCC00]") : "text-gray-300"}`}>
+                    {isShopReply ? (isShopOwner ? "You" : "Shop") : (review.customerName || "Customer")}
+                  </Text>
+                  <Text className="text-gray-400 text-sm" numberOfLines={2}>{reply.content}</Text>
+                </View>
+              </View>
+            );
+          })}
+
+          {/* Add reply (shop only in compact view) */}
+          {isAddingReply ? (
+            <View className="flex-row">
+              <View className="items-center mr-3" style={{ width: 22 }}>
+                <View className="w-[22px] h-[22px] rounded-full items-center justify-center" style={{ backgroundColor: "rgba(96,165,250,0.15)" }}>
+                  <Ionicons name="storefront-outline" size={11} color="#60A5FA" />
+                </View>
+              </View>
+              <View className="flex-1">
+                <TextInput
+                  value={newReplyText}
+                  onChangeText={setNewReplyText}
+                  placeholder="Reply to customer..."
+                  placeholderTextColor="#6B7280"
+                  multiline
+                  maxLength={1000}
+                  className="text-white text-sm min-h-[60px] bg-[#0d0d0d] border border-gray-700 rounded-lg p-2"
+                  style={{ textAlignVertical: "top" }}
+                />
+                <Text className="text-gray-500 text-xs mt-1 text-right">{newReplyText.length}/1000</Text>
+                <View className="flex-row gap-2 mt-2">
+                  <TouchableOpacity
+                    onPress={async () => {
+                      if (!newReplyText.trim()) return;
+                      setIsSubmitting(true);
+                      try {
+                        await serviceApi.addThreadReply(review.reviewId, newReplyText);
+                        setIsAddingReply(false);
+                        setNewReplyText("");
+                        onReviewUpdated?.();
+                      } catch {
+                        Alert.alert("Error", "Failed to add reply");
+                      } finally {
+                        setIsSubmitting(false);
+                      }
+                    }}
+                    disabled={isSubmitting || !newReplyText.trim()}
+                    className={`flex-1 bg-[#FFCC00] rounded-lg py-2 items-center ${isSubmitting || !newReplyText.trim() ? "opacity-50" : ""}`}
+                  >
+                    {isSubmitting ? <ActivityIndicator size="small" color="#000" /> : <Text className="text-black font-semibold text-sm">Submit</Text>}
+                  </TouchableOpacity>
+                  <TouchableOpacity onPress={() => { setIsAddingReply(false); setNewReplyText(""); }} className="px-3 py-2 bg-gray-800 rounded-lg">
+                    <Text className="text-white text-sm">Cancel</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            </View>
+          ) : canAddReply ? (
+            <TouchableOpacity onPress={() => setIsAddingReply(true)} className="flex-row items-center ml-9">
+              <Ionicons name="chatbubble-outline" size={12} color="#60A5FA" />
+              <Text className="text-blue-400 text-xs ml-1">Reply to customer</Text>
+            </TouchableOpacity>
+          ) : null}
+
         </View>
       ) : isShopOwner && isResponding ? (
         <View className="mt-3 bg-[#0d0d0d] border border-gray-700 rounded-lg p-3">

--- a/mobile/feature/services/services-main/feature-tab/components/UnifiedReviewsSection.tsx
+++ b/mobile/feature/services/services-main/feature-tab/components/UnifiedReviewsSection.tsx
@@ -69,16 +69,13 @@ function ReviewCard({
   const [isResponding, setIsResponding] = useState(false);
   const [responseText, setResponseText] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [threadExpanded, setThreadExpanded] = useState(false);
+  const [commentsVisible, setCommentsVisible] = useState(false);
   const [isAddingReply, setIsAddingReply] = useState(false);
   const [newReplyText, setNewReplyText] = useState("");
 
   const replies: ReviewReply[] = review.replies ?? [];
-  const COLLAPSED_COUNT = 2;
-  const visibleReplies = threadExpanded ? replies : replies.slice(-COLLAPSED_COUNT);
-  const hiddenCount = replies.length - COLLAPSED_COUNT;
-  const lastReply = replies[replies.length - 1];
-  const canShopReply = isShopOwner && replies.length > 0 && lastReply?.authorType === 'customer';
+  const commentCount = replies.length;
+  const canShopReply = isShopOwner;
   const canAddReply = canShopReply;
 
   const formatDate = (dateString: string) => {
@@ -111,7 +108,6 @@ function ReviewCard({
     setIsSubmitting(true);
     try {
       await serviceApi.addShopResponse(review.reviewId, responseText);
-      Alert.alert("Success", "Response added successfully!");
       setIsResponding(false);
       setResponseText("");
       onReviewUpdated?.();
@@ -179,9 +175,7 @@ function ReviewCard({
               <View className="w-[22px] h-[22px] rounded-full items-center justify-center" style={{ backgroundColor: isShopOwner ? "rgba(96,165,250,0.15)" : "rgba(255,204,0,0.12)" }}>
                 <Ionicons name="storefront-outline" size={11} color={isShopOwner ? "#60A5FA" : "#FFCC00"} />
               </View>
-              {(replies.length > 0 || canAddReply || isAddingReply) && (
-                <View className="flex-1 mt-1" style={{ width: 1, backgroundColor: "#374151" }} />
-              )}
+                  <View className="flex-1 mt-1" style={{ width: 1, backgroundColor: "#374151" }} />
             </View>
             <View className="flex-1 pb-2">
               <Text className={`text-xs font-semibold mb-1 ${isShopOwner ? "text-blue-400" : "text-[#FFCC00]"}`}>
@@ -193,97 +187,106 @@ function ReviewCard({
             </View>
           </View>
 
-          {/* "X more replies" collapse */}
-          {hiddenCount > 0 && !threadExpanded && (
-            <TouchableOpacity onPress={() => setThreadExpanded(true)} className="flex-row items-center ml-9 mb-1">
-              <Ionicons name="chevron-down-outline" size={12} color="#9CA3AF" />
-              <Text className="text-gray-500 text-xs ml-1">{hiddenCount} more {hiddenCount === 1 ? "reply" : "replies"}</Text>
+          {/* Comments toggle button */}
+          {(commentCount > 0 || canAddReply) && (
+            <TouchableOpacity
+              onPress={() => { setCommentsVisible(!commentsVisible); setIsAddingReply(false); setNewReplyText(""); }}
+              className="flex-row items-center mt-1 ml-8"
+            >
+              <Ionicons name={commentsVisible ? "chatbubble" : "chatbubble-outline"} size={12} color="#9CA3AF" />
+              <Text className="text-gray-500 text-xs ml-1">
+                {commentCount > 0 ? `${commentCount} ${commentCount === 1 ? "comment" : "comments"}` : "Comment"}
+              </Text>
             </TouchableOpacity>
           )}
 
-          {/* Thread replies (compact, read-only) */}
-          {visibleReplies.map((reply, index) => {
-            const isShopReply = reply.authorType === 'shop';
-            const isLast = index === visibleReplies.length - 1;
-            return (
-              <View key={reply.id} className="flex-row">
-                <View className="items-center mr-3" style={{ width: 22 }}>
-                  {isShopReply ? (
-                    <View className="w-[22px] h-[22px] rounded-full items-center justify-center" style={{ backgroundColor: isShopOwner ? "rgba(96,165,250,0.15)" : "rgba(255,204,0,0.12)" }}>
-                      <Ionicons name="storefront-outline" size={11} color={isShopOwner ? "#60A5FA" : "#FFCC00"} />
+          {/* Comments section */}
+          {commentsVisible && (
+            <View className="mt-2">
+              {replies.map((reply, index) => {
+                const isShopReply = reply.authorType === 'shop';
+                const isLast = index === replies.length - 1;
+                return (
+                  <View key={reply.id} className="flex-row">
+                    <View className="items-center mr-3" style={{ width: 22 }}>
+                      {isShopReply ? (
+                        <View className="w-[22px] h-[22px] rounded-full items-center justify-center" style={{ backgroundColor: isShopOwner ? "rgba(96,165,250,0.15)" : "rgba(255,204,0,0.12)" }}>
+                          <Ionicons name="storefront-outline" size={11} color={isShopOwner ? "#60A5FA" : "#FFCC00"} />
+                        </View>
+                      ) : (
+                        <View className="w-[22px] h-[22px] rounded-full bg-[#333] items-center justify-center">
+                          <Text className="text-white font-bold" style={{ fontSize: 8 }}>{getInitials(review.customerName, review.customerAddress)}</Text>
+                        </View>
+                      )}
+                      {(!isLast || canAddReply || isAddingReply) && (
+                        <View className="flex-1 mt-1" style={{ width: 1, backgroundColor: "#374151" }} />
+                      )}
                     </View>
-                  ) : (
-                    <View className="w-[22px] h-[22px] rounded-full bg-[#333] items-center justify-center">
-                      <Text className="text-white font-bold" style={{ fontSize: 8 }}>{getInitials(review.customerName, review.customerAddress)}</Text>
+                    <View className="flex-1 pb-2">
+                      <Text className={`text-xs font-semibold mb-0.5 ${isShopReply ? (isShopOwner ? "text-blue-400" : "text-[#FFCC00]") : "text-gray-300"}`}>
+                        {isShopReply ? (isShopOwner ? "You" : "Shop") : (review.customerName || "Customer")}
+                      </Text>
+                      <Text className="text-gray-400 text-sm" numberOfLines={2}>{reply.content}</Text>
                     </View>
-                  )}
-                  {(!isLast || canAddReply || isAddingReply) && (
-                    <View className="flex-1 mt-1" style={{ width: 1, backgroundColor: "#374151" }} />
-                  )}
-                </View>
-                <View className="flex-1 pb-2">
-                  <Text className={`text-xs font-semibold mb-0.5 ${isShopReply ? (isShopOwner ? "text-blue-400" : "text-[#FFCC00]") : "text-gray-300"}`}>
-                    {isShopReply ? (isShopOwner ? "You" : "Shop") : (review.customerName || "Customer")}
-                  </Text>
-                  <Text className="text-gray-400 text-sm" numberOfLines={2}>{reply.content}</Text>
-                </View>
-              </View>
-            );
-          })}
+                  </View>
+                );
+              })}
 
-          {/* Add reply (shop only in compact view) */}
-          {isAddingReply ? (
-            <View className="flex-row">
-              <View className="items-center mr-3" style={{ width: 22 }}>
-                <View className="w-[22px] h-[22px] rounded-full items-center justify-center" style={{ backgroundColor: "rgba(96,165,250,0.15)" }}>
-                  <Ionicons name="storefront-outline" size={11} color="#60A5FA" />
+              {/* Add comment */}
+              {isAddingReply ? (
+                <View className="flex-row">
+                  <View className="items-center mr-3" style={{ width: 22 }}>
+                    <View className="w-[22px] h-[22px] rounded-full items-center justify-center" style={{ backgroundColor: "rgba(96,165,250,0.15)" }}>
+                      <Ionicons name="storefront-outline" size={11} color="#60A5FA" />
+                    </View>
+                  </View>
+                  <View className="flex-1">
+                    <TextInput
+                      value={newReplyText}
+                      onChangeText={setNewReplyText}
+                      placeholder="Write a comment..."
+                      placeholderTextColor="#6B7280"
+                      multiline
+                      maxLength={1000}
+                      className="text-white text-sm min-h-[60px] bg-[#0d0d0d] border border-gray-700 rounded-lg p-2"
+                      style={{ textAlignVertical: "top" }}
+                    />
+                    <Text className="text-gray-500 text-xs mt-1 text-right">{newReplyText.length}/1000</Text>
+                    <View className="flex-row gap-2 mt-2">
+                      <TouchableOpacity
+                        onPress={async () => {
+                          if (!newReplyText.trim()) return;
+                          setIsSubmitting(true);
+                          try {
+                            await serviceApi.addThreadReply(review.reviewId, newReplyText);
+                            setIsAddingReply(false);
+                            setNewReplyText("");
+                            onReviewUpdated?.();
+                          } catch {
+                            Alert.alert("Error", "Failed to add comment");
+                          } finally {
+                            setIsSubmitting(false);
+                          }
+                        }}
+                        disabled={isSubmitting || !newReplyText.trim()}
+                        className={`flex-1 bg-[#FFCC00] rounded-lg py-2 items-center ${isSubmitting || !newReplyText.trim() ? "opacity-50" : ""}`}
+                      >
+                        {isSubmitting ? <ActivityIndicator size="small" color="#000" /> : <Text className="text-black font-semibold text-sm">Submit</Text>}
+                      </TouchableOpacity>
+                      <TouchableOpacity onPress={() => { setIsAddingReply(false); setNewReplyText(""); }} className="px-3 py-2 bg-gray-800 rounded-lg">
+                        <Text className="text-white text-sm">Cancel</Text>
+                      </TouchableOpacity>
+                    </View>
+                  </View>
                 </View>
-              </View>
-              <View className="flex-1">
-                <TextInput
-                  value={newReplyText}
-                  onChangeText={setNewReplyText}
-                  placeholder="Reply to customer..."
-                  placeholderTextColor="#6B7280"
-                  multiline
-                  maxLength={1000}
-                  className="text-white text-sm min-h-[60px] bg-[#0d0d0d] border border-gray-700 rounded-lg p-2"
-                  style={{ textAlignVertical: "top" }}
-                />
-                <Text className="text-gray-500 text-xs mt-1 text-right">{newReplyText.length}/1000</Text>
-                <View className="flex-row gap-2 mt-2">
-                  <TouchableOpacity
-                    onPress={async () => {
-                      if (!newReplyText.trim()) return;
-                      setIsSubmitting(true);
-                      try {
-                        await serviceApi.addThreadReply(review.reviewId, newReplyText);
-                        setIsAddingReply(false);
-                        setNewReplyText("");
-                        onReviewUpdated?.();
-                      } catch {
-                        Alert.alert("Error", "Failed to add reply");
-                      } finally {
-                        setIsSubmitting(false);
-                      }
-                    }}
-                    disabled={isSubmitting || !newReplyText.trim()}
-                    className={`flex-1 bg-[#FFCC00] rounded-lg py-2 items-center ${isSubmitting || !newReplyText.trim() ? "opacity-50" : ""}`}
-                  >
-                    {isSubmitting ? <ActivityIndicator size="small" color="#000" /> : <Text className="text-black font-semibold text-sm">Submit</Text>}
-                  </TouchableOpacity>
-                  <TouchableOpacity onPress={() => { setIsAddingReply(false); setNewReplyText(""); }} className="px-3 py-2 bg-gray-800 rounded-lg">
-                    <Text className="text-white text-sm">Cancel</Text>
-                  </TouchableOpacity>
-                </View>
-              </View>
+              ) : canAddReply ? (
+                <TouchableOpacity onPress={() => setIsAddingReply(true)} className="flex-row items-center ml-8">
+                  <Ionicons name="add-circle-outline" size={12} color="#9CA3AF" />
+                  <Text className="text-gray-500 text-xs ml-1">Add a comment</Text>
+                </TouchableOpacity>
+              ) : null}
             </View>
-          ) : canAddReply ? (
-            <TouchableOpacity onPress={() => setIsAddingReply(true)} className="flex-row items-center ml-9">
-              <Ionicons name="chatbubble-outline" size={12} color="#60A5FA" />
-              <Text className="text-blue-400 text-xs ml-1">Reply to customer</Text>
-            </TouchableOpacity>
-          ) : null}
+          )}
 
         </View>
       ) : isShopOwner && isResponding ? (

--- a/mobile/feature/services/services-main/feature-tab/hooks/useServiceReviews.ts
+++ b/mobile/feature/services/services-main/feature-tab/hooks/useServiceReviews.ts
@@ -29,8 +29,8 @@ export function useServiceReviews() {
     refetchOnMount: true,
   });
 
-  // Check if user is shop owner of this service
   const isShopOwner = !!userProfile?.shopId;
+  const currentUserAddress: string | undefined = userProfile?.address;
 
   const allReviews = data?.data || [];
   const hasReviews = allReviews.length > 0;
@@ -87,6 +87,7 @@ export function useServiceReviews() {
     stats,
     hasReviews,
     isShopOwner,
+    currentUserAddress,
 
     // State
     ratingFilter,

--- a/mobile/feature/services/services-main/screens/shared/ServiceReviewsScreen.tsx
+++ b/mobile/feature/services/services-main/screens/shared/ServiceReviewsScreen.tsx
@@ -23,6 +23,7 @@ export default function ServiceReviewsScreen() {
     stats,
     hasReviews,
     isShopOwner,
+    currentUserAddress,
     ratingFilter,
     refreshing,
     isLoading,
@@ -92,6 +93,7 @@ export default function ServiceReviewsScreen() {
                   key={review.reviewId}
                   review={review}
                   isShopOwner={isShopOwner}
+                  currentUserAddress={currentUserAddress}
                   onReviewUpdated={refetch}
                 />
               ))}

--- a/mobile/feature/services/services-main/services-tab/components/ShopServiceDetailsModal.tsx
+++ b/mobile/feature/services/services-main/services-tab/components/ShopServiceDetailsModal.tsx
@@ -247,7 +247,6 @@ export function ShopServiceDetailsModal({
     setSubmittingResponse(true);
     try {
       await serviceApi.addShopResponse(reviewId, responseText);
-      Alert.alert("Success", "Response added successfully!");
       setRespondingTo(null);
       setResponseText("");
       // Reload reviews

--- a/mobile/feature/services/services-main/services-tab/hooks/useServicesTabQuery.ts
+++ b/mobile/feature/services/services-main/services-tab/hooks/useServicesTabQuery.ts
@@ -11,7 +11,6 @@ import {
   UpdateServiceData,
 } from "@/feature/services/services/service.interface";
 import { appointmentApi } from "@/feature/services/services/service.services";
-import { ReviewData } from "@/feature/services/services/service.interface";
 
 // ============================================
 // Shop Service Queries
@@ -194,14 +193,13 @@ export function useShopReviewsQuery() {
 }
 
 export function useShopReviewResponseMutation() {
-  const { showSuccess, showError } = useAppToast();
+  const { showError } = useAppToast();
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: ({ reviewId, response }: { reviewId: string; response: string }) =>
       serviceApi.addShopResponse(reviewId, response),
     onSuccess: () => {
-      showSuccess("Response added successfully!");
       queryClient.invalidateQueries({ queryKey: ["shopReviews"] });
     },
     onError: (err: any) => {

--- a/mobile/feature/services/services/service.interface.ts
+++ b/mobile/feature/services/services/service.interface.ts
@@ -246,6 +246,16 @@ export interface SubmitReviewData {
   images?: string[];
 }
 
+export interface ReviewReply {
+  id: string;
+  reviewId: string;
+  authorAddress: string;
+  authorType: 'customer' | 'shop';
+  content: string;
+  createdAt: string;
+  updatedAt: string | null;
+}
+
 export interface ReviewData {
   reviewId: string;
   orderId: string;
@@ -258,6 +268,11 @@ export interface ReviewData {
   images: string[] | null;
   shopResponse: string | null;
   shopResponseAt: string | null;
+  customerReply: string | null;
+  customerReplyAt: string | null;
+  shopRejoinder: string | null;
+  shopRejoinderAt: string | null;
+  replies: ReviewReply[];
   helpfulCount: number;
   createdAt: string;
   updatedAt: string;

--- a/mobile/feature/services/services/service.services.ts
+++ b/mobile/feature/services/services/service.services.ts
@@ -32,6 +32,7 @@ import {
   DisputeResponse,
   NoShowPolicy,
   ServiceGroupLink,
+  ReviewReply,
 } from "@/feature/services/services/service.interface";
 import { apiClient } from "@/shared/utilities/axios";
 
@@ -224,6 +225,102 @@ class ServiceApi {
       });
     } catch (error: any) {
       console.error("Failed to add shop response:", error.message);
+      throw error;
+    }
+  }
+
+  async addCustomerReply(
+    reviewId: string,
+    reply: string
+  ): Promise<{ success: boolean; message?: string }> {
+    try {
+      return await apiClient.post(`/services/reviews/${reviewId}/reply`, { reply });
+    } catch (error: any) {
+      console.error("Failed to add customer reply:", error.message);
+      throw error;
+    }
+  }
+
+  async updateCustomerReply(
+    reviewId: string,
+    reply: string
+  ): Promise<{ success: boolean; message?: string }> {
+    try {
+      return await apiClient.put(`/services/reviews/${reviewId}/reply`, { reply });
+    } catch (error: any) {
+      console.error("Failed to update customer reply:", error.message);
+      throw error;
+    }
+  }
+
+  async updateReview(
+    reviewId: string,
+    data: { rating?: number; comment?: string }
+  ): Promise<{ success: boolean; message?: string }> {
+    try {
+      return await apiClient.put(`/services/reviews/${reviewId}`, data);
+    } catch (error: any) {
+      console.error("Failed to update review:", error.message);
+      throw error;
+    }
+  }
+
+  async updateShopResponse(
+    reviewId: string,
+    response: string
+  ): Promise<{ success: boolean; message?: string }> {
+    try {
+      return await apiClient.put(`/services/reviews/${reviewId}/respond`, { response });
+    } catch (error: any) {
+      console.error("Failed to update shop response:", error.message);
+      throw error;
+    }
+  }
+
+  async addShopRejoinder(
+    reviewId: string,
+    rejoinder: string
+  ): Promise<{ success: boolean; message?: string }> {
+    try {
+      return await apiClient.post(`/services/reviews/${reviewId}/rejoinder`, { rejoinder });
+    } catch (error: any) {
+      console.error("Failed to add shop rejoinder:", error.message);
+      throw error;
+    }
+  }
+
+  async updateShopRejoinder(
+    reviewId: string,
+    rejoinder: string
+  ): Promise<{ success: boolean; message?: string }> {
+    try {
+      return await apiClient.put(`/services/reviews/${reviewId}/rejoinder`, { rejoinder });
+    } catch (error: any) {
+      console.error("Failed to update shop rejoinder:", error.message);
+      throw error;
+    }
+  }
+
+  async addThreadReply(
+    reviewId: string,
+    content: string
+  ): Promise<{ success: boolean; data: ReviewReply }> {
+    try {
+      return await apiClient.post(`/services/reviews/${reviewId}/thread`, { content });
+    } catch (error: any) {
+      console.error("Failed to add thread reply:", error.message);
+      throw error;
+    }
+  }
+
+  async editThreadReply(
+    replyId: string,
+    content: string
+  ): Promise<{ success: boolean; data: ReviewReply }> {
+    try {
+      return await apiClient.put(`/services/reviews/thread/${replyId}`, { content });
+    } catch (error: any) {
+      console.error("Failed to edit thread reply:", error.message);
       throw error;
     }
   }

--- a/mobile/shared/constants/notifications.ts
+++ b/mobile/shared/constants/notifications.ts
@@ -78,4 +78,17 @@ export const NOTIFICATION_ROUTES = {
     shop: "/(dashboard)/shop/subscription",
     customer: null,
   },
+  // Review notifications
+  customer_review_received: {
+    shop: "/(dashboard)/shop/tabs/service",
+    customer: null,
+  },
+  shop_review_response: {
+    shop: null,
+    customer: "/(dashboard)/customer/tabs/service",
+  },
+  review_comment: {
+    shop: "/(dashboard)/shop/tabs/service",
+    customer: "/(dashboard)/customer/tabs/service",
+  },
 } as const;

--- a/mobile/shared/utilities/notificationHelpers.tsx
+++ b/mobile/shared/utilities/notificationHelpers.tsx
@@ -84,11 +84,20 @@ export function getNavigationRoute(
   notification: Notification,
   userType: string | null
 ): string | null {
-  const { notificationType } = notification;
+  const { notificationType, metadata } = notification;
+  const isShop = userType === "shop";
+
+  // Review notifications: deep-link to the specific service's reviews when serviceId is present
+  const reviewTypes = ["customer_review_received", "shop_review_response", "review_comment"];
+  if (reviewTypes.includes(notificationType) && metadata?.serviceId) {
+    return isShop
+      ? `/(dashboard)/shop/service/${metadata.serviceId}/reviews`
+      : `/(dashboard)/customer/review/service/${metadata.serviceId}`;
+  }
+
   const routes = NOTIFICATION_ROUTES[notificationType as keyof typeof NOTIFICATION_ROUTES];
 
   if (!routes) return null;
 
-  const isShop = userType === "shop";
   return isShop ? routes.shop : routes.customer;
 }


### PR DESCRIPTION
## Summary
- Replace single `shop_rejoinder` column with `review_replies` table (migration 138)
- Unlimited alternating-turn replies enforced server-side (customer → shop → customer → ...)
- Timeline UI with avatar circles and vertical connector line
- Thread collapses to last 2 replies by default with "Show X more" toggle
- Both full-screen ReviewCard and compact UnifiedReviewsSection updated

## Changes
- `backend/migrations/138_add_review_replies_table.sql` — new replies table
- `backend/src/repositories/ReviewRepository.ts` — batch-fetch replies, add/edit reply methods
- `backend/src/domains/ServiceDomain/controllers/ReviewController.ts` — alternating-turn enforcement
- `mobile/feature/services/services/service.interface.ts` — `ReviewReply` interface, `replies[]` on `ReviewData`
- `mobile/feature/services/services/service.services.ts` — `addThreadReply`, `editThreadReply` API calls
- `mobile/.../ReviewCard.tsx` — full thread UI with collapse/expand
- `mobile/.../UnifiedReviewsSection.tsx` — compact thread UI with collapse/expand

## Test plan
- [ ] Customer can reply after shop responds
- [ ] Shop can reply after customer replies
- [ ] Neither party can reply twice in a row
- [ ] Thread collapses when more than 2 replies exist
- [ ] "Show X more" expands all replies
- [ ] Edit own reply works
