### PR TITLE
fix(ui): mobile responsiveness & modal overflow fixes

### DIFF
--- a/frontend/src/components/admin/tabs/SubscriptionManagementTab.tsx
+++ b/frontend/src/components/admin/tabs/SubscriptionManagementTab.tsx
@@ -862,10 +862,10 @@ export default function SubscriptionManagementTab() {
               <button
                 onClick={handleSync}
                 disabled={syncing || loading}
-                className="px-3 sm:px-4 py-2 bg-[#FFCC00] text-black border border-yellow-500 rounded-3xl hover:bg-yellow-500 transition-all text-sm font-medium disabled:opacity-50 flex items-center gap-2"
+                className="w-full sm:w-auto px-3 sm:px-4 py-2 bg-[#FFCC00] text-black border border-yellow-500 rounded-3xl hover:bg-yellow-500 transition-all text-sm font-medium disabled:opacity-50 flex items-center justify-center gap-2"
               >
                 <RefreshCw className={`w-4 h-4 ${syncing ? "animate-spin" : ""}`} />
-                <span className="hidden sm:inline">{syncing ? "Syncing..." : "Sync Stripe"}</span>
+                <span>{syncing ? "Syncing..." : "Sync Stripe"}</span>
               </button>
             </div>
           </div>

--- a/frontend/src/components/customer/DisputeModal.tsx
+++ b/frontend/src/components/customer/DisputeModal.tsx
@@ -99,9 +99,9 @@ export default function DisputeModal({
 
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-zinc-900 border border-zinc-700 rounded-2xl w-full max-w-lg shadow-2xl">
+      <div className="bg-zinc-900 border border-zinc-700 rounded-2xl w-full max-w-lg shadow-2xl flex flex-col max-h-[calc(100vh-2rem)]">
         {/* Header */}
-        <div className="flex items-center justify-between p-6 border-b border-zinc-700">
+        <div className="flex items-center justify-between p-6 border-b border-zinc-700 shrink-0">
           <div className="flex items-center gap-3">
             <div className="p-2 bg-orange-500/10 rounded-lg">
               <AlertTriangle className="w-5 h-5 text-orange-400" />
@@ -120,7 +120,7 @@ export default function DisputeModal({
         </div>
 
         {/* Content */}
-        <div className="p-6 space-y-5">
+        <div className="p-6 space-y-5 overflow-y-auto flex-1">
           {/* Success State */}
           {result?.success && (
             <div
@@ -254,7 +254,7 @@ export default function DisputeModal({
 
         {/* Footer */}
         {!result?.success && daysRemaining > 0 && (
-          <div className="flex gap-3 p-6 pt-0">
+          <div className="flex gap-3 p-6 pt-4 border-t border-zinc-700 shrink-0">
             <button
               onClick={onClose}
               className="flex-1 py-2.5 border border-zinc-700 text-zinc-300 hover:bg-zinc-800 rounded-lg text-sm transition-colors"
@@ -272,7 +272,7 @@ export default function DisputeModal({
         )}
 
         {!result?.success && daysRemaining === 0 && (
-          <div className="p-6 pt-0">
+          <div className="p-6 pt-4 border-t border-zinc-700 shrink-0">
             <button
               onClick={onClose}
               className="w-full py-2.5 border border-zinc-700 text-zinc-300 hover:bg-zinc-800 rounded-lg text-sm transition-colors"

--- a/frontend/src/components/shop/ServiceQRModal.tsx
+++ b/frontend/src/components/shop/ServiceQRModal.tsx
@@ -94,9 +94,9 @@ export const ServiceQRModal: React.FC<ServiceQRModalProps> = ({
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50 p-4">
-      <div className="bg-[#101010] rounded-xl border border-gray-800 max-w-md w-full overflow-hidden">
+      <div className="bg-[#101010] rounded-xl border border-gray-800 max-w-md w-full overflow-hidden flex flex-col max-h-[calc(100vh-2rem)]">
         {/* Header */}
-        <div className="px-6 py-4 border-b border-gray-800 flex items-center justify-between">
+        <div className="px-6 py-4 border-b border-gray-800 flex items-center justify-between shrink-0">
           <div>
             <h2 className="text-xl font-bold text-white">Service QR Code</h2>
             <p className="text-sm text-gray-400 mt-1">Share this code with customers</p>
@@ -110,7 +110,7 @@ export const ServiceQRModal: React.FC<ServiceQRModalProps> = ({
         </div>
 
         {/* QR Code */}
-        <div className="px-6 py-8 flex flex-col items-center">
+        <div className="px-6 py-8 flex flex-col items-center overflow-y-auto flex-1">
           <div className="bg-white p-6 rounded-xl shadow-lg">
             <canvas ref={canvasRef} />
           </div>
@@ -146,7 +146,7 @@ export const ServiceQRModal: React.FC<ServiceQRModalProps> = ({
         </div>
 
         {/* Actions */}
-        <div className="px-6 py-4 border-t border-gray-800 flex gap-3">
+        <div className="px-6 py-4 border-t border-gray-800 flex gap-3 shrink-0">
           <button
             onClick={handleDownload}
             className="flex-1 py-3 bg-[#FFCC00] hover:bg-[#e6b800] text-[#101010] font-semibold rounded-lg transition-colors flex items-center justify-center gap-2"
@@ -164,7 +164,7 @@ export const ServiceQRModal: React.FC<ServiceQRModalProps> = ({
         </div>
 
         {/* Instructions */}
-        <div className="px-6 py-4 bg-[#1a1a1a] border-t border-gray-800">
+        <div className="px-6 py-4 bg-[#1a1a1a] border-t border-gray-800 shrink-0">
           <p className="text-xs text-gray-400 text-center">
             Customers can scan this QR code to view and book this service directly
           </p>

--- a/frontend/src/components/shop/modals/ServiceExportModal.tsx
+++ b/frontend/src/components/shop/modals/ServiceExportModal.tsx
@@ -46,9 +46,9 @@ export const ServiceExportModal: React.FC<ServiceExportModalProps> = ({ onClose 
 
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-      <div className="bg-[#1A1A1A] rounded-2xl shadow-2xl w-full max-w-md border border-gray-800 overflow-hidden">
+      <div className="bg-[#1A1A1A] rounded-2xl shadow-2xl w-full max-w-md border border-gray-800 overflow-hidden flex flex-col max-h-[calc(100vh-2rem)]">
         {/* Header */}
-        <div className="flex items-center justify-between p-6 border-b border-gray-800">
+        <div className="flex items-center justify-between p-6 border-b border-gray-800 shrink-0">
           <div className="flex items-center gap-3">
             <div className="p-2 bg-[#FFCC00]/10 rounded-lg">
               <Download className="h-5 w-5 text-[#FFCC00]" />
@@ -67,7 +67,7 @@ export const ServiceExportModal: React.FC<ServiceExportModalProps> = ({ onClose 
         </div>
 
         {/* Content */}
-        <div className="p-6 space-y-6">
+        <div className="p-6 space-y-6 overflow-y-auto flex-1">
           {/* File Format Selection */}
           <div>
             <label className="block text-sm font-semibold text-white mb-3">
@@ -207,7 +207,7 @@ export const ServiceExportModal: React.FC<ServiceExportModalProps> = ({ onClose 
         </div>
 
         {/* Footer */}
-        <div className="flex gap-3 p-6 border-t border-gray-800 bg-gray-900/30">
+        <div className="flex gap-3 p-6 border-t border-gray-800 bg-gray-900/30 shrink-0">
           <button
             type="button"
             onClick={onClose}

--- a/frontend/src/components/shop/tabs/AppointmentsTab.tsx
+++ b/frontend/src/components/shop/tabs/AppointmentsTab.tsx
@@ -613,7 +613,7 @@ export const AppointmentsTab: React.FC<AppointmentsTabProps> = ({ defaultSubTab 
         {/* Status badge and payment link button */}
         <div className="mt-1.5 sm:mt-2 flex items-center justify-between gap-2">
           <span className={`text-[9px] sm:text-[10px] px-1.5 sm:px-2 py-0.5 rounded-full font-medium ${badgeBg}`}>
-            {booking.status.charAt(0).toUpperCase() + booking.status.slice(1)}
+            {(booking.status.charAt(0).toUpperCase() + booking.status.slice(1)).replace(/_/g, ' ')}
           </span>
           {/* Show payment link button for pending (unpaid) bookings */}
           {booking.status === 'pending' && (

--- a/frontend/src/components/ui/FilterTabs.tsx
+++ b/frontend/src/components/ui/FilterTabs.tsx
@@ -21,12 +21,14 @@ export const FilterTabs: React.FC<FilterTabsProps> = ({
   className = "",
 }) => {
   return (
-    <div className={`flex flex-wrap gap-2 ${className}`}>
+    <div
+      className={`flex gap-2 overflow-x-auto sm:flex-wrap sm:overflow-visible ${className}`}
+    >
       {tabs.map((tab) => (
         <button
           key={tab.value}
           onClick={() => onTabChange(tab.value)}
-          className={`px-4 py-2 rounded-lg border text-sm font-medium transition-colors duration-150 ${
+          className={`shrink-0 whitespace-nowrap px-4 py-2 rounded-lg border text-sm font-medium transition-colors duration-150 ${
             activeTab === tab.value
               ? "bg-yellow-400 text-gray-900 border-yellow-400"
               : "bg-[#1A1A1A] border-gray-800 text-gray-400 hover:bg-gray-800 hover:text-white"


### PR DESCRIPTION
## Summary
A batch of small UI fixes targeting mobile/laptop responsiveness and modal usability. No backend or logic changes — CSS/markup and one display-string tweak only.

## Changes

**Modal overflow on short viewports** — three modals grew past the screen and clipped their content (textarea, notes, action buttons) with no way to scroll. Each now caps at the viewport height with a fixed header/footer and a scrollable body:
- `DisputeModal` (no-show dispute)
- `ServiceExportModal` (export services)
- `ServiceQRModal` (share QR code)

**Appointments status label** — `AppointmentsTab` rendered the `no_show` status as "No_show". Now displays "No show" (underscore stripped).

**Sync Stripe button** — in `SubscriptionManagementTab` the button was missing its label on mobile and stretched oddly. Now full-width with a visible label on mobile, normal-sized next to the search on desktop.

**Filter tabs (shared `FilterTabs`)** — on mobile the tabs wrapped into ragged, uneven rows. Now a single horizontally-scrollable row on mobile; wrap behavior on `sm+` is unchanged, so all 9 consumers look identical on desktop.

## Testing
- Verified on narrow (≈360–414px) and laptop (1366×768) widths.
- Confirmed each modal scrolls internally with header/footer pinned and all controls reachable.
- Desktop layouts unchanged for the Sync button and filter tabs.