### PR TITLE
feat(marketing): manual campaign rewards (RCN + coupon)

### DIFF
--- a/backend/src/domains/MarketingDomain/controllers/MarketingController.ts
+++ b/backend/src/domains/MarketingDomain/controllers/MarketingController.ts
@@ -5,6 +5,11 @@ import { ContactRepository } from '../../../repositories/ContactRepository';
 import { EmailService } from '../../../services/EmailService';
 import { campaignEmailService } from '../../../services/CampaignEmailService';
 import { campaignRewardService, CampaignRewardBlockedError } from '../../../services/CampaignRewardService';
+import {
+  parseCampaignRewardInput,
+  rewardInputWrites,
+  CampaignRewardInputError
+} from './campaignRewardInput';
 import { logger } from '../../../utils/logger';
 
 export class MarketingController {
@@ -136,7 +141,8 @@ export class MarketingController {
         couponType,
         couponExpiresAt,
         serviceId,
-        manualEmails
+        manualEmails,
+        reward
       } = req.body;
 
       // Verify shop ownership using shopId from JWT (works for both wallet and social login)
@@ -151,6 +157,22 @@ export class MarketingController {
         return;
       }
 
+      let rewardInput;
+      try {
+        rewardInput = parseCampaignRewardInput(reward);
+      } catch (error) {
+        if (error instanceof CampaignRewardInputError) {
+          res.status(400).json({ success: false, error: error.message });
+          return;
+        }
+        throw error;
+      }
+
+      if (rewardInputWrites(rewardInput) && !(await this.marketingService.isCampaignRewardsEnabled(shopId))) {
+        res.status(403).json({ success: false, error: 'Campaign rewards are not enabled for this shop' });
+        return;
+      }
+
       const processedManualEmails = await this.processManualEmails(shopId, manualEmails);
 
       // Merge manual emails into audienceFilters
@@ -159,7 +181,7 @@ export class MarketingController {
         ...(processedManualEmails.length > 0 && { manualEmails: processedManualEmails })
       };
 
-      const campaign = await this.marketingService.createCampaign({
+      const createParams = {
         shopId,
         name,
         campaignType,
@@ -175,7 +197,19 @@ export class MarketingController {
         couponType,
         couponExpiresAt: couponExpiresAt ? new Date(couponExpiresAt) : undefined,
         serviceId
-      });
+      };
+
+      // A coupon reward stores its bonus RCN + expiry on the campaign's coupon_*
+      // columns; the code itself is minted at send.
+      if (rewardInputWrites(rewardInput) && rewardInput.config.rewardType === 'coupon') {
+        createParams.couponValue = rewardInput.config.couponValue;
+        createParams.couponType = 'fixed';
+        createParams.couponExpiresAt = rewardInput.config.couponExpiresAt ?? undefined;
+      }
+
+      const campaign = rewardInputWrites(rewardInput)
+        ? await this.marketingService.createCampaignWithReward(createParams, rewardInput.config)
+        : await this.marketingService.createCampaign(createParams);
 
       res.status(201).json({
         success: true,
@@ -239,8 +273,25 @@ export class MarketingController {
         couponType,
         couponExpiresAt,
         serviceId,
-        manualEmails
+        manualEmails,
+        reward
       } = req.body;
+
+      let rewardInput;
+      try {
+        rewardInput = parseCampaignRewardInput(reward);
+      } catch (error) {
+        if (error instanceof CampaignRewardInputError) {
+          res.status(400).json({ success: false, error: error.message });
+          return;
+        }
+        throw error;
+      }
+
+      if (rewardInputWrites(rewardInput) && !(await this.marketingService.isCampaignRewardsEnabled(existing.shopId))) {
+        res.status(403).json({ success: false, error: 'Campaign rewards are not enabled for this shop' });
+        return;
+      }
 
       const processedManualEmails = await this.processManualEmails(existing.shopId, manualEmails);
       const updatedAudienceFilters = audienceFilters !== undefined
@@ -250,7 +301,7 @@ export class MarketingController {
           }
         : audienceFilters;
 
-      const campaign = await this.marketingService.updateCampaign(campaignId, {
+      const updateParams = {
         name,
         subject,
         previewText,
@@ -264,7 +315,26 @@ export class MarketingController {
         couponType,
         couponExpiresAt: couponExpiresAt ? new Date(couponExpiresAt) : undefined,
         serviceId
-      });
+      };
+
+      // A coupon reward stores its bonus RCN + expiry on the campaign's coupon_*
+      // columns; the code itself is minted at send.
+      if (rewardInputWrites(rewardInput) && rewardInput.config.rewardType === 'coupon') {
+        updateParams.couponValue = rewardInput.config.couponValue;
+        updateParams.couponType = 'fixed';
+        updateParams.couponExpiresAt = rewardInput.config.couponExpiresAt ?? undefined;
+      }
+
+      const campaign = await this.marketingService.updateCampaign(campaignId, updateParams);
+
+      // Apply reward changes only when the caller sent a `reward` field
+      // (omitted → left untouched; null / { type: 'none' } → cleared).
+      if (rewardInput.action !== 'ignore') {
+        await this.marketingService.setCampaignReward(campaignId, rewardInput.config);
+        const refreshed = await this.marketingService.getCampaign(campaignId);
+        res.json({ success: true, data: refreshed ?? campaign });
+        return;
+      }
 
       res.json({ success: true, data: campaign });
     } catch (error: any) {

--- a/backend/src/domains/MarketingDomain/controllers/campaignRewardInput.ts
+++ b/backend/src/domains/MarketingDomain/controllers/campaignRewardInput.ts
@@ -1,0 +1,181 @@
+export type SetCampaignRewardConfig = {
+  rewardType: 'none' | 'rcn' | 'coupon';
+  rewardMode: 'flat' | 'by_tier' | 'by_spend' | null;
+  rewardRcnAmount: number | null;
+  rewardRcnByTier: Record<string, number> | null;
+  rewardSpendBands: Array<{ minSpend: number; rcn: number }> | null;
+  fulfillmentTrigger: 'on_send' | 'on_return';
+  returnWindowDays: number | null;
+  // Coupon reward: bonus RCN granted by a one-per-customer code minted at send.
+  // These ride on the campaign's coupon_* columns, not the reward ledger.
+  couponValue: number | null;
+  couponExpiresAt: Date | null;
+};
+
+const COUPON_RCN_MAX = 10000;
+const COUPON_EXPIRES_DAYS_DEFAULT = 60;
+
+export type CampaignRewardInput =
+  | { action: 'ignore' }
+  | { action: 'clear'; config: SetCampaignRewardConfig }
+  | { action: 'set'; config: SetCampaignRewardConfig };
+
+export function rewardInputWrites(
+  input: CampaignRewardInput
+): input is { action: 'set'; config: SetCampaignRewardConfig } {
+  return input.action === 'set';
+}
+
+export class CampaignRewardInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CampaignRewardInputError';
+  }
+}
+
+const CLEARED: SetCampaignRewardConfig = {
+  rewardType: 'none',
+  rewardMode: null,
+  rewardRcnAmount: null,
+  rewardRcnByTier: null,
+  rewardSpendBands: null,
+  fulfillmentTrigger: 'on_send',
+  returnWindowDays: null,
+  couponValue: null,
+  couponExpiresAt: null,
+};
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v);
+}
+
+export function parseCampaignRewardInput(reward: unknown): CampaignRewardInput {
+  if (reward === undefined) {
+    return { action: 'ignore' };
+  }
+  if (reward === null) {
+    return { action: 'clear', config: { ...CLEARED } };
+  }
+  if (typeof reward !== 'object') {
+    throw new CampaignRewardInputError('reward must be an object, null, or omitted');
+  }
+
+  const r = reward as Record<string, unknown>;
+  const type = r.type;
+
+  if (type === undefined || type === 'none') {
+    return { action: 'clear', config: { ...CLEARED } };
+  }
+  if (type === 'coupon') {
+    if (!isFiniteNumber(r.couponValue) || r.couponValue <= 0) {
+      throw new CampaignRewardInputError('Coupon reward requires couponValue (bonus RCN) > 0');
+    }
+    if (r.couponValue > COUPON_RCN_MAX) {
+      throw new CampaignRewardInputError(`Coupon bonus RCN cannot exceed ${COUPON_RCN_MAX}`);
+    }
+    let days = COUPON_EXPIRES_DAYS_DEFAULT;
+    if (r.couponExpiresDays !== undefined) {
+      if (!isFiniteNumber(r.couponExpiresDays) || r.couponExpiresDays <= 0) {
+        throw new CampaignRewardInputError('couponExpiresDays must be a number > 0');
+      }
+      days = Math.min(365, Math.round(r.couponExpiresDays));
+    }
+    return {
+      action: 'set',
+      config: {
+        ...CLEARED,
+        rewardType: 'coupon',
+        couponValue: r.couponValue,
+        couponExpiresAt: new Date(Date.now() + days * 86400000),
+      },
+    };
+  }
+  if (type !== 'rcn') {
+    throw new CampaignRewardInputError(`Unsupported reward type: ${String(type)}`);
+  }
+
+  const mode = r.mode;
+  if (mode !== 'flat' && mode !== 'by_tier' && mode !== 'by_spend') {
+    throw new CampaignRewardInputError("reward.mode must be 'flat', 'by_tier', or 'by_spend'");
+  }
+
+  let rewardRcnAmount: number | null = null;
+  let rewardRcnByTier: Record<string, number> | null = null;
+  let rewardSpendBands: Array<{ minSpend: number; rcn: number }> | null = null;
+
+  if (mode === 'flat') {
+    if (!isFiniteNumber(r.rcnAmount) || r.rcnAmount <= 0) {
+      throw new CampaignRewardInputError('Flat reward requires rcnAmount > 0');
+    }
+    rewardRcnAmount = r.rcnAmount;
+  } else if (mode === 'by_tier') {
+    const byTier = r.rcnByTier;
+    if (!byTier || typeof byTier !== 'object' || Array.isArray(byTier)) {
+      throw new CampaignRewardInputError('By-tier reward requires an rcnByTier object');
+    }
+    const entries = Object.entries(byTier as Record<string, unknown>);
+    if (entries.length === 0) {
+      throw new CampaignRewardInputError('By-tier reward requires at least one tier amount');
+    }
+    const cleaned: Record<string, number> = {};
+    for (const [tier, value] of entries) {
+      if (!isFiniteNumber(value) || value < 0) {
+        throw new CampaignRewardInputError(`By-tier amount for "${tier}" must be a number >= 0`);
+      }
+      cleaned[tier] = value;
+    }
+    if (!Object.values(cleaned).some((v) => v > 0)) {
+      throw new CampaignRewardInputError('By-tier reward needs at least one tier with amount > 0');
+    }
+    rewardRcnByTier = cleaned;
+  } else {
+    const bands = r.spendBands;
+    if (!Array.isArray(bands) || bands.length === 0) {
+      throw new CampaignRewardInputError('By-spend reward requires a non-empty spendBands array');
+    }
+    const cleaned: Array<{ minSpend: number; rcn: number }> = [];
+    for (const band of bands) {
+      const b = band as Record<string, unknown>;
+      if (!isFiniteNumber(b?.minSpend) || b.minSpend < 0) {
+        throw new CampaignRewardInputError('Each spend band requires minSpend >= 0');
+      }
+      if (!isFiniteNumber(b?.rcn) || b.rcn < 0) {
+        throw new CampaignRewardInputError('Each spend band requires rcn >= 0');
+      }
+      cleaned.push({ minSpend: b.minSpend, rcn: b.rcn });
+    }
+    if (!cleaned.some((b) => b.rcn > 0)) {
+      throw new CampaignRewardInputError('By-spend reward needs at least one band with rcn > 0');
+    }
+    rewardSpendBands = cleaned;
+  }
+
+  const fulfillmentRaw = r.fulfillment;
+  if (fulfillmentRaw !== undefined && fulfillmentRaw !== 'on_send' && fulfillmentRaw !== 'on_return') {
+    throw new CampaignRewardInputError("reward.fulfillment must be 'on_send' or 'on_return'");
+  }
+  const fulfillment: 'on_send' | 'on_return' = fulfillmentRaw === 'on_return' ? 'on_return' : 'on_send';
+
+  let returnWindowDays: number | null = null;
+  if (fulfillment === 'on_return') {
+    if (!isFiniteNumber(r.returnWindowDays) || r.returnWindowDays <= 0) {
+      throw new CampaignRewardInputError('On-return rewards require returnWindowDays > 0');
+    }
+    returnWindowDays = Math.min(365, Math.round(r.returnWindowDays));
+  }
+
+  return {
+    action: 'set',
+    config: {
+      rewardType: 'rcn',
+      rewardMode: mode,
+      rewardRcnAmount,
+      rewardRcnByTier,
+      rewardSpendBands,
+      fulfillmentTrigger: fulfillment,
+      returnWindowDays,
+      couponValue: null,
+      couponExpiresAt: null,
+    },
+  };
+}

--- a/backend/src/repositories/MarketingCampaignRepository.ts
+++ b/backend/src/repositories/MarketingCampaignRepository.ts
@@ -1,5 +1,18 @@
+import { Pool, PoolClient } from 'pg';
 import { BaseRepository, PaginatedResult, PaginationParams } from './BaseRepository';
 import { logger } from '../utils/logger';
+
+type Executor = Pick<Pool | PoolClient, 'query'>;
+
+export type CampaignRewardConfig = {
+  rewardType?: 'none' | 'rcn' | 'coupon';
+  rewardMode?: 'flat' | 'by_tier' | 'by_spend' | null;
+  rewardRcnAmount?: number | null;
+  rewardRcnByTier?: Record<string, number> | null;
+  rewardSpendBands?: Array<{ minSpend: number; rcn: number }> | null;
+  fulfillmentTrigger?: 'on_send' | 'on_return';
+  returnWindowDays?: number | null;
+};
 
 export interface MarketingCampaign {
   id: string;
@@ -115,7 +128,7 @@ export interface UpdateCampaignParams {
 
 export class MarketingCampaignRepository extends BaseRepository {
 
-  async create(params: CreateCampaignParams): Promise<MarketingCampaign> {
+  async create(params: CreateCampaignParams, executor: Executor = this.pool): Promise<MarketingCampaign> {
     const query = `
       INSERT INTO marketing_campaigns (
         shop_id, name, campaign_type, subject, preview_text,
@@ -149,7 +162,7 @@ export class MarketingCampaignRepository extends BaseRepository {
     ];
 
     try {
-      const result = await this.pool.query(query, values);
+      const result = await executor.query(query, values);
       return this.mapCampaign(result.rows[0]);
     } catch (error: any) {
       logger.error('Error creating marketing campaign:', error);
@@ -157,11 +170,23 @@ export class MarketingCampaignRepository extends BaseRepository {
     }
   }
 
-  async findById(id: string): Promise<MarketingCampaign | null> {
+  async createWithReward(
+    params: CreateCampaignParams,
+    reward: CampaignRewardConfig
+  ): Promise<MarketingCampaign> {
+    return this.withTransaction(async (client) => {
+      const campaign = await this.create(params, client);
+      await this.setReward(campaign.id, reward, client);
+      const refreshed = await this.findById(campaign.id, client);
+      return refreshed ?? campaign;
+    });
+  }
+
+  async findById(id: string, executor: Executor = this.pool): Promise<MarketingCampaign | null> {
     const query = 'SELECT * FROM marketing_campaigns WHERE id = $1';
 
     try {
-      const result = await this.pool.query(query, [id]);
+      const result = await executor.query(query, [id]);
       if (result.rows.length === 0) return null;
       return this.mapCampaign(result.rows[0]);
     } catch (error: any) {
@@ -552,15 +577,8 @@ export class MarketingCampaignRepository extends BaseRepository {
    *  manual builder. Only writes the fields provided. */
   async setReward(
     campaignId: string,
-    config: {
-      rewardType?: 'none' | 'rcn' | 'coupon';
-      rewardMode?: 'flat' | 'by_tier' | 'by_spend' | null;
-      rewardRcnAmount?: number | null;
-      rewardRcnByTier?: Record<string, number> | null;
-      rewardSpendBands?: Array<{ minSpend: number; rcn: number }> | null;
-      fulfillmentTrigger?: 'on_send' | 'on_return';
-      returnWindowDays?: number | null;
-    }
+    config: CampaignRewardConfig,
+    executor: Executor = this.pool
   ): Promise<void> {
     const updates: string[] = [];
     const values: any[] = [];
@@ -575,7 +593,7 @@ export class MarketingCampaignRepository extends BaseRepository {
     if (config.returnWindowDays !== undefined) set('return_window_days', config.returnWindowDays);
     if (updates.length === 0) return;
     values.push(campaignId);
-    await this.pool.query(
+    await executor.query(
       `UPDATE marketing_campaigns SET ${updates.join(', ')}, updated_at = NOW() WHERE id = $${i}`,
       values
     );

--- a/backend/src/services/MarketingService.ts
+++ b/backend/src/services/MarketingService.ts
@@ -4,7 +4,8 @@ import {
   MarketingCampaign,
   CreateCampaignParams,
   UpdateCampaignParams,
-  MarketingTemplate
+  MarketingTemplate,
+  CampaignRewardConfig
 } from '../repositories/MarketingCampaignRepository';
 import { NotificationRepository, CreateNotificationParams } from '../repositories/NotificationRepository';
 import { CustomerRepository } from '../repositories/CustomerRepository';
@@ -80,6 +81,16 @@ export class MarketingService {
   async createCampaign(params: CreateCampaignParams): Promise<MarketingCampaign> {
     logger.info(`Creating marketing campaign for shop ${params.shopId}`, { name: params.name });
     return this.campaignRepo.create(params);
+  }
+
+  /** Create a campaign and set its reward in a single transaction — a failed
+   *  reward write rolls back the create so no orphaned campaign is left behind. */
+  async createCampaignWithReward(
+    params: CreateCampaignParams,
+    reward: CampaignRewardConfig
+  ): Promise<MarketingCampaign> {
+    logger.info(`Creating marketing campaign with reward for shop ${params.shopId}`, { name: params.name });
+    return this.campaignRepo.createWithReward(params, reward);
   }
 
   async getCampaign(id: string): Promise<MarketingCampaign | null> {

--- a/frontend/src/components/shop/marketing/CampaignBuilderModal.tsx
+++ b/frontend/src/components/shop/marketing/CampaignBuilderModal.tsx
@@ -69,13 +69,16 @@ import {
   MarketingCampaign,
   MarketingTemplate,
   CreateCampaignData,
+  CampaignReward,
   createCampaign,
   updateCampaign,
   sendCampaign,
   scheduleCampaign,
+  rewardPrecheck,
   getShopCustomers,
   ShopCustomer,
 } from "@/services/api/marketing";
+import { getShopAiSettings } from "@/services/api/aiSettings";
 import { ShopService, getShopServices } from "@/services/api/services";
 import apiClient from "@/services/api/client";
 import { RichTextEditor } from "@/components/ui/RichTextEditor";
@@ -176,6 +179,8 @@ const colorPresets = [
   '#3B82F6', '#6366F1', '#8B5CF6', '#A855F7', '#D946EF',
   '#EC4899', '#F43F5E', '#EF4444', '#F97316', '#EAB308',
 ];
+
+const REWARD_TIERS = ['BRONZE', 'SILVER', 'GOLD'] as const;
 
 // Sortable Block Item Component
 function SortableBlockItem({
@@ -292,6 +297,43 @@ export function CampaignBuilderModal({
   const [initialLoadDone, setInitialLoadDone] = useState(false);
   const [manualEmails, setManualEmails] = useState<string>('');
 
+  // Reward configuration
+  const [rewardsEnabled, setRewardsEnabled] = useState(false);
+  const [rewardType, setRewardType] = useState<'none' | 'rcn' | 'coupon'>(
+    existingCampaign?.rewardType === 'rcn' || existingCampaign?.rewardType === 'coupon'
+      ? existingCampaign.rewardType
+      : 'none'
+  );
+  const [rewardMode, setRewardMode] = useState<'flat' | 'by_tier' | 'by_spend'>(
+    existingCampaign?.rewardMode || 'flat'
+  );
+  const [rewardFlatAmount, setRewardFlatAmount] = useState<string>(
+    existingCampaign?.rewardRcnAmount?.toString() || '5'
+  );
+  const [rewardByTier, setRewardByTier] = useState<Record<string, string>>(() => {
+    const src = existingCampaign?.rewardRcnByTier || {};
+    return Object.fromEntries(
+      REWARD_TIERS.map((t) => [t, src[t] != null ? String(src[t]) : ''])
+    );
+  });
+  const [rewardSpendBands, setRewardSpendBands] = useState<Array<{ minSpend: string; rcn: string }>>(
+    existingCampaign?.rewardSpendBands?.length
+      ? existingCampaign.rewardSpendBands.map((b) => ({ minSpend: String(b.minSpend), rcn: String(b.rcn) }))
+      : [{ minSpend: '0', rcn: '' }]
+  );
+  const [fulfillment, setFulfillment] = useState<'on_send' | 'on_return'>(
+    existingCampaign?.fulfillmentTrigger || 'on_send'
+  );
+  const [returnWindowDays, setReturnWindowDays] = useState<string>(
+    existingCampaign?.returnWindowDays?.toString() || '30'
+  );
+  const [couponBonusRcn, setCouponBonusRcn] = useState<string>(
+    existingCampaign?.rewardType === 'coupon' && existingCampaign?.couponValue != null
+      ? String(existingCampaign.couponValue)
+      : '5'
+  );
+  const [couponExpiresDays, setCouponExpiresDays] = useState<string>('60');
+
   // DnD sensors
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -339,6 +381,15 @@ export function CampaignBuilderModal({
     };
     loadServices();
   }, [shopId]);
+
+  // Whether this shop is allowed to attach campaign rewards (admin gate)
+  useEffect(() => {
+    let cancelled = false;
+    getShopAiSettings()
+      .then((s) => { if (!cancelled) setRewardsEnabled(s.campaignRewardsEnabled === true); })
+      .catch(() => { if (!cancelled) setRewardsEnabled(false); });
+    return () => { cancelled = true; };
+  }, []);
 
   // Load shop promo codes
   useEffect(() => {
@@ -619,6 +670,81 @@ export function CampaignBuilderModal({
     },
   });
 
+  const validateReward = (): string | null => {
+    if (!rewardsEnabled || rewardType === 'none') return null;
+    if (rewardType === 'coupon') {
+      const bonus = Number(couponBonusRcn);
+      if (!Number.isFinite(bonus) || bonus <= 0) return 'Coupon needs a bonus RCN amount greater than 0';
+      const days = Number(couponExpiresDays);
+      if (!Number.isFinite(days) || days <= 0) return 'Coupon expiry must be greater than 0 days';
+      return null;
+    }
+    if (rewardMode === 'flat') {
+      const amt = Number(rewardFlatAmount);
+      if (!Number.isFinite(amt) || amt <= 0) return 'Flat reward needs an RCN amount greater than 0';
+    } else if (rewardMode === 'by_tier') {
+      for (const t of REWARD_TIERS) {
+        const raw = rewardByTier[t];
+        if (raw === '' || raw == null) continue;
+        const n = Number(raw);
+        if (!Number.isFinite(n) || n < 0) return 'Tier amounts must be 0 or more';
+      }
+      if (!REWARD_TIERS.some((t) => Number(rewardByTier[t]) > 0)) {
+        return 'Set an RCN amount greater than 0 for at least one tier';
+      }
+    } else {
+      for (const b of rewardSpendBands) {
+        const min = Number(b.minSpend);
+        if (!Number.isFinite(min) || min < 0) return 'Each spend band needs a minimum spend of 0 or more';
+        if (b.rcn !== '' && (!Number.isFinite(Number(b.rcn)) || Number(b.rcn) < 0)) {
+          return 'Each spend band reward must be 0 or more';
+        }
+      }
+      if (!rewardSpendBands.some((b) => Number(b.rcn) > 0)) {
+        return 'Set an RCN amount greater than 0 for at least one spend band';
+      }
+    }
+    if (fulfillment === 'on_return') {
+      const d = Number(returnWindowDays);
+      if (!Number.isFinite(d) || d <= 0) return 'Return window must be greater than 0 days';
+    }
+    return null;
+  };
+
+  const buildReward = (): CampaignReward | undefined => {
+    if (!rewardsEnabled) return undefined;
+    if (rewardType === 'none') {
+      // Clear only a reward the builder manages (rcn/coupon); never touch an
+      // unrepresentable one.
+      const managed = existingCampaign?.rewardType === 'rcn' || existingCampaign?.rewardType === 'coupon';
+      return managed ? { type: 'none' } : undefined;
+    }
+    if (rewardType === 'coupon') {
+      return {
+        type: 'coupon',
+        couponValue: Number(couponBonusRcn),
+        couponExpiresDays: Number(couponExpiresDays),
+      };
+    }
+    const reward: CampaignReward = { type: 'rcn', mode: rewardMode, fulfillment };
+    if (rewardMode === 'flat') {
+      reward.rcnAmount = Number(rewardFlatAmount);
+    } else if (rewardMode === 'by_tier') {
+      const byTier: Record<string, number> = {};
+      for (const t of REWARD_TIERS) {
+        const raw = rewardByTier[t];
+        if (raw !== '' && raw != null) byTier[t] = Number(raw);
+      }
+      reward.rcnByTier = byTier;
+    } else {
+      reward.spendBands = rewardSpendBands
+        .filter((b) => b.rcn !== '')
+        .map((b) => ({ minSpend: Number(b.minSpend) || 0, rcn: Number(b.rcn) }));
+    }
+    if (fulfillment === 'on_return') reward.returnWindowDays = Number(returnWindowDays);
+    return reward;
+  };
+
   const persistCampaign = async (): Promise<MarketingCampaign> => {
     const serviceCardBlock = blocks.find(b => b.type === 'service_card' && b.serviceId);
     const selectedServiceId = serviceCardBlock?.serviceId;
@@ -635,6 +761,9 @@ export function CampaignBuilderModal({
       ...(selectedServiceId && { serviceId: selectedServiceId }),
       ...(manualEmails.trim() && { manualEmails: manualEmails.trim() }),
     };
+
+    const reward = buildReward();
+    if (reward !== undefined) campaignData.reward = reward;
 
     const hasCouponBlock = blocks.some(b => b.type === 'coupon');
     if (hasCouponBlock && selectedPromoCodeId) {
@@ -657,6 +786,11 @@ export function CampaignBuilderModal({
       toast.error('Please enter a campaign name');
       return;
     }
+    const rewardError = validateReward();
+    if (rewardError) {
+      toast.error(rewardError);
+      return;
+    }
 
     try {
       setSaving(true);
@@ -664,6 +798,16 @@ export function CampaignBuilderModal({
       toast.success(existingCampaign ? 'Campaign saved' : 'Campaign created');
 
       if (andSend) {
+        if (rewardsEnabled && rewardType === 'rcn' && fulfillment === 'on_send') {
+          const pre = await rewardPrecheck(savedCampaign.id);
+          if (pre.applicable && !pre.affordable) {
+            toast.error(
+              `Not enough RCN: this reward needs ${pre.required.toLocaleString()} RCN but you have ${pre.available.toLocaleString()}. Saved as a draft — buy more RCN, then send.`
+            );
+            onClose(true);
+            return;
+          }
+        }
         setSending(true);
         const result = await sendCampaign(savedCampaign.id);
         toast.success(`Campaign sent to ${result.totalRecipients} recipients!`);
@@ -691,6 +835,11 @@ export function CampaignBuilderModal({
     const when = new Date(scheduledAt);
     if (isNaN(when.getTime()) || when <= new Date()) {
       toast.error('Scheduled time must be in the future');
+      return;
+    }
+    const rewardError = validateReward();
+    if (rewardError) {
+      toast.error(rewardError);
       return;
     }
 
@@ -1862,6 +2011,242 @@ export function CampaignBuilderModal({
                 ))}
               </div>
 
+              {/* Reward */}
+              <div className="mt-8">
+                <h4 className="text-white font-medium text-sm mb-3 flex items-center gap-2">
+                  <Gift className="w-4 h-4 text-[#FFCC00]" />
+                  Reward
+                </h4>
+
+                {!rewardsEnabled ? (
+                  <div className="p-4 bg-gray-800/50 border border-gray-700 rounded-lg text-sm text-gray-400">
+                    Campaign rewards aren&apos;t enabled for your shop. Ask an admin to turn them on to attach rewards to campaigns.
+                  </div>
+                ) : (
+                  <div className="space-y-4">
+                    <div className="grid grid-cols-3 gap-2">
+                      {([
+                        { value: 'none', label: 'No reward' },
+                        { value: 'rcn', label: 'RCN reward' },
+                        { value: 'coupon', label: 'Coupon' },
+                      ] as const).map((opt) => (
+                        <button
+                          key={opt.value}
+                          type="button"
+                          disabled={viewOnly}
+                          onClick={() => setRewardType(opt.value)}
+                          className={`p-3 rounded-lg border text-sm font-medium transition-colors disabled:opacity-60 ${
+                            rewardType === opt.value
+                              ? 'bg-[#FFCC00]/20 border-[#FFCC00] text-white'
+                              : 'bg-gray-800 border-transparent text-gray-400 hover:bg-gray-700/50'
+                          }`}
+                        >
+                          {opt.label}
+                        </button>
+                      ))}
+                    </div>
+
+                    {rewardType === 'rcn' && (
+                      <div className="space-y-4 p-4 bg-gray-800/50 border border-gray-700 rounded-lg">
+                        <div>
+                          <Label className="text-gray-300 text-xs uppercase tracking-wide">Reward amount</Label>
+                          <div className="grid grid-cols-3 gap-2 mt-1.5">
+                            {([
+                              { value: 'flat', label: 'Flat' },
+                              { value: 'by_tier', label: 'By tier' },
+                              { value: 'by_spend', label: 'By spend' },
+                            ] as const).map((opt) => (
+                              <button
+                                key={opt.value}
+                                type="button"
+                                disabled={viewOnly}
+                                onClick={() => setRewardMode(opt.value)}
+                                className={`p-2 rounded-md border text-sm font-medium transition-colors disabled:opacity-60 ${
+                                  rewardMode === opt.value
+                                    ? 'bg-[#FFCC00]/20 border-[#FFCC00] text-white'
+                                    : 'bg-gray-800 border-gray-700 text-gray-400 hover:bg-gray-700/50'
+                                }`}
+                              >
+                                {opt.label}
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+
+                        {rewardMode === 'flat' && (
+                          <div>
+                            <Label className="text-gray-300 text-xs">RCN per recipient</Label>
+                            <Input
+                              type="number"
+                              min={0}
+                              step="0.1"
+                              value={rewardFlatAmount}
+                              disabled={viewOnly}
+                              onChange={(e) => setRewardFlatAmount(e.target.value)}
+                              className="mt-1.5 bg-gray-900 border-gray-600 text-white"
+                            />
+                          </div>
+                        )}
+
+                        {rewardMode === 'by_tier' && (
+                          <div className="space-y-2">
+                            {REWARD_TIERS.map((tier) => (
+                              <div key={tier} className="flex items-center gap-3">
+                                <span className="w-20 text-sm text-gray-300 capitalize">{tier.toLowerCase()}</span>
+                                <Input
+                                  type="number"
+                                  min={0}
+                                  step="0.1"
+                                  placeholder="0"
+                                  value={rewardByTier[tier] ?? ''}
+                                  disabled={viewOnly}
+                                  onChange={(e) => setRewardByTier((prev) => ({ ...prev, [tier]: e.target.value }))}
+                                  className="flex-1 bg-gray-900 border-gray-600 text-white"
+                                />
+                                <span className="text-sm text-gray-500">RCN</span>
+                              </div>
+                            ))}
+                            <p className="text-xs text-gray-500">Leave a tier blank to give it nothing.</p>
+                          </div>
+                        )}
+
+                        {rewardMode === 'by_spend' && (
+                          <div className="space-y-2">
+                            {rewardSpendBands.map((band, idx) => (
+                              <div key={idx} className="flex items-center gap-2">
+                                <span className="text-sm text-gray-400">Spend ≥ $</span>
+                                <Input
+                                  type="number"
+                                  min={0}
+                                  value={band.minSpend}
+                                  disabled={viewOnly}
+                                  onChange={(e) => setRewardSpendBands((prev) =>
+                                    prev.map((b, i) => (i === idx ? { ...b, minSpend: e.target.value } : b))
+                                  )}
+                                  className="w-24 bg-gray-900 border-gray-600 text-white"
+                                />
+                                <span className="text-sm text-gray-400">→</span>
+                                <Input
+                                  type="number"
+                                  min={0}
+                                  step="0.1"
+                                  placeholder="0"
+                                  value={band.rcn}
+                                  disabled={viewOnly}
+                                  onChange={(e) => setRewardSpendBands((prev) =>
+                                    prev.map((b, i) => (i === idx ? { ...b, rcn: e.target.value } : b))
+                                  )}
+                                  className="w-24 bg-gray-900 border-gray-600 text-white"
+                                />
+                                <span className="text-sm text-gray-500">RCN</span>
+                                {!viewOnly && rewardSpendBands.length > 1 && (
+                                  <button
+                                    type="button"
+                                    onClick={() => setRewardSpendBands((prev) => prev.filter((_, i) => i !== idx))}
+                                    className="p-1 hover:bg-red-500/20 rounded"
+                                  >
+                                    <Trash2 className="w-4 h-4 text-red-400" />
+                                  </button>
+                                )}
+                              </div>
+                            ))}
+                            {!viewOnly && (
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={() => setRewardSpendBands((prev) => [...prev, { minSpend: '0', rcn: '' }])}
+                                className="border-gray-600 text-gray-300"
+                              >
+                                Add band
+                              </Button>
+                            )}
+                          </div>
+                        )}
+
+                        <div>
+                          <Label className="text-gray-300 text-xs uppercase tracking-wide">Fulfillment</Label>
+                          <div className="grid grid-cols-2 gap-2 mt-1.5">
+                            {([
+                              { value: 'on_send', label: 'On send', desc: 'Issued immediately' },
+                              { value: 'on_return', label: 'On return', desc: 'Issued when they come back' },
+                            ] as const).map((opt) => (
+                              <button
+                                key={opt.value}
+                                type="button"
+                                disabled={viewOnly}
+                                onClick={() => setFulfillment(opt.value)}
+                                className={`p-3 rounded-md border text-left transition-colors disabled:opacity-60 ${
+                                  fulfillment === opt.value
+                                    ? 'bg-[#FFCC00]/20 border-[#FFCC00] text-white'
+                                    : 'bg-gray-800 border-gray-700 text-gray-400 hover:bg-gray-700/50'
+                                }`}
+                              >
+                                <div className="text-sm font-medium">{opt.label}</div>
+                                <div className="text-xs text-gray-500">{opt.desc}</div>
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+
+                        {fulfillment === 'on_return' && (
+                          <div>
+                            <Label className="text-gray-300 text-xs">Return window (days)</Label>
+                            <Input
+                              type="number"
+                              min={1}
+                              max={365}
+                              value={returnWindowDays}
+                              disabled={viewOnly}
+                              onChange={(e) => setReturnWindowDays(e.target.value)}
+                              className="mt-1.5 bg-gray-900 border-gray-600 text-white"
+                            />
+                            <p className="text-xs text-gray-500 mt-1">
+                              Unredeemed rewards expire after this many days.
+                            </p>
+                          </div>
+                        )}
+                      </div>
+                    )}
+
+                    {rewardType === 'coupon' && (
+                      <div className="space-y-4 p-4 bg-gray-800/50 border border-gray-700 rounded-lg">
+                        <p className="text-xs text-gray-400">
+                          A unique code is added to the email at send. Each recipient can redeem it once on
+                          their next visit for bonus RCN — the shop enters the code when issuing their reward.
+                        </p>
+                        <div className="grid grid-cols-2 gap-3">
+                          <div>
+                            <Label className="text-gray-300 text-xs">Bonus RCN</Label>
+                            <Input
+                              type="number"
+                              min={1}
+                              step="1"
+                              value={couponBonusRcn}
+                              disabled={viewOnly}
+                              onChange={(e) => setCouponBonusRcn(e.target.value)}
+                              className="mt-1.5 bg-gray-900 border-gray-600 text-white"
+                            />
+                          </div>
+                          <div>
+                            <Label className="text-gray-300 text-xs">Expires in (days)</Label>
+                            <Input
+                              type="number"
+                              min={1}
+                              max={365}
+                              value={couponExpiresDays}
+                              disabled={viewOnly}
+                              onChange={(e) => setCouponExpiresDays(e.target.value)}
+                              className="mt-1.5 bg-gray-900 border-gray-600 text-white"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+
               {/* Summary */}
               <div className="mt-8 p-4 bg-gray-800 rounded-lg space-y-2">
                 <h4 className="text-white font-medium mb-3">Campaign Summary</h4>
@@ -1893,6 +2278,22 @@ export function CampaignBuilderModal({
                     <span className="text-gray-400">Coupon:</span>
                     <span className="text-white">
                       {couponType === 'percentage' ? `${couponValue}%` : `$${couponValue}`} off
+                    </span>
+                  </div>
+                )}
+                {rewardsEnabled && rewardType === 'rcn' && (
+                  <div className="flex justify-between text-sm">
+                    <span className="text-gray-400">Reward:</span>
+                    <span className="text-white capitalize">
+                      {rewardMode.replace('_', ' ')} RCN · {fulfillment === 'on_return' ? `on return (${returnWindowDays}d)` : 'on send'}
+                    </span>
+                  </div>
+                )}
+                {rewardsEnabled && rewardType === 'coupon' && (
+                  <div className="flex justify-between text-sm">
+                    <span className="text-gray-400">Reward:</span>
+                    <span className="text-white">
+                      Coupon · {couponBonusRcn} bonus RCN · expires in {couponExpiresDays}d
                     </span>
                   </div>
                 )}

--- a/frontend/src/services/api/marketing.ts
+++ b/frontend/src/services/api/marketing.ts
@@ -20,6 +20,13 @@ export interface MarketingCampaign {
   couponType: 'fixed' | 'percentage' | null;
   couponExpiresAt: string | null;
   serviceId: string | null;
+  rewardType: 'none' | 'rcn' | 'coupon';
+  rewardMode: 'flat' | 'by_tier' | 'by_spend' | null;
+  rewardRcnAmount: number | null;
+  rewardRcnByTier: Record<string, number> | null;
+  rewardSpendBands: Array<{ minSpend: number; rcn: number }> | null;
+  fulfillmentTrigger: 'on_send' | 'on_return';
+  returnWindowDays: number | null;
   totalRecipients: number;
   emailsSent: number;
   emailsOpened: number;
@@ -52,6 +59,18 @@ export interface CampaignStats {
   avgOpenRate: number;
 }
 
+export interface CampaignReward {
+  type: 'none' | 'rcn' | 'coupon';
+  mode?: 'flat' | 'by_tier' | 'by_spend';
+  rcnAmount?: number;
+  rcnByTier?: Record<string, number>;
+  spendBands?: Array<{ minSpend: number; rcn: number }>;
+  fulfillment?: 'on_send' | 'on_return';
+  returnWindowDays?: number;
+  couponValue?: number;
+  couponExpiresDays?: number;
+}
+
 export interface CreateCampaignData {
   name: string;
   campaignType: MarketingCampaign['campaignType'];
@@ -68,6 +87,7 @@ export interface CreateCampaignData {
   couponExpiresAt?: string;
   serviceId?: string;
   manualEmails?: string;
+  reward?: CampaignReward | null;
 }
 
 export interface CampaignDeliveryResult {


### PR DESCRIPTION
## Summary

Closes the gap where campaign rewards could only be attached via the AI marketing agent. Shop owners can now configure the **same rewards by hand** in the manual campaign builder.

The campaign create/update routes gain an optional nested `reward` object (no dedicated endpoint — the reward is a column group on the campaign row, saved in one action):

```jsonc
"reward": {
  "type": "rcn",              // 'none' | 'rcn' | 'coupon'
  "mode": "flat",             // 'flat' | 'by_tier' | 'by_spend'
  "rcnAmount": 5,
  "rcnByTier": { "GOLD": 50, "SILVER": 25, "BRONZE": 10 },
  "spendBands": [{ "minSpend": 0, "rcn": 10 }],
  "fulfillment": "on_return", // 'on_send' | 'on_return'
  "returnWindowDays": 30,
  "couponValue": 5,           // coupon: bonus RCN
  "couponExpiresDays": 60
}
```

Semantics: reward omitted → existing config untouched; null / { type: 'none' } → cleared; present → validated then persisted.

Backend

- campaignRewardInput.ts — validates the payload into a tri-state (ignore / clear / set); enforces mode↔amount shape, returnWindowDays > 0 (clamped to 365) iff on_return, and coupon bonus RCN (> 0, ≤ 10000) + expiry days (default 60).
- Create/update routes parse and persist the reward. Create wraps campaign + reward in a single transaction so a failed reward write can't leave an orphaned campaign. A coupon writes the campaign's coupon_* columns; the one-per-customer code is minted at send via the existing path.
- All reward writes are gated on the per-shop campaign_rewards_enabled flag (403 when off) — matching AI behavior.

Frontend (CampaignBuilderModal)

- New Reward section in the Delivery step: None / RCN / Coupon (mutually exclusive). RCN supports flat / by-tier / by-spend and on-send / on-return (+ return window). Coupon takes bonus RCN + expiry days.
- Section hides when campaign_rewards_enabled is off (read from GET /api/ai/settings).
- On-send RCN rewards run the existing affordability precheck before sending; the send is blocked (saved as draft) when the shop can't cover the total.
- Only clears a reward the builder manages (rcn/coupon) — won't clobber reward types it can't represent.
- On-send RCN rewards run the existing affordability precheck before sending; the send is blocked (saved as draft) when the shop can't cover the total.
- Only clears a reward the builder manages (rcn/coupon) — won't clobber reward types it can't represent.