### PR TITLE
fix(campaign-rewards): renumber migrations 136/137 to 141/142 (number collision)

### DIFF
--- a/backend/migrations/141_campaign_rewards.sql
+++ b/backend/migrations/141_campaign_rewards.sql
@@ -1,4 +1,4 @@
--- 136_campaign_rewards.sql
+-- 141_campaign_rewards.sql
 --
 -- Campaign Rewards — Phase 0 (foundation).
 -- See docs/tasks/strategy/campaign-rewards/.

--- a/backend/migrations/142_add_campaign_rewards_enabled.sql
+++ b/backend/migrations/142_add_campaign_rewards_enabled.sql
@@ -1,4 +1,4 @@
--- 137_add_campaign_rewards_enabled.sql
+-- 142_add_campaign_rewards_enabled.sql
 --
 -- Campaign Rewards — Phase 0. Per-shop admin kill switch, mirroring
 -- ai_images_enabled (migration 134). Default OFF for a controlled rollout:

--- a/backend/src/repositories/MarketingCampaignRepository.ts
+++ b/backend/src/repositories/MarketingCampaignRepository.ts
@@ -21,7 +21,7 @@ export interface MarketingCampaign {
   couponType: 'fixed' | 'percentage' | null;
   couponExpiresAt: Date | null;
   serviceId: string | null;
-  // Campaign rewards (migration 136). Default reward_type 'none' = message-only.
+  // Campaign rewards (migration 141). Default reward_type 'none' = message-only.
   rewardType: 'none' | 'rcn' | 'coupon';
   rewardMode: 'flat' | 'by_tier' | 'by_spend' | null;
   rewardRcnAmount: number | null;
@@ -51,7 +51,7 @@ export interface CampaignRecipient {
   inAppSentAt: Date | null;
   inAppReadAt: Date | null;
   deliveryError: string | null;
-  // Reward ledger (migration 136) — the per-recipient idempotency anchor.
+  // Reward ledger (migration 141) — the per-recipient idempotency anchor.
   rewardKind: 'rcn' | 'coupon' | null;
   rewardAmount: number | null;
   rewardStatus: 'pending' | 'issued' | 'redeemed' | 'skipped' | 'failed' | 'expired' | null;
@@ -546,7 +546,7 @@ export class MarketingCampaignRepository extends BaseRepository {
     }
   }
 
-  // ---- Campaign rewards (migration 136) ----
+  // ---- Campaign rewards (migration 141) ----
 
   /** Set/clear the reward config on a campaign. Used by the AI draft + the
    *  manual builder. Only writes the fields provided. */


### PR DESCRIPTION
The campaign-rewards migrations collided with the reviews migrations (136_add_customer_reply_to_reviews, 137_add_shop_rejoinder_to_reviews), which were created first (Jun 8) and recorded versions 136/137 in schema_migrations.

The runner (scripts/run-migrations.ts) tracks applied migrations by the integer version (schema_migrations PRIMARY KEY), parsed from the leading NNN_, NOT the filename. So a duplicate number makes one file's SQL silently skip on any DB where the version is already recorded. On prod the reviews 136/137 recorded first, so the campaign-rewards SQL never ran (campaign tables/columns missing).

Renumbered to 141/142 (next free above main's max of 140) so the runner applies them as new on the next deploy. They are idempotent (IF NOT EXISTS), so re-running where the schema already exists (staging) is a no-op. The reviews migrations keep 136/137.

Also updates the "(migration 136)" comments in MarketingCampaignRepository.