### PR TITLE
fix(marketplace): show favorited hearts in favorites view & consistent card button spacing

### DIFF
--- a/backend/src/domains/ServiceDomain/controllers/FavoriteController.ts
+++ b/backend/src/domains/ServiceDomain/controllers/FavoriteController.ts
@@ -130,6 +130,7 @@ export class FavoriteController {
         averageRating: item.averageRating,
         reviewCount: item.reviewCount,
         active: true,
+        isFavorited: true,
         companyName: item.shopName, // Map shopName to companyName
         shopAddress: item.shopAddress,
         shopIsVerified: item.shopIsVerified || false,

--- a/frontend/src/components/customer/ServiceCard.tsx
+++ b/frontend/src/components/customer/ServiceCard.tsx
@@ -95,8 +95,8 @@ export const ServiceCard: React.FC<ServiceCardProps> = ({
           </div>
         )}
 
-        {/* Favorite Button - Top Right */}
-        <div className="absolute top-3 right-3 z-10">
+        {/* Favorite + Share Buttons - Top Right (stacked) */}
+        <div className="absolute top-3 right-3 z-20 flex flex-col gap-2">
           <FavoriteButton
             serviceId={service.serviceId}
             initialIsFavorited={service.isFavorited}
@@ -104,10 +104,6 @@ export const ServiceCard: React.FC<ServiceCardProps> = ({
             className="ring-2 ring-white/20"
             onFavoriteChange={(isFavorited) => onFavoriteChange?.(service.serviceId, isFavorited)}
           />
-        </div>
-
-        {/* Share Button - Top Right (below favorite) */}
-        <div className="absolute top-14 right-3 z-10">
           <ShareButton
             serviceId={service.serviceId}
             serviceName={service.serviceName}


### PR DESCRIPTION
## Summary

  Two independent fixes for the customer **Services & Bookings → Marketplace**.

  ### 1. Favorited services show an empty heart in the Favorites filter
  **Steps to reproduce:** Marketplace → favorite a service (heart fills) → click the **Favorites** filter → services there show the heart as
  *unclicked*.

  **Cause:** `FavoriteController.getCustomerFavorites` builds a transformed response object per service but never set `isFavorited`. Every item
  arrived with `isFavorited === undefined`, so `ServiceCard` → `FavoriteButton` initialized to `false` and rendered an empty heart. (The regular
  marketplace doesn't hit this because its queries compute `isFavorited` from the customer address.)

  **Fix:** set `isFavorited: true` on each item in the transform — everything this endpoint returns is by definition a favorite.

  ### 2. Inconsistent spacing between the favorite and share buttons across cards
  **Cause:** the two buttons were separately positioned absolute elements (`top-3` / `top-14`, both `z-10`). On out-of-stock/low-stock cards the
  inventory banner (`z-20`) rendered above the buttons and overlapped the favorite, so the favorite↔share spacing looked different from in-stock
  cards. The fixed offsets also left the `ring-2` rings nearly touching.

  **Fix:** stack both buttons in a single flex column (`flex flex-col gap-2`) for one guaranteed-consistent gap on every card, and raise the
  container to `z-20` so the inventory banner never overlaps them.