### PR TITLE
feat(marketing): surface reward outcomes on campaign list

### DIFF
--- a/backend/src/repositories/MarketingCampaignRepository.ts
+++ b/backend/src/repositories/MarketingCampaignRepository.ts
@@ -14,6 +14,42 @@ export type CampaignRewardConfig = {
   returnWindowDays?: number | null;
 };
 
+export interface CampaignRewardSummary {
+  pending: number;
+  redeemed: number;
+  expired: number;
+  issued: number;
+  failed: number;
+  skipped: number;
+}
+
+export type CampaignDisplayStatus = 'draft' | 'scheduled' | 'sent' | 'active' | 'cancelled';
+
+// 'active' surfaces only for on_return RCN campaigns with a still-pending promise.
+export function deriveCampaignDisplayStatus(
+  campaign: Pick<MarketingCampaign, 'status' | 'rewardType' | 'fulfillmentTrigger'>,
+  summary: CampaignRewardSummary
+): CampaignDisplayStatus {
+  if (campaign.status !== 'sent') {
+    return campaign.status as CampaignDisplayStatus;
+  }
+  const isOnReturnRcn = campaign.rewardType === 'rcn' && campaign.fulfillmentTrigger === 'on_return';
+  if (isOnReturnRcn && summary.pending > 0) return 'active';
+  return 'sent';
+}
+
+export function mapRewardSummary(row: any): CampaignRewardSummary {
+  const n = (v: any) => (v != null ? parseInt(v, 10) : 0);
+  return {
+    pending: n(row.reward_pending),
+    redeemed: n(row.reward_redeemed),
+    expired: n(row.reward_expired),
+    issued: n(row.reward_issued),
+    failed: n(row.reward_failed),
+    skipped: n(row.reward_skipped),
+  };
+}
+
 export interface MarketingCampaign {
   id: string;
   shopId: string;
@@ -51,6 +87,8 @@ export interface MarketingCampaign {
   createdBySource: 'manual' | 'ai_agent';
   createdAt: Date;
   updatedAt: Date;
+  rewardSummary?: CampaignRewardSummary;
+  displayStatus?: CampaignDisplayStatus;
 }
 
 export interface CampaignRecipient {
@@ -203,23 +241,40 @@ export class MarketingCampaignRepository extends BaseRepository {
     const offset = this.getPaginationOffset(pagination.page, pagination.limit);
 
     let countQuery = 'SELECT COUNT(*) FROM marketing_campaigns WHERE shop_id = $1';
-    let dataQuery = 'SELECT * FROM marketing_campaigns WHERE shop_id = $1';
+    let whereClause = 'WHERE c.shop_id = $1';
     const values: any[] = [shopId];
 
     if (status) {
       countQuery += ' AND status = $2';
-      dataQuery += ' AND status = $2';
+      whereClause += ' AND c.status = $2';
       values.push(status);
     }
 
-    dataQuery += ` ORDER BY created_at DESC LIMIT $${values.length + 1} OFFSET $${values.length + 2}`;
+    // Paginated campaigns LEFT JOINed to their recipient ledger, grouped to one
+    // rollup row per campaign — single aggregated query, no N+1.
+    const dataQuery = `
+      SELECT
+        c.*,
+        COUNT(r.id) FILTER (WHERE r.reward_status = 'pending')  AS reward_pending,
+        COUNT(r.id) FILTER (WHERE r.reward_status = 'redeemed') AS reward_redeemed,
+        COUNT(r.id) FILTER (WHERE r.reward_status = 'expired')  AS reward_expired,
+        COUNT(r.id) FILTER (WHERE r.reward_status = 'issued')   AS reward_issued,
+        COUNT(r.id) FILTER (WHERE r.reward_status = 'failed')   AS reward_failed,
+        COUNT(r.id) FILTER (WHERE r.reward_status = 'skipped')  AS reward_skipped
+      FROM marketing_campaigns c
+      LEFT JOIN marketing_campaign_recipients r ON r.campaign_id = c.id
+      ${whereClause}
+      GROUP BY c.id
+      ORDER BY c.created_at DESC
+      LIMIT $${values.length + 1} OFFSET $${values.length + 2}
+    `;
 
     try {
       const countResult = await this.pool.query(countQuery, values);
       const totalItems = parseInt(countResult.rows[0].count, 10);
 
       const dataResult = await this.pool.query(dataQuery, [...values, pagination.limit, offset]);
-      const items = dataResult.rows.map(row => this.mapCampaign(row));
+      const items = dataResult.rows.map(row => this.mapCampaignWithRollup(row));
 
       const totalPages = Math.ceil(totalItems / pagination.limit);
 
@@ -839,6 +894,14 @@ export class MarketingCampaignRepository extends BaseRepository {
       createdAt: new Date(row.created_at),
       updatedAt: new Date(row.updated_at)
     };
+  }
+
+  private mapCampaignWithRollup(row: any): MarketingCampaign {
+    const campaign = this.mapCampaign(row);
+    const summary = mapRewardSummary(row);
+    campaign.rewardSummary = summary;
+    campaign.displayStatus = deriveCampaignDisplayStatus(campaign, summary);
+    return campaign;
   }
 
   private mapRecipient(row: any): CampaignRecipient {

--- a/backend/tests/unit/campaign-reward-rollup.test.ts
+++ b/backend/tests/unit/campaign-reward-rollup.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  deriveCampaignDisplayStatus,
+  mapRewardSummary,
+  CampaignRewardSummary,
+} from '../../src/repositories/MarketingCampaignRepository';
+
+const emptySummary: CampaignRewardSummary = {
+  pending: 0,
+  redeemed: 0,
+  expired: 0,
+  issued: 0,
+  failed: 0,
+  skipped: 0,
+};
+
+describe('mapRewardSummary', () => {
+  it('parses the reward_* aggregate columns into integers', () => {
+    const summary = mapRewardSummary({
+      reward_pending: '12',
+      reward_redeemed: '5',
+      reward_expired: '3',
+      reward_issued: '0',
+      reward_failed: '1',
+      reward_skipped: '2',
+    });
+    expect(summary).toEqual({
+      pending: 12,
+      redeemed: 5,
+      expired: 3,
+      issued: 0,
+      failed: 1,
+      skipped: 2,
+    });
+  });
+
+  it('defaults missing/null columns to zero', () => {
+    expect(mapRewardSummary({})).toEqual(emptySummary);
+    expect(mapRewardSummary({ reward_pending: null })).toEqual(emptySummary);
+  });
+});
+
+describe('deriveCampaignDisplayStatus', () => {
+  it('passes draft / scheduled / cancelled through unchanged', () => {
+    for (const status of ['draft', 'scheduled', 'cancelled'] as const) {
+      const display = deriveCampaignDisplayStatus(
+        { status, rewardType: 'rcn', fulfillmentTrigger: 'on_return' },
+        { ...emptySummary, pending: 5 }
+      );
+      expect(display).toBe(status);
+    }
+  });
+
+  it('returns "active" for a sent on_return RCN campaign with a pending promise', () => {
+    const display = deriveCampaignDisplayStatus(
+      { status: 'sent', rewardType: 'rcn', fulfillmentTrigger: 'on_return' },
+      { ...emptySummary, pending: 1, redeemed: 4, expired: 2 }
+    );
+    expect(display).toBe('active');
+  });
+
+  it('returns "sent" for a sent on_return RCN campaign with no pending promises', () => {
+    const display = deriveCampaignDisplayStatus(
+      { status: 'sent', rewardType: 'rcn', fulfillmentTrigger: 'on_return' },
+      { ...emptySummary, redeemed: 4, expired: 2 }
+    );
+    expect(display).toBe('sent');
+  });
+
+  it('never returns "active" for on_send RCN campaigns even with pending rows', () => {
+    const display = deriveCampaignDisplayStatus(
+      { status: 'sent', rewardType: 'rcn', fulfillmentTrigger: 'on_send' },
+      { ...emptySummary, pending: 5 }
+    );
+    expect(display).toBe('sent');
+  });
+
+  it('never returns "active" for message-only campaigns', () => {
+    const display = deriveCampaignDisplayStatus(
+      { status: 'sent', rewardType: 'none', fulfillmentTrigger: 'on_return' },
+      { ...emptySummary, pending: 5 }
+    );
+    expect(display).toBe('sent');
+  });
+});

--- a/frontend/src/components/shop/tabs/MarketingTab.tsx
+++ b/frontend/src/components/shop/tabs/MarketingTab.tsx
@@ -71,7 +71,6 @@ const statusBadgeStyles: Record<string, { bg: string; text: string; border?: str
   sent: { bg: "bg-green-500/20", text: "text-green-400", border: "border border-green-500/30" },
   scheduled: { bg: "bg-purple-500/20", text: "text-purple-400", border: "border border-purple-500/30" },
   expired: { bg: "bg-red-500/20", text: "text-red-400", border: "border border-red-500/30" },
-  paused: { bg: "bg-amber-600/20", text: "text-amber-400", border: "border border-amber-600/30" },
   cancelled: { bg: "bg-red-500/20", text: "text-red-400", border: "border border-red-500/30" },
 };
 
@@ -81,7 +80,6 @@ const statusFilterOptions = [
   { value: "sent", label: "Sent" },
   { value: "scheduled", label: "Scheduled" },
   { value: "draft", label: "Draft" },
-  { value: "paused", label: "Paused" },
   { value: "expired", label: "Expired" },
 ];
 
@@ -98,10 +96,17 @@ export function MarketingTab({ shopId, shopName }: MarketingTabProps) {
   const [viewOnlyMode, setViewOnlyMode] = useState(false);
   const [statusFilter, setStatusFilter] = useState("all");
 
-  // Filter campaigns based on status
+  // Filter campaigns based on derived status / reward outcomes
   const filteredCampaigns = campaigns.filter((campaign) => {
-    if (statusFilter === "all") return true;
-    return campaign.status === statusFilter;
+    const display = campaign.displayStatus ?? campaign.status;
+    switch (statusFilter) {
+      case "all":
+        return true;
+      case "expired":
+        return (campaign.rewardSummary?.expired ?? 0) > 0;
+      default:
+        return display === statusFilter;
+    }
   });
 
   useEffect(() => {
@@ -383,7 +388,12 @@ export function MarketingTab({ shopId, shopName }: MarketingTabProps) {
               </Button>
             </div>
           ) : (
-            filteredCampaigns.map((campaign) => (
+            filteredCampaigns.map((campaign) => {
+              const display = campaign.displayStatus ?? campaign.status;
+              const isOnReturnRcn =
+                campaign.rewardType === "rcn" && campaign.fulfillmentTrigger === "on_return";
+              const showRewardRollup = isOnReturnRcn && !!campaign.rewardSummary;
+              return (
               <div
                 key={campaign.id}
                 className="flex items-start sm:items-center justify-between gap-3 px-4 sm:px-6 py-4 hover:bg-gray-800/50 transition-colors cursor-pointer"
@@ -408,15 +418,15 @@ export function MarketingTab({ shopId, shopName }: MarketingTabProps) {
                       <h4 className="text-white font-medium truncate max-w-full">{campaign.name}</h4>
                       {/* Status badge */}
                       <Badge
-                        className={`${getStatusBadgeStyle(campaign.status)} text-xs px-2 py-0.5 rounded-md flex-shrink-0`}
+                        className={`${getStatusBadgeStyle(display)} text-xs px-2 py-0.5 rounded-md flex-shrink-0`}
                       >
-                        {campaign.status.charAt(0).toUpperCase() + campaign.status.slice(1)}
+                        {display.charAt(0).toUpperCase() + display.slice(1)}
                       </Badge>
                     </div>
 
                     {/* Description row with Sent badge, type, and delivery method icons */}
                     <div className="flex flex-wrap items-center gap-2 text-sm">
-                      {/* Show "Sent" badge with checkmark for sent campaigns */}
+                      {/* Show "Sent" badge with checkmark for delivered campaigns */}
                       {campaign.status === "sent" && (
                         <span className="flex items-center gap-1 text-green-400 text-xs">
                           <CheckCircle2 className="w-3 h-3" />
@@ -431,17 +441,27 @@ export function MarketingTab({ shopId, shopName }: MarketingTabProps) {
                       </span>
                     </div>
 
+                    {/* Reward outcome rollup for on_return RCN campaigns */}
+                    {showRewardRollup && (
+                      <div className="flex flex-wrap items-center gap-1.5 text-xs">
+                        <span className="text-green-400">{campaign.rewardSummary!.redeemed} redeemed</span>
+                        <span className="text-gray-600">·</span>
+                        <span className="text-amber-400">{campaign.rewardSummary!.pending} pending</span>
+                        <span className="text-gray-600">·</span>
+                        <span className="text-red-400">{campaign.rewardSummary!.expired} expired</span>
+                      </div>
+                    )}
+
                     {/* Mobile-only stats row (shown only on mobile, hidden on sm+) */}
-                    {((campaign.status as string) === "sent" ||
-                      (campaign.status as string) === "active" ||
-                      (campaign.status as string) === "expired" ||
-                      (((campaign.status as string) === "scheduled" || (campaign.status as string) === "paused") && campaign.scheduledAt)) && (
+                    {(display === "sent" ||
+                      display === "active" ||
+                      (display === "scheduled" && campaign.scheduledAt)) && (
                       <div className="sm:hidden text-xs mt-1">
                         <p className="text-gray-300">
                           {campaign.inAppSent || 0} in app • {campaign.emailsSent || 0} email
                         </p>
                         <p className="text-gray-500">
-                          {((campaign.status as string) === "scheduled" || (campaign.status as string) === "paused") && campaign.scheduledAt
+                          {display === "scheduled" && campaign.scheduledAt
                             ? `Scheduled for ${formatDate(campaign.scheduledAt)}`
                             : campaign.sentAt
                               ? formatDate(campaign.sentAt)
@@ -454,7 +474,7 @@ export function MarketingTab({ shopId, shopName }: MarketingTabProps) {
 
                 {/* Right side - Stats and date (hidden on mobile, shown sm+) */}
                 <div className="flex items-center gap-2 sm:gap-4 flex-shrink-0">
-                  {((campaign.status as string) === "sent" || (campaign.status as string) === "active") && (
+                  {(display === "sent" || display === "active") && (
                     <div className="hidden sm:block text-right text-sm">
                       <p className="text-gray-300">
                         {campaign.inAppSent} in app • {campaign.emailsSent} email
@@ -464,33 +484,13 @@ export function MarketingTab({ shopId, shopName }: MarketingTabProps) {
                       </p>
                     </div>
                   )}
-                  {(campaign.status as string) === "scheduled" && campaign.scheduledAt && (
+                  {display === "scheduled" && campaign.scheduledAt && (
                     <div className="hidden sm:block text-right text-sm">
                       <p className="text-gray-300">
                         {campaign.inAppSent || 0} in app • {campaign.emailsSent || 0} email
                       </p>
                       <p className="text-gray-500">
                         Scheduled for {formatDate(campaign.scheduledAt)}
-                      </p>
-                    </div>
-                  )}
-                  {(campaign.status as string) === "paused" && campaign.scheduledAt && (
-                    <div className="hidden sm:block text-right text-sm">
-                      <p className="text-gray-300">
-                        {campaign.inAppSent || 0} in app • {campaign.emailsSent || 0} email
-                      </p>
-                      <p className="text-gray-500">
-                        Scheduled for {formatDate(campaign.scheduledAt)}
-                      </p>
-                    </div>
-                  )}
-                  {(campaign.status as string) === "expired" && (
-                    <div className="hidden sm:block text-right text-sm">
-                      <p className="text-gray-300">
-                        {campaign.inAppSent || 0} in app • {campaign.emailsSent || 0} email
-                      </p>
-                      <p className="text-gray-500">
-                        {campaign.sentAt ? formatDate(campaign.sentAt) : ""}
                       </p>
                     </div>
                   )}
@@ -539,7 +539,7 @@ export function MarketingTab({ shopId, shopName }: MarketingTabProps) {
                           Cancel
                         </DropdownMenuItem>
                       )}
-                      {(campaign.status as string) !== "sent" && (campaign.status as string) !== "active" && (
+                      {campaign.status !== "sent" && (
                         <DropdownMenuItem
                           onClick={(e) => {
                             e.stopPropagation();
@@ -565,7 +565,8 @@ export function MarketingTab({ shopId, shopName }: MarketingTabProps) {
                   </DropdownMenu>
                 </div>
               </div>
-            ))
+              );
+            })
           )}
         </div>
       </div>

--- a/frontend/src/services/api/marketing.ts
+++ b/frontend/src/services/api/marketing.ts
@@ -35,7 +35,20 @@ export interface MarketingCampaign {
   inAppRead: number;
   createdAt: string;
   updatedAt: string;
+  rewardSummary?: CampaignRewardSummary;
+  displayStatus?: CampaignDisplayStatus;
 }
+
+export interface CampaignRewardSummary {
+  pending: number;
+  redeemed: number;
+  expired: number;
+  issued: number;
+  failed: number;
+  skipped: number;
+}
+
+export type CampaignDisplayStatus = 'draft' | 'scheduled' | 'sent' | 'active' | 'cancelled';
 
 export interface MarketingTemplate {
   id: string;


### PR DESCRIPTION
## What

Wires up real reward-outcome data behind the previously-dead **active** / **expired** badges and status-filter options in the shop Marketing tab. After an `on_return` RCN campaign is sent, each recipient's reward moves `pending → redeemed → expired`; shop owners now see how many win-back promises are outstanding, redeemed, or expired directly on the campaign list.

## Design decision

`active` is **not** a new value on `marketing_campaigns.status` (that column is load-bearing for the sender and ends at `sent`). Instead we compute a derived `displayStatus` from a recipient rollup:

- **active** — campaign has `on_return` RCN rewards **and** ≥1 recipient is `reward_status = 'pending'`
- **sent** — otherwise (message-only, `on_send`, or all rewards resolved)

So `active` only ever surfaces on `on_return` campaigns with outstanding promises; message-only and `on_send` campaigns stay **Sent**.

## Backend — `MarketingCampaignRepository`

- `findByShop` now runs a **single aggregated query** (campaigns `LEFT JOIN` recipients, `GROUP BY c.id`) returning a per-campaign `rewardSummary` rollup: `pending / redeemed / expired / issued / failed / skipped`. No N+1; the count query and pagination are unchanged.
- Returns a derived `displayStatus` per the rule above.
- Exports pure `deriveCampaignDisplayStatus()` and `mapRewardSummary()` helpers (unit-tested).
- Change is purely additive — `mapCampaignWithRollup` delegates to the existing `mapCampaign`, so the only other caller of `findByShop` (the AI marketing `contextBuilder`, which reads `subject`) is unaffected.

## Frontend — `MarketingTab.tsx`

- Status badge now reads `displayStatus` instead of the never-set raw status.
- Status filter wired to derived data: **Active** → `displayStatus === 'active'`; **Expired** → `rewardSummary.expired > 0`.
- `on_return` RCN cards show a compact rollup: `5 redeemed · 12 pending · 3 expired`.
- Removed the dead **Paused** filter option + badge style (campaigns have no paused state) and all `campaign.status as string` casts now that the values are real.

## Tests

- `backend/tests/unit/campaign-reward-rollup.test.ts` — covers `mapRewardSummary` parsing and the `displayStatus` derivation, including that `on_send` and message-only campaigns never show **active**.